### PR TITLE
Real-world script hardening (50%->95.5%) and the Lush Semantics spec

### DIFF
--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -1,0 +1,436 @@
+# Lush Semantics
+
+**The engine-layer contract: what a lush value *is*, and how a name resolves.**
+
+**Status**: Foundational engine specification. The decisions recorded
+here are settled; revising them requires an explicit owner decision,
+the same bar as `VISION.md`.
+
+**Scope**: this document specifies the value model and the scoping
+discipline -- the core of how lush evaluates. It is deliberately not
+yet exhaustive (§8 records what is still open); it grows toward a
+complete semantic specification.
+
+This document is the concrete form of `PHILOSOPHY.md` §2 ("Spelling is
+polyglot; behavior is canonical lush"). PHILOSOPHY states the principle
+abstractly -- one unified engine behind many dialect spellings. This
+document specifies that engine: the kinds of values it holds, the rules
+by which they are transformed and presented, and the discipline by
+which names resolve to them.
+
+It is a working contract, not marketing. Every expansion-, array-, and
+scope-related implementation choice should be measurable against it.
+
+---
+
+## 1. The two layers: engine and preset
+
+Lush has exactly two layers, and they are never the same layer.
+
+**The preset layer** is the four configuration surfaces of
+`PHILOSOPHY.md` §3 -- `mode`, `set`, `setopt`/`shopt`, `config`. It
+governs *which syntax is accepted* and *which behaviors default on*.
+It is curation over a substrate.
+
+**The engine layer** is the substrate itself: what a value fundamentally
+is, how a transformation acts on it, how it is presented at a boundary,
+and how a name resolves to it. This document specifies the engine.
+
+The dividing rule is absolute:
+
+> The preset layer configures the engine. It never redefines the
+> engine. No `mode`, no `setopt`, no `config` key changes what a value
+> *is*, the coercion rules, the presentation rule, or the scoping
+> discipline.
+
+This is not a stylistic preference; it is what makes lush one shell.
+A preset that could fork the type system or the name-resolution rule
+would not produce a polyglot shell -- it would produce N shells
+sharing a parser. "Polyglot" means many syntactic front doors onto
+*one* engine (PHILOSOPHY §2: "not because it runs three engines under
+the hood"). The engine is uniform across every mode, by construction.
+
+When a behavior feels like it could belong to either layer, apply the
+test: *does it change what a value is, or only how a value is spelled
+or defaulted?* The former is engine; the latter is preset. Word
+splitting (§3.8) is a preset because it gates an expansion behavior;
+the list/scalar distinction is engine because it is a value's nature.
+
+---
+
+## 2. Pure-local reasoning
+
+Every expansion, every function, every construct must be understandable
+*from itself* -- without consulting the statement that encloses it or
+the mode that is active.
+
+A reader (human, static analyzer, or the interactive debugger) looking
+at `${arr[@]}` knows it is a vector from those four characters alone.
+Looking at a function's declaration line, they know its scoping
+discipline. They never have to scan outward to a wrapping quote, an
+enclosing assignment, or a `mode` setting to know what a fragment
+means.
+
+Pure-local reasoning is the property the rest of this document is
+built to preserve. Where a design choice would make meaning depend on
+surrounding context, the choice is wrong. This is why presentation is
+bound to the subscript and not to quoting (§3.5), and why scoping is
+bound to the declaration form and not to the mode (§5).
+
+---
+
+## 3. The value model
+
+### 3.1 Three value kinds
+
+A lush value is exactly one of:
+
+- **scalar** -- a single string.
+- **list** -- an ordered sequence of scalars (the indexed array).
+- **map** -- an ordered set of key/scalar pairs (the associative
+  array).
+
+Lists and maps are **first-class values**, not text that happens to be
+interpreted as structure. A variable holds a value of one kind; the
+kind is part of the value.
+
+### 3.2 Bounded and flat
+
+The value model is **bounded**: there are three kinds and no more.
+It is **flat**: a list element is a scalar, a map value is a scalar.
+A list of lists, a map of maps, a list of maps -- none of these are
+native values.
+
+This is a deliberate fork away from the fully-nested structured-data
+model (Nushell, Elvish). The reasoning:
+
+- **The serialization trap.** External commands understand only
+  byte streams. A fully-nested value crossing a pipe into `grep`,
+  `awk`, or `sed` must be flattened to text, and the shell would have
+  to *guess* how. A guess is implicit coercion -- the precise thing
+  §3.4 forbids. A bounded model makes every text-boundary crossing
+  total and obvious: a flat list maps to an argument vector or to
+  lines; a flat map maps to key/value lines or to environment
+  variables. Nothing is guessed.
+- **Debugger sanity.** Lush ships an interactive debugger. A bounded
+  model renders runtime state as flat rows -- low, constant cognitive
+  load while stepping. A nested model forces tree rendering and makes
+  mutation- and scope-tracking across multidimensional state vastly
+  harder to keep correct.
+- **Shell-first ergonomics.** A shell's job is executing programs and
+  stitching them together. A fully-nested type system pulls the
+  language toward expression-heavy, Python-shaped syntax. Bounded
+  keeps lush close to the Unix shore: it delivers exactly what bash
+  and zsh reached for -- first-class, space-safe arrays and native
+  maps -- without the structural pitfalls.
+
+### 3.3 Strict flatness; depth via explicit serialization
+
+Nesting a structured value inside another is never implicit. An
+attempt to do so is either a diagnosed error or an explicitly
+operator-driven flatten -- never a silent restructuring.
+
+When a script genuinely needs depth, it reaches for it explicitly,
+through the **utility layer**, not the type system: serialized strings
+(JSON, etc.) handled by named helpers (e.g. `json.get(var,
+"path.to.key")`). The native type system stays small and total; reach
+lives in functions. This is the same move as preferring an explicit
+`split()` over an implicit coercion -- power through named, visible
+operations rather than through type-system complexity.
+
+### 3.4 No implicit coercion: lists are never silently flattened
+
+A list is never converted to a scalar string implicitly -- not by a
+double quote, not by an assignment, not by reaching a string-shaped
+slot. Joining a list into a string is always an operation the script
+*asks for* (the `[*]` subscript of §3.5, an explicit `join`, a `(j:)`
+flag).
+
+Implicit list-to-string coercion is one of the largest sources of
+silent bugs and quoting gymnastics in legacy shells. It violates least
+surprise (a list the author built silently stops being a list), and it
+hides type errors (passing a list where a scalar was meant should be a
+clear, immediate diagnostic, not a quiet flatten).
+
+This is the engine's central safety property. Everything in §3.5 and
+§3.6 exists to uphold it.
+
+### 3.5 Transformation and presentation are orthogonal
+
+Two independent things happen to a value reference, and they never
+interfere:
+
+**Transformation** -- what a parameter flag *does* to the data: `(o)`
+sort, `(O)` reverse-sort, `(u)` unique, `(s:x:)` split, `(U)`
+uppercase, and so on. A transformation flag **always fires**,
+regardless of how the reference is written or quoted. `(o)` always
+sorts.
+
+**Presentation** -- whether the reference yields a **vector** (N
+distinct words) or a **scalar** (one string). Presentation is
+determined **solely by the subscript** on the reference:
+
+- `${arr[@]}` -- vector. The elements, distinct, one-to-one.
+- `${arr[*]}` -- scalar. The elements joined into a single string
+  (joined by the first character of `IFS`, as POSIX `"$*"` already
+  does).
+
+The two compose cleanly:
+
+| Reference        | Transformation | Presentation        |
+|------------------|----------------|---------------------|
+| `${arr[@]}`      | none           | vector              |
+| `${arr[*]}`      | none           | joined scalar       |
+| `${(o)arr[@]}`   | sorted         | vector              |
+| `${(o)arr[*]}`   | sorted         | joined scalar       |
+
+The transformation is uniform; the subscript alone selects the shape.
+This ratifies the existing documented behavior (`known_divergences.txt`
+entries 301, 307, 314): lush applies flags uniformly, and the `[@]`
+subscript -- not quoting -- marks a vector.
+
+### 3.6 Double quotes are a whitespace anchor, not a type operator
+
+In legacy shells the double quote is overloaded: it means both "treat
+this whitespace-containing string as one field" and "flatten this
+array" (or, with `[*]` vs `[@]`, "join or keep distinct"). Lush
+removes the second meaning entirely.
+
+A double quote does exactly one thing: it guarantees a **scalar** is
+carried as a single field, immune to word splitting. It has **no
+effect on a list's structure**. `${arr[@]}` is a vector whether
+quoted or not; `${arr[*]}` is a joined scalar whether quoted or not.
+Quoting and presentation are independent axes.
+
+The consequence is zero quoting footguns of the legacy kind: omitting
+a quote can never silently turn a list into a merged scalar, and the
+structural intent of a reference is baked into the reference itself
+(`[@]` vs `[*]`), not into the syntax that happens to wrap it. This is
+§2 (pure-local reasoning) applied to expansion.
+
+### 3.7 The `(@)` flag is redundant
+
+zsh's `(@)` parameter flag forces array context. In lush the `[@]`
+subscript already *is* the vector marker, unconditionally and locally.
+`(@)` is therefore not load-bearing and not part of the engine. If it
+is accepted at all, it is accepted only as a polyglot **spelling**
+courtesy (PHILOSOPHY §2) routing to the same presentation as `[@]`. It
+carries no semantics that `[@]` does not already carry.
+
+### 3.8 Word splitting is retained as a preset
+
+§3.4 forbids implicit list-to-**string** coercion. It does *not*
+forbid string-to-**list** word splitting (`for f in $files`). These
+are different operations, and only one is a silent engine coercion:
+
+- list-to-string is silent, destroys structure irreversibly, and is
+  triggered by nothing visible. The engine forbids it.
+- word splitting is triggered by a *visible* syntactic choice (leaving
+  an expansion unquoted) and is already a curated preset --
+  `FEATURE_WORD_SPLIT_DEFAULT`, on in POSIX/bash modes, off in zsh
+  mode.
+
+The asymmetry is principled: one is the engine silently lying; the
+other is a configurable, syntactically-requested expansion. Word
+splitting stays exactly as it is, governed by the feature matrix.
+
+---
+
+## 4. The three boundary rules
+
+The engine holds typed values; the world outside holds byte streams.
+These three rules govern every crossing.
+
+### 4.1 Text into the engine: capture as scalar, split explicitly
+
+The output of an external command is captured as a **scalar string**.
+Command substitution strips trailing newlines (POSIX behavior,
+retained). It is *not* implicitly split into a list -- that would be
+implicit coercion.
+
+Converting captured text to a list is always explicit. The one native,
+blessed splitter is **newline** (the `(f)` flag / a `lines` helper),
+because lines-of-text is the actual Unix interchange convention and it
+is whitespace-safe. A trailing newline is a *terminator*, not a
+separator: `"a\nb\n"` splits to two elements, not three. Other shapes
+(custom delimiter, NUL-delimited, CSV, JSON) are explicit helpers or
+flags. There is no implicit `IFS`-driven splitting of command output.
+
+### 4.2 Maps preserve insertion order
+
+A map enumerates in the order its keys were first inserted. Order is
+deterministic, never hash-bucket order. This is already implemented
+(`array_value_t.assoc_insertion_order`, Issue #69) and already
+documented as a deliberate divergence (`known_divergences.txt` entry
+052); this model ratifies it.
+
+Insertion order is the modern consensus (Python 3.7+, Ruby, JS) and
+the only choice compatible with §2 -- a map that enumerated
+nondeterministically would render differently in the debugger on every
+step. Sorted *views* are available on top via `${(ko)map}` /
+`${(kO)map}`: a deterministic default, plus explicit tools to reorder.
+
+### 4.3 The engine into argv: every slot preserved
+
+When a list is expanded into an external command's argument vector,
+the invariant is:
+
+> A list's element count equals the number of argv slots it
+> contributes.
+
+A three-element list contributes three arguments, in order. An empty
+element is preserved as a zero-length argument -- it is not dropped,
+and it never shifts the position of later arguments. An *empty list*
+contributes zero arguments; a one-element list whose element is the
+empty string contributes one (empty) argument. `${#list[@]}` always
+predicts the slot count exactly.
+
+Dropping an empty element would be the engine silently mutating the
+data. A script that wants empties removed does so explicitly, with a
+filter transformation -- never as a side effect of expansion.
+
+---
+
+## 5. The scope model
+
+### 5.1 Scoping is a property of the declaration form, not the mode
+
+How a name resolves to a value is engine-layer (§1) -- it cannot be
+forked by a preset. But lush supports two function-declaration forms,
+and **each form carries its own scoping discipline**, uniformly in
+every mode.
+
+### 5.2 POSIX-form functions: dynamic scoping
+
+A function declared in POSIX form -- `name() { ... }` or `function
+name { ... }` -- is **dynamically scoped**, in every mode including
+lush mode. Its locals are visible to the functions it calls. This is
+the behavior the inherited shell ecosystem expects; scripts in that
+form keep it.
+
+### 5.3 Lush typed-function form: lexical scoping
+
+A function declared in lush's typed-function form (see §7 -- this form
+is not yet built) is **lexically (block) scoped**, in every mode
+including POSIX mode. Name resolution is determined by the program's
+block structure, not by the dynamic call chain. There is no
+cross-function variable pollution; the debugger and analyzer can
+resolve a name's binding from the program text alone.
+
+### 5.4 One engine, both disciplines, self-describing code
+
+The engine supports both disciplines as first-class. A function's
+declaration form states which one applies; a reader determines a
+function's scoping from its own header line, with no reference to mode
+or caller -- §2 again. A single script may contain a dynamically
+scoped POSIX-form helper and a lexically scoped typed function side by
+side, each coherent, because each is self-describing.
+
+Lexical scoping is therefore not a mode and not a bolt-on -- it is a
+property the typed-function form *carries*. A consistency dividend
+from §3.8: dynamic scoping's one genuinely-used feature in legacy
+shells -- a caller setting `local IFS` to steer a callee's splitting --
+is already largely moot, because implicit `IFS` splitting is no longer
+the default path.
+
+### 5.5 Environment variables are a separate axis
+
+Exported environment variables are process-level: inherited by child
+processes, always, by POSIX rule. They are *not* governed by this
+scope model. The lexical/dynamic choice governs only **shell-local
+(non-exported) variable** resolution. "Functions share the process
+environment" and "functions isolate their local variables" are two
+different statements about two different axes; do not conflate them.
+
+---
+
+## 6. Relationship to the preset layer and the divergence registry
+
+The four preset surfaces (`mode`, `set`, `setopt`/`shopt`, `config`)
+govern dialect spelling and curated defaults. They never govern the
+value kinds (§3.1), the no-coercion rule (§3.4), the
+transformation/presentation split (§3.5), or the scoping discipline
+(§5). Those are engine.
+
+`FEATURE_WORD_SPLIT_DEFAULT` is a legitimate preset: it gates an
+expansion *behavior*, not a value *kind* (§3.8).
+
+Deliberate divergences from bash/zsh are recorded in
+`tests/fuzz/differential/known_divergences.txt` with rationale, and
+honored by `diff_oracle` (an allow-listed divergence is reported but
+does not count as a failure). **This document is the principle behind
+those entries.** A deliberate, developer-reasoned divergence is a
+feature of lush, not a debt -- it is recorded, justified, and honored,
+never silently "corrected" toward a reference shell. Entries 052, 301,
+307, and 314 are ratified by this model.
+
+A guard for tooling built on the corpus: differential testing against
+bash/zsh is excellent at catching cases where lush is *unambiguously
+wrong*, but it cannot, by mechanism, distinguish "wrong" from
+"deliberately different." A divergence from a reference shell is only a
+defect if it contradicts *this document*. If it is consistent with
+this document, it belongs in `known_divergences.txt`, not in a bug fix.
+
+---
+
+## 7. Current implementation vs. this model
+
+This model is the **vision**. The following is the **reality** as of
+this writing, so the two are aligned and the gap is never lost. (Gap
+sizes are rough engineering estimates.)
+
+| Area | Current state | Target | Gap |
+|------|---------------|--------|-----|
+| Value kinds | `symvar.value` is `char *`; arrays in a side-table `array_value_t`; a `symvar_type_t` tag exists | scalar/list/map are first-class throughout the expansion engine | medium |
+| Flatness / nesting | none (a list element is always `char *`) | none (bounded, §3.2) | **match** |
+| Map insertion order | implemented -- `array_value_t.assoc_insertion_order` (Issue #69) | insertion order (§4.2) | **match** |
+| Transformation always fires | yes (`known_divergences.txt` 301/314) | yes (§3.5) | **match** |
+| Presentation by subscript | yes -- `${arr[@]}` vector, `${(flags)arr}` scalar (`known_divergences.txt` 307) | yes (§3.5) | **match** |
+| Quoting irrelevant to presentation | `parse_parameter_expansion` does not receive quote context; `expand_quoted_string` tracks `in_double_quotes` but does not thread it down | presentation must NOT consult quote context (§3.6) -- so the un-threaded state is *correct*, not a gap | **match** |
+| Implicit list-to-string | the expansion engine still joins lists to strings on some paths | no implicit coercion (§3.4) | real -- needs a full audit of expansion sites |
+| `(@)` flag | recognized among parameter flags | redundant; at most a spelling alias (§3.7) | small |
+| Word splitting | `FEATURE_WORD_SPLIT_DEFAULT`, per-mode | retained as a preset (§3.8) | **match** |
+| Typed-function form | not implemented -- no `fn` keyword, no typed parameters; `return_value` is a builtin emitting a `__LUSH_RETURN__` marker, not a language construct | a typed form carrying lexical scope (§5.3) | large -- form not yet designed |
+| Scoping | dynamic scope-chain for all functions (`symtable` walks `scope->parent`; issue #47 assignment semantics) | dynamic for POSIX form, lexical for the typed form (§5) | large -- lexical resolution and the typed form both unbuilt |
+
+The two "large" gaps -- the typed-function form and lexical scoping --
+are coupled and are deliberately out of scope for this document; see
+§8.
+
+---
+
+## 8. Deliberately deferred
+
+Recorded here so they are not lost. These are *not* decided by this
+document; they are to be decided against it, as their own work.
+
+- **The bare, un-subscripted reference `${arr}`** on a list- or
+  map-valued variable. `[@]` and `[*]` are defined (§3.5); the
+  no-subscript form is not. Candidates: it is the first-class list
+  value itself; it is a diagnosed error ("a structured value
+  referenced without a presentation subscript"); it defaults to
+  `[*]`-style scalar. Current behavior is joined-scalar
+  (`known_divergences.txt` 307). To be decided.
+- **The typed-function form.** Its syntax, typed parameters, a proper
+  `return_value` construct (replacing the marker-hack builtin), and
+  the lexical-scope resolution pass. A full design of its own.
+- **Pipeline status reporting** -- a modern alternative to `pipefail`
+  feeding clean per-stage exit states into the structured-error
+  system.
+- **LLE real-time variable inspection** -- inspection hooks on the
+  command line.
+- **Sigil conventions** (`$`, `@`, `%`) once values are first-class.
+- **Error catalogue for misapplied transformations** -- e.g. an
+  array-only flag applied to a scalar. The principle is settled (an
+  immediate, clear diagnostic); the exhaustive catalogue is not.
+
+---
+
+## See also
+
+- [VISION.md](VISION.md) -- what lush is.
+- [PHILOSOPHY.md](PHILOSOPHY.md) -- the founding principles; §2 and
+  §3 are the abstract form of §1 here.
+- [CONFIGURATION.md](CONFIGURATION.md) -- the four preset surfaces.
+- `tests/fuzz/differential/known_divergences.txt` -- the deliberate-
+  divergence registry this document is the rationale for.

--- a/include/parser.h
+++ b/include/parser.h
@@ -34,6 +34,32 @@
  */
 #define PARSER_MAX_RECURSION_DEPTH 256
 
+/**
+ * Maximum number of heredocs whose body collection can be pending on a
+ * single command line (`cat <<A <<B <<C ...`). Real scripts never come
+ * close; the cap exists only to bound the fixed-size queue.
+ */
+#define PARSER_MAX_PENDING_HEREDOCS 16
+
+/**
+ * A heredoc redirection whose body has NOT yet been collected.
+ *
+ * POSIX heredoc bodies start on the line AFTER the line containing the
+ * `<<delim` operator -- so when the parser sees `<<delim` it cannot
+ * collect the body immediately without skipping the rest of that line
+ * (e.g. the `| wc` in `cat <<EOF | wc`). Instead the parser records a
+ * pending_heredoc_t and keeps tokenizing the line normally; the body is
+ * collected when the line's terminating newline is reached, in queue
+ * order (multiple heredocs on one line stack their bodies in sequence).
+ */
+typedef struct {
+    node_t *redir_node;       /* NODE_REDIR_HEREDOC[_STRIP] to populate   */
+    const char *delimiter;    /* borrowed from redir_node->val.str        */
+    bool strip_tabs;          /* <<- variant: strip leading tabs          */
+    bool expand_variables;    /* unquoted delimiter -> expand body at exec */
+    source_location_t op_loc; /* `<<` operator location, for diagnostics  */
+} pending_heredoc_t;
+
 /** Parser state */
 typedef struct parser {
     tokenizer_t *tokenizer;
@@ -50,6 +76,10 @@ typedef struct parser {
 
     /* Recursion depth tracking for stack overflow protection */
     size_t recursion_depth;
+
+    /* Heredocs awaiting deferred body collection (see pending_heredoc_t) */
+    pending_heredoc_t pending_heredocs[PARSER_MAX_PENDING_HEREDOCS];
+    size_t pending_heredoc_count;
 } parser_t;
 
 /* ============================================================================

--- a/meson.build
+++ b/meson.build
@@ -2382,3 +2382,31 @@ diff_oracle = executable('diff_oracle',
                          'tests/fuzz/diff_oracle.c',
                          include_directories: inc,
                          build_by_default: false)
+
+# ============================================================================
+# REAL-WORLD SCRIPT SCORECARD (1.5.0 release-readiness signal)
+# ============================================================================
+# Reuses diff_oracle to grade lush against representative real-world script
+# patterns under tests/real_world/. Failures here are concrete release-
+# readiness items: each one is something a user's actual script can't run.
+#
+# Run examples:
+#   meson compile -C build diff_oracle
+#   find tests/real_world -name '*.sh' | xargs ./build/diff_oracle
+#
+# See tests/real_world/README.md for the curation criteria.
+# ----------------------------------------------------------------------------
+
+# Wrap diff_oracle in a small driver so the meson test target reports
+# pass-percentage and a clean summary rather than per-script JSON. The
+# driver is checked in at tools/real_world_scorecard.sh.
+if fs.exists('tools/real_world_scorecard.sh')
+  test('real-world scorecard',
+       find_program('tools/real_world_scorecard.sh'),
+       args: [diff_oracle.full_path(),
+              meson.project_source_root() / 'tests/real_world',
+              lush_exe.full_path()],
+       suite: 'real-world',
+       is_parallel: false,
+       timeout: 120)
+endif

--- a/src/builtins/bin_printf.c
+++ b/src/builtins/bin_printf.c
@@ -149,6 +149,7 @@ int bin_printf(int argc, char **argv) {
 
         for (int i = 0; format[i] != '\0'; i++) {
             if (format[i] == '%' && format[i + 1] != '\0') {
+                int spec_start = i; /* points at '%' for forwarding to libc */
                 i++; // Skip the %
 
                 // Handle literal %
@@ -220,6 +221,24 @@ int bin_printf(int argc, char **argv) {
                 const char *format_arg =
                     (arg_index < argc) ? argv[arg_index] : "";
 
+                /* Reconstruct the user's original conversion spec
+                 * (e.g. "%05d", "%+8.2f") so libc printf handles all
+                 * flags — `0`, `+`, ` `, `#`, `-` — uniformly across
+                 * every numeric specifier. Without this, lush would
+                 * silently drop every flag except `-`. */
+                char fwd_fmt[64];
+                {
+                    size_t fwd_len = (size_t)(i - spec_start + 1);
+                    if (fwd_len >= sizeof(fwd_fmt)) {
+                        fwd_len = sizeof(fwd_fmt) - 1;
+                    }
+                    memcpy(fwd_fmt, &format[spec_start], fwd_len);
+                    fwd_fmt[fwd_len] = '\0';
+                }
+                (void)width;
+                (void)left_align;
+                (void)zero_pad;
+
                 switch (specifier) {
                 case 's': {
                     // String format
@@ -258,10 +277,8 @@ int bin_printf(int argc, char **argv) {
                 }
                 case 'd':
                 case 'i': {
-                    // Integer format
                     int value = (arg_index < argc) ? atoi(format_arg) : 0;
-                    int effective_width = left_align ? -width : width;
-                    printf("%*d", effective_width, value);
+                    printf(fwd_fmt, value);
                     if (arg_index < argc) {
                         arg_index++;
                         args_used_this_pass++;
@@ -295,43 +312,14 @@ int bin_printf(int argc, char **argv) {
                     break;
                 }
                 case 'x':
-                case 'X': {
-                    // Hexadecimal format
-                    unsigned int value =
-                        (arg_index < argc)
-                            ? (unsigned int)strtoul(format_arg, NULL, 10)
-                            : 0;
-                    int effective_width = left_align ? -width : width;
-                    printf(specifier == 'x' ? "%*x" : "%*X", effective_width,
-                           value);
-                    if (arg_index < argc) {
-                        arg_index++;
-                        args_used_this_pass++;
-                    }
-                    break;
-                }
-                case 'o': {
-                    // Octal format
-                    unsigned int value =
-                        (arg_index < argc)
-                            ? (unsigned int)strtoul(format_arg, NULL, 10)
-                            : 0;
-                    int effective_width = left_align ? -width : width;
-                    printf("%*o", effective_width, value);
-                    if (arg_index < argc) {
-                        arg_index++;
-                        args_used_this_pass++;
-                    }
-                    break;
-                }
+                case 'X':
+                case 'o':
                 case 'u': {
-                    // Unsigned integer format
                     unsigned int value =
                         (arg_index < argc)
                             ? (unsigned int)strtoul(format_arg, NULL, 10)
                             : 0;
-                    int effective_width = left_align ? -width : width;
-                    printf("%*u", effective_width, value);
+                    printf(fwd_fmt, value);
                     if (arg_index < argc) {
                         arg_index++;
                         args_used_this_pass++;
@@ -339,54 +327,14 @@ int bin_printf(int argc, char **argv) {
                     break;
                 }
                 case 'f':
-                case 'F': {
-                    // Float format
-                    double value =
-                        (arg_index < argc) ? strtod(format_arg, NULL) : 0.0;
-                    int effective_width = left_align ? -width : width;
-                    if (precision >= 0) {
-                        printf("%*.*f", effective_width, precision, value);
-                    } else {
-                        printf("%*f", effective_width, value);
-                    }
-                    if (arg_index < argc) {
-                        arg_index++;
-                        args_used_this_pass++;
-                    }
-                    break;
-                }
+                case 'F':
                 case 'g':
-                case 'G': {
-                    // General float format
-                    double value =
-                        (arg_index < argc) ? strtod(format_arg, NULL) : 0.0;
-                    int effective_width = left_align ? -width : width;
-                    if (precision >= 0) {
-                        printf(specifier == 'g' ? "%*.*g" : "%*.*G",
-                               effective_width, precision, value);
-                    } else {
-                        printf(specifier == 'g' ? "%*g" : "%*G",
-                               effective_width, value);
-                    }
-                    if (arg_index < argc) {
-                        arg_index++;
-                        args_used_this_pass++;
-                    }
-                    break;
-                }
+                case 'G':
                 case 'e':
                 case 'E': {
-                    // Scientific notation
                     double value =
                         (arg_index < argc) ? strtod(format_arg, NULL) : 0.0;
-                    int effective_width = left_align ? -width : width;
-                    if (precision >= 0) {
-                        printf(specifier == 'e' ? "%*.*e" : "%*.*E",
-                               effective_width, precision, value);
-                    } else {
-                        printf(specifier == 'e' ? "%*e" : "%*E",
-                               effective_width, value);
-                    }
+                    printf(fwd_fmt, value);
                     if (arg_index < argc) {
                         arg_index++;
                         args_used_this_pass++;

--- a/src/executor.c
+++ b/src/executor.c
@@ -1259,6 +1259,20 @@ static int execute_command_list(executor_t *executor, node_t *list) {
             return executor->shell_exit_status;
         }
 
+        /* `exit` builtin requested shell termination. bin_exit sets the
+         * global exit_flag (the REPL polls it to leave its top-level
+         * loop) and stashes the chosen status in last_exit_status. The
+         * REPL alone is not enough: when a script is run as a single
+         * parsed AST, the whole tree executes inside ONE call to
+         * execute_command_list, so without this check every statement
+         * after `exit` still runs (real_world/posix/101 fell through
+         * `exit $?` and ran trailing `rm -f` / `exit 0`). Honor it
+         * here so `exit` inside any nested construct - case arm, if
+         * body, brace group, loop - immediately propagates up. */
+        if (exit_flag) {
+            return last_exit_status;
+        }
+
         // Flush stdout to prevent pipeline from picking up residual output
         fflush(stdout);
 
@@ -8503,11 +8517,21 @@ static int execute_case(executor_t *executor, node_t *node) {
         }
 
         if (matched) {
-            // Execute commands for this case item
+            /* Execute commands for this case item. A case arm is a
+             * command list - run every statement sequentially. Do NOT
+             * short-circuit on a non-zero status (that was wrong: it
+             * dropped `exit $?` after a non-zero `do_status` in
+             * real_world/posix/101 init scripts, and silently dropped
+             * later statements in `x) echo a; false; echo b ;;`).
+             * Errexit (set -e) is enforced at execute_command_list,
+             * not here. Honor loop control / shell exit between
+             * statements so `break` / `continue` / `exit` propagate
+             * out of the arm without running trailing commands. */
             node_t *commands = case_item->first_child;
             while (commands) {
                 result = execute_node(executor, commands);
-                if (result != 0) {
+                if (executor->loop_control != LOOP_NORMAL ||
+                    executor->shell_exit_requested || exit_flag) {
                     break;
                 }
                 commands = commands->next_sibling;

--- a/src/executor.c
+++ b/src/executor.c
@@ -7512,7 +7512,26 @@ char **expand_brace_pattern(const char *pattern, int *expanded_count) {
         return result;
     }
 
-    const char *close = strchr(open + 1, '}');
+    /* Find the matching close brace, tracking nesting depth so that
+     * patterns like `{{1..3},{a..c}}` resolve the OUTER brace first
+     * rather than the first inner `}`. Without this, the function
+     * splits content as `{1..3` and bails, leaving the pattern
+     * un-expanded (real_world/bash/206). */
+    const char *close = NULL;
+    {
+        int depth = 1;
+        for (const char *p = open + 1; *p; p++) {
+            if (*p == '{') {
+                depth++;
+            } else if (*p == '}') {
+                depth--;
+                if (depth == 0) {
+                    close = p;
+                    break;
+                }
+            }
+        }
+    }
     if (!close) {
         // Malformed brace - return original pattern
         char **result = malloc(2 * sizeof(char *));
@@ -7545,8 +7564,27 @@ char **expand_brace_pattern(const char *pattern, int *expanded_count) {
     strncpy(content, open + 1, content_len);
     content[content_len] = '\0';
 
-    // Check if this is a range pattern (contains ..)
+    /* Check if this is a SIMPLE range pattern (e.g. `1..10`, `a..z`,
+     * `1..10..2`). A range pattern has `..` and no top-level commas
+     * and no nested braces — otherwise it's a comma-list whose items
+     * happen to contain ranges (e.g. `{{1..3},{a..c}}`) and must be
+     * split on the outer commas first. */
+    bool is_range = false;
     if (strstr(content, "..")) {
+        is_range = true;
+        int depth = 0;
+        for (const char *p = content; *p; p++) {
+            if (*p == '{') {
+                depth++;
+            } else if (*p == '}') {
+                depth--;
+            } else if (*p == ',' && depth == 0) {
+                is_range = false;
+                break;
+            }
+        }
+    }
+    if (is_range) {
         char **range_result =
             expand_brace_range(prefix, content, suffix, expanded_count);
         free(prefix);
@@ -7564,11 +7602,21 @@ char **expand_brace_pattern(const char *pattern, int *expanded_count) {
         return result;
     }
 
-    // Count comma-separated items
+    /* Count comma-separated items at the TOP LEVEL only. Commas
+     * inside nested braces belong to the inner pattern and must not
+     * split the outer one (e.g. `{{1..3},{a..c}}` has two outer
+     * items, not five). */
     int item_count = 1;
-    for (const char *p = content; *p; p++) {
-        if (*p == ',') {
-            item_count++;
+    {
+        int depth = 0;
+        for (const char *p = content; *p; p++) {
+            if (*p == '{') {
+                depth++;
+            } else if (*p == '}') {
+                depth--;
+            } else if (*p == ',' && depth == 0) {
+                item_count++;
+            }
         }
     }
 
@@ -7587,8 +7635,15 @@ char **expand_brace_pattern(const char *pattern, int *expanded_count) {
     char *comma_pos = content;
 
     while (result_index < item_count) {
-        // Find next comma or end of string
-        while (*comma_pos && *comma_pos != ',') {
+        /* Find next TOP-LEVEL comma (depth 0) or end of string.
+         * Nested braces hide their commas from the outer split. */
+        int depth = 0;
+        while (*comma_pos && !(depth == 0 && *comma_pos == ',')) {
+            if (*comma_pos == '{') {
+                depth++;
+            } else if (*comma_pos == '}') {
+                depth--;
+            }
             comma_pos++;
         }
 
@@ -7645,9 +7700,19 @@ char **expand_brace_pattern(const char *pattern, int *expanded_count) {
     free(prefix);
     free(content);
 
-    // Recursively expand any remaining brace patterns in results
-    // This handles Cartesian products like {1..2}{a..b}
-    if (strchr(suffix, '{')) {
+    /* Recursively expand any remaining brace patterns in results.
+     * This handles Cartesian products like `{1..2}{a..b}` (where the
+     * suffix carries another brace) AND nested patterns like
+     * `{{1..3},{a..c}}` (where each comma-separated item is itself a
+     * brace pattern). Scan all results so neither case is missed. */
+    bool any_result_has_brace = false;
+    for (int i = 0; i < item_count; i++) {
+        if (strchr(result[i], '{')) {
+            any_result_has_brace = true;
+            break;
+        }
+    }
+    if (any_result_has_brace) {
         char **final_results = NULL;
         int final_count = 0;
         int cap = brace_expansion_cap();
@@ -16185,6 +16250,34 @@ static int execute_array_assignment(executor_t *executor, node_t *assign_node) {
                         // elements even if they contain spaces
                         bool is_quoted = (elem->type == NODE_STRING_LITERAL ||
                                           elem->type == NODE_STRING_EXPANDABLE);
+
+                        /* Brace expansion on unquoted indexed-array
+                         * elements: `arr=(/tmp/{a,b}/sub)` must yield
+                         * two elements, matching bash/zsh behavior.
+                         * Each brace-expansion result becomes its own
+                         * array element regardless of internal spaces
+                         * (the brace expander has already partitioned
+                         * the source into discrete words). */
+                        if (!is_quoted &&
+                            needs_brace_expansion(final_value)) {
+                            int brace_count = 0;
+                            char **brace_results = expand_brace_pattern(
+                                final_value, &brace_count);
+                            if (brace_results) {
+                                for (int bi = 0; bi < brace_count; bi++) {
+                                    symtable_array_set_index(array, index,
+                                                             brace_results[bi]);
+                                    index++;
+                                    free(brace_results[bi]);
+                                }
+                                free(brace_results);
+                                if (expanded) {
+                                    free(expanded);
+                                }
+                                elem = elem->next_sibling;
+                                continue;
+                            }
+                        }
 
                         // Word split the expanded value if it contains spaces
                         // This handles ${(s:,:)var} and ${(f)var} producing

--- a/src/executor.c
+++ b/src/executor.c
@@ -2731,6 +2731,78 @@ static int execute_repeat(executor_t *executor, node_t *repeat_node) {
 }
 
 /**
+ * @brief Pathname-expand a slice of a for-loop word list in place
+ *
+ * Replaces every word in words[start..*count) that carries glob
+ * metacharacters with its sorted matches; words with no matches are
+ * kept verbatim (bash default) unless nullglob drops them. The slice
+ * mechanism lets the caller glob only the words produced by an
+ * UNQUOTED word node, leaving quoted words and `$@` elements alone.
+ *
+ * The for-loop word builder expands variables, braces, and fields but
+ * historically never globbed -- `for x in *` iterated the literal
+ * `*`. expand_glob_pattern handles zsh glob qualifiers, extglob,
+ * nullglob, and `set -f` internally.
+ *
+ * @return false only on allocation failure
+ */
+static bool for_word_list_glob_range(char ***words, int *count, int start) {
+    if (!words || !*words || !count) {
+        return true;
+    }
+    char **src = *words;
+    int n = *count;
+
+    bool any = false;
+    for (int i = start; i < n; i++) {
+        if (src[i] && needs_glob_expansion(src[i])) {
+            any = true;
+            break;
+        }
+    }
+    if (!any) {
+        return true;
+    }
+
+    char **out = NULL;
+    int out_count = 0;
+    for (int i = 0; i < n; i++) {
+        if (i >= start && src[i] && needs_glob_expansion(src[i])) {
+            int gc = 0;
+            char **g = expand_glob_pattern(src[i], &gc);
+            if (g) {
+                char **no =
+                    realloc(out, (size_t)(out_count + gc) * sizeof(char *));
+                if (!no) {
+                    free(g);
+                    free(out);
+                    return false;
+                }
+                out = no;
+                for (int j = 0; j < gc; j++) {
+                    out[out_count++] = g[j];
+                }
+                free(g);
+                free(src[i]);
+                continue;
+            }
+        }
+        char **no = realloc(out, (size_t)(out_count + 1) * sizeof(char *));
+        if (!no) {
+            free(out);
+            return false;
+        }
+        out = no;
+        out[out_count++] = src[i];
+    }
+
+    free(src);
+    *words = out;
+    *count = out_count;
+    return true;
+}
+
+/**
  * @brief Execute a for loop
  *
  * Iterates over a word list, setting the loop variable for each iteration.
@@ -2809,6 +2881,13 @@ static int execute_for(executor_t *executor, node_t *for_node) {
     if (word_list && word_list->first_child) {
         node_t *word = word_list->first_child;
         while (word) {
+            /* Index into expanded_words where this word node's
+             * normal-expansion output begins, and whether that output
+             * is eligible for pathname expansion. -1 until the normal
+             * expansion path runs (the `$@` and vector paths produce
+             * already-final values that are never glob-expanded). */
+            int normal_wc_start = -1;
+            bool word_globbable = false;
             if (word->val.str) {
                 // Special handling for "$@" to preserve word boundaries
                 if (strcmp(word->val.str, "\"$@\"") == 0 ||
@@ -2902,7 +2981,12 @@ static int execute_for(executor_t *executor, node_t *for_node) {
                         continue;
                     }
 
-                    // Normal expansion and splitting for other words
+                    // Normal expansion and splitting for other words.
+                    // Record the start index and quotedness so the
+                    // words produced below can be pathname-expanded.
+                    normal_wc_start = word_count;
+                    word_globbable = (word->type != NODE_STRING_LITERAL &&
+                                      word->type != NODE_STRING_EXPANDABLE);
                     char *expanded = expand_if_needed(executor, word->val.str);
                     if (expanded) {
                         // Check for brace expansion first
@@ -3013,6 +3097,23 @@ static int execute_for(executor_t *executor, node_t *for_node) {
                             }
                         }
                     }
+                }
+            }
+            /* Pathname-expand the words this UNQUOTED word node just
+             * produced. normal_wc_start is -1 for the `$@` / vector
+             * paths and for quoted word nodes, leaving those
+             * untouched. */
+            if (normal_wc_start >= 0 && word_globbable) {
+                if (!for_word_list_glob_range(&expanded_words, &word_count,
+                                              normal_wc_start)) {
+                    set_executor_error(executor,
+                                       "Memory allocation failed in for loop");
+                    for (int j = 0; j < word_count; j++) {
+                        free(expanded_words[j]);
+                    }
+                    free(expanded_words);
+                    symtable_pop_scope(executor->symtable);
+                    return 1;
                 }
             }
             word = word->next_sibling;
@@ -5795,7 +5896,17 @@ typedef enum {
     GLOB_QUAL_EXEC = 8,      // (*) - executable files
     GLOB_QUAL_READABLE = 16, // (r) - readable files
     GLOB_QUAL_WRITABLE = 32, // (w) - writable files
+    /* Behavior modifiers (not type/permission filters): */
+    GLOB_QUAL_NULLGLOB = 64,  // (N) - no match -> empty, never literal
+    GLOB_QUAL_DOTGLOB = 128,  // (D) - include dot (hidden) files
 } glob_qualifier_t;
+
+/* Bits that filter by file type or permission (vs. behavior modifiers
+ * like N/D). matches_glob_qualifier only needs to act when one of
+ * these is set. */
+#define GLOB_QUAL_FILTER_MASK                                                  \
+    (GLOB_QUAL_FILE | GLOB_QUAL_DIR | GLOB_QUAL_LINK | GLOB_QUAL_EXEC |         \
+     GLOB_QUAL_READABLE | GLOB_QUAL_WRITABLE)
 
 /**
  * @brief Parse and strip glob qualifier from pattern
@@ -5853,6 +5964,12 @@ static glob_qualifier_t parse_glob_qualifier(const char *pattern,
                     break;
                 case 'w':
                     qual |= GLOB_QUAL_WRITABLE;
+                    break;
+                case 'N':
+                    qual |= GLOB_QUAL_NULLGLOB;
+                    break;
+                case 'D':
+                    qual |= GLOB_QUAL_DOTGLOB;
                     break;
                 case ',':
                     break; // Separator, ignore
@@ -6862,6 +6979,113 @@ static char **expand_globstar_pattern(const char *pattern,
     return results;
 }
 
+/**
+ * @brief Expand a glob pattern with dotfile matching (zsh `D` qualifier)
+ *
+ * libc glob() never matches leading-dot files and offers no portable
+ * flag to change that (GLOB_PERIOD is a glibc/_GNU_SOURCE extension,
+ * absent on macOS). The zsh `(D)` glob qualifier explicitly requests
+ * dotfile inclusion, so for D-qualified patterns scan the directory
+ * directly with readdir + fnmatch. `.` and `..` are always excluded.
+ *
+ * Only single-component patterns and `dir/filepat` forms are handled
+ * (the qualifier-glob syntax in practice never nests deeper). Results
+ * are filtered through matches_glob_qualifier for any type/permission
+ * bits combined with D.
+ *
+ * @param base_pattern Pattern with the qualifier already stripped
+ * @param qualifier    Parsed qualifier bitmask (includes GLOB_QUAL_DOTGLOB)
+ * @param count        OUT: number of matches
+ * @return Match array (caller frees), empty array on no match, or NULL
+ *         on error
+ */
+static char **expand_glob_dotglob(const char *base_pattern,
+                                  glob_qualifier_t qualifier, int *count) {
+    *count = 0;
+
+    /* Split into directory and filename pattern at the last '/'. */
+    const char *slash = strrchr(base_pattern, '/');
+    char *dir = NULL;
+    const char *filepat = base_pattern;
+    if (slash) {
+        size_t dlen = (size_t)(slash - base_pattern);
+        dir = malloc(dlen + 1);
+        if (!dir) {
+            return NULL;
+        }
+        memcpy(dir, base_pattern, dlen);
+        dir[dlen] = '\0';
+        filepat = slash + 1;
+    }
+
+    DIR *d = opendir(dir ? dir : ".");
+    if (!d) {
+        free(dir);
+        return NULL;
+    }
+
+    char **result = NULL;
+    size_t result_count = 0;
+    size_t result_cap = 0;
+    struct dirent *entry;
+    while ((entry = readdir(d)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 ||
+            strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+        /* fnmatch without FNM_PERIOD: `*` matches leading-dot names,
+         * which is exactly the D-qualifier semantics. */
+        if (fnmatch(filepat, entry->d_name, 0) != 0) {
+            continue;
+        }
+        /* Build the path as the caller would see it. */
+        char *path;
+        if (dir) {
+            size_t plen = strlen(dir) + 1 + strlen(entry->d_name) + 1;
+            path = malloc(plen);
+            if (path) {
+                snprintf(path, plen, "%s/%s", dir, entry->d_name);
+            }
+        } else {
+            path = strdup(entry->d_name);
+        }
+        if (!path) {
+            continue;
+        }
+        if ((qualifier & GLOB_QUAL_FILTER_MASK) &&
+            !matches_glob_qualifier(path, qualifier)) {
+            free(path);
+            continue;
+        }
+        if (result_count + 1 >= result_cap) {
+            size_t new_cap = result_cap ? result_cap * 2 : 8;
+            char **nr = realloc(result, new_cap * sizeof(char *));
+            if (!nr) {
+                free(path);
+                break;
+            }
+            result = nr;
+            result_cap = new_cap;
+        }
+        result[result_count++] = path;
+    }
+    closedir(d);
+    free(dir);
+
+    if (!result) {
+        /* No matches: hand back an empty (non-NULL) array. */
+        result = malloc(sizeof(char *));
+        if (result) {
+            result[0] = NULL;
+        }
+        *count = 0;
+        return result;
+    }
+    result[result_count] = NULL;
+    *count = (int)result_count;
+    return result;
+}
+
 static char **expand_glob_pattern(const char *pattern, int *expanded_count) {
     if (!pattern || !expanded_count) {
         *expanded_count = 0;
@@ -7009,13 +7233,36 @@ static char **expand_glob_pattern(const char *pattern, int *expanded_count) {
         return NULL;
     }
 
+    /* The zsh `D` qualifier requests dotfile matching, which libc
+     * glob() cannot do portably -- route through a readdir scan. */
+    if (qualifier & GLOB_QUAL_DOTGLOB) {
+        char **dot_results =
+            expand_glob_dotglob(base_pattern, qualifier, expanded_count);
+        free(base_pattern);
+        if (dot_results) {
+            return dot_results;
+        }
+        /* Scan failed: fall back to the literal pattern. */
+        char **result = malloc(2 * sizeof(char *));
+        if (result) {
+            result[0] = strdup(pattern);
+            result[1] = NULL;
+            *expanded_count = 1;
+        } else {
+            *expanded_count = 0;
+        }
+        return result;
+    }
+
     glob_t globbuf;
     int glob_result = glob(base_pattern, GLOB_NOSORT, NULL, &globbuf);
     free(base_pattern);
 
     if (glob_result == GLOB_NOMATCH) {
-        // No matches - check nullglob setting
-        if (shell_mode_allows(FEATURE_NULL_GLOB)) {
+        // No matches - nullglob mode OR an explicit (N) qualifier
+        // both mean "expand to nothing" rather than the literal.
+        if (shell_mode_allows(FEATURE_NULL_GLOB) ||
+            (qualifier & GLOB_QUAL_NULLGLOB)) {
             // Nullglob: unmatched patterns expand to nothing
             // Return empty array (not NULL, to distinguish from error)
             char **result = malloc(sizeof(char *));
@@ -7103,9 +7350,11 @@ static char **expand_glob_pattern(const char *pattern, int *expanded_count) {
         globfree(&globbuf);
 
         if (match_count == 0) {
-            // No matches after filtering - check nullglob
+            // No matches after filtering - nullglob mode OR an
+            // explicit (N) qualifier both expand to nothing.
             free(result);
-            if (shell_mode_allows(FEATURE_NULL_GLOB)) {
+            if (shell_mode_allows(FEATURE_NULL_GLOB) ||
+                (qualifier & GLOB_QUAL_NULLGLOB)) {
                 // Nullglob: expand to nothing
                 // Return empty array (not NULL, to distinguish from error)
                 result = malloc(sizeof(char *));
@@ -16447,6 +16696,32 @@ static int execute_array_assignment(executor_t *executor, node_t *assign_node) {
                                     free(brace_results[bi]);
                                 }
                                 free(brace_results);
+                                if (expanded) {
+                                    free(expanded);
+                                }
+                                elem = elem->next_sibling;
+                                continue;
+                            }
+                        }
+
+                        /* Pathname (glob) expansion on unquoted
+                         * indexed-array elements: `arr=(*.txt)` must
+                         * list the matching files, not iterate the
+                         * literal pattern. expand_glob_pattern handles
+                         * zsh glob qualifiers, extglob, nullglob, and
+                         * `set -f` internally. */
+                        if (!is_quoted && needs_glob_expansion(final_value)) {
+                            int glob_count = 0;
+                            char **glob_results =
+                                expand_glob_pattern(final_value, &glob_count);
+                            if (glob_results) {
+                                for (int gi = 0; gi < glob_count; gi++) {
+                                    symtable_array_set_index(array, index,
+                                                             glob_results[gi]);
+                                    index++;
+                                    free(glob_results[gi]);
+                                }
+                                free(glob_results);
                                 if (expanded) {
                                     free(expanded);
                                 }

--- a/src/executor.c
+++ b/src/executor.c
@@ -2321,6 +2321,19 @@ static void loop_monitor_init(loop_monitor_t *m) {
     m->armed = false;
 }
 
+/* A `return` (or `exit`) executed inside a function surfaces as the
+ * special 200-455 status code that bin_return / the executor use to
+ * signal function unwinding. Loop bodies must recognize it, stop
+ * iterating, and propagate the code unchanged so the enclosing
+ * function actually returns. Without this check, `for x in ...; do
+ * ... return 0; done` ran every remaining iteration and then fell
+ * through to the post-loop statements (real_world/bash/201 is_in()).
+ * This check must run BEFORE loop_errexit_tripped: a function-return
+ * code is non-zero and would otherwise be misread as a failed body. */
+static bool loop_body_is_function_return(int body_status) {
+    return body_status >= 200 && body_status <= 455;
+}
+
 /* errexit_in_loops: when FEATURE_ERREXIT_IN_LOOPS is enabled (curated
  * lush-mode default; off in POSIX/bash/zsh for polyglot parity), the
  * first non-zero body exit aborts the loop. Caller should report
@@ -2449,6 +2462,12 @@ static int execute_while(executor_t *executor, node_t *while_node) {
             // Continue to next iteration (just reset and loop again)
         }
 
+        /* `return` inside the body: stop iterating, propagate the
+         * function-return signal to the enclosing function. */
+        if (loop_body_is_function_return(last_result)) {
+            break;
+        }
+
         if (loop_errexit_tripped(last_result)) {
             errexit_tripped = true;
             break;
@@ -2574,6 +2593,12 @@ static int execute_until(executor_t *executor, node_t *until_node) {
             // Continue to next iteration
         }
 
+        /* `return` inside the body: stop iterating, propagate the
+         * function-return signal to the enclosing function. */
+        if (loop_body_is_function_return(last_result)) {
+            break;
+        }
+
         if (loop_errexit_tripped(last_result)) {
             errexit_tripped = true;
             break;
@@ -2688,6 +2713,11 @@ static int execute_repeat(executor_t *executor, node_t *repeat_node) {
         } else if (executor->loop_control == LOOP_CONTINUE) {
             executor->loop_control = LOOP_NORMAL;
             continue;
+        }
+        /* `return` inside the body: stop iterating, propagate the
+         * function-return signal to the enclosing function. */
+        if (loop_body_is_function_return(last_result)) {
+            break;
         }
         if (executor->shell_exit_requested) {
             break;
@@ -3045,6 +3075,12 @@ static int execute_for(executor_t *executor, node_t *for_node) {
                 // Continue to next iteration
             }
 
+            /* `return` inside the body: stop iterating, propagate the
+             * function-return signal to the enclosing function. */
+            if (loop_body_is_function_return(last_result)) {
+                break;
+            }
+
             if (loop_errexit_tripped(last_result)) {
                 errexit_tripped = true;
                 break;
@@ -3246,6 +3282,12 @@ static int execute_for_arith(executor_t *executor, node_t *for_arith_node) {
         } else if (executor->loop_control == LOOP_CONTINUE) {
             executor->loop_control = LOOP_NORMAL;
             // Fall through to update expression
+        }
+
+        /* `return` inside the body: stop iterating, propagate the
+         * function-return signal to the enclosing function. */
+        if (loop_body_is_function_return(last_result)) {
+            break;
         }
 
         if (loop_errexit_tripped(last_result)) {
@@ -9269,6 +9311,64 @@ static bool match_pattern(const char *str, const char *pattern) {
             }
 
             while (*p && *p != ']') {
+                /* POSIX character class [:CLASS:] (e.g. [:space:],
+                 * [:alpha:], [:digit:]). Used heavily by real-world
+                 * trim/parse idioms - `${s%%[![:space:]]*}` was
+                 * silently treating [:space:] as the literal
+                 * character set { '[', ':', 's', 'p', 'a', 'c', 'e' }
+                 * because the class form was never parsed
+                 * (real_world/bash/201 trim function). Scan for `:]`
+                 * to delimit the class name, then test via ctype. */
+                if (p[0] == '[' && p[1] == ':') {
+                    const char *class_start = p + 2;
+                    const char *class_end = strstr(class_start, ":]");
+                    if (class_end) {
+                        size_t cl = (size_t)(class_end - class_start);
+                        unsigned char uc = (unsigned char)*s;
+                        bool cls_match = false;
+                        if (cl == 5 && memcmp(class_start, "space", 5) == 0) {
+                            cls_match = isspace(uc) != 0;
+                        } else if (cl == 5 &&
+                                   memcmp(class_start, "alpha", 5) == 0) {
+                            cls_match = isalpha(uc) != 0;
+                        } else if (cl == 5 &&
+                                   memcmp(class_start, "digit", 5) == 0) {
+                            cls_match = isdigit(uc) != 0;
+                        } else if (cl == 5 &&
+                                   memcmp(class_start, "alnum", 5) == 0) {
+                            cls_match = isalnum(uc) != 0;
+                        } else if (cl == 5 &&
+                                   memcmp(class_start, "upper", 5) == 0) {
+                            cls_match = isupper(uc) != 0;
+                        } else if (cl == 5 &&
+                                   memcmp(class_start, "lower", 5) == 0) {
+                            cls_match = islower(uc) != 0;
+                        } else if (cl == 5 &&
+                                   memcmp(class_start, "punct", 5) == 0) {
+                            cls_match = ispunct(uc) != 0;
+                        } else if (cl == 5 &&
+                                   memcmp(class_start, "print", 5) == 0) {
+                            cls_match = isprint(uc) != 0;
+                        } else if (cl == 5 &&
+                                   memcmp(class_start, "graph", 5) == 0) {
+                            cls_match = isgraph(uc) != 0;
+                        } else if (cl == 5 &&
+                                   memcmp(class_start, "blank", 5) == 0) {
+                            cls_match = (uc == ' ' || uc == '\t');
+                        } else if (cl == 5 &&
+                                   memcmp(class_start, "cntrl", 5) == 0) {
+                            cls_match = iscntrl(uc) != 0;
+                        } else if (cl == 6 &&
+                                   memcmp(class_start, "xdigit", 6) == 0) {
+                            cls_match = isxdigit(uc) != 0;
+                        }
+                        if (cls_match) {
+                            matched = true;
+                        }
+                        p = class_end + 2; /* past `:]` */
+                        continue;
+                    }
+                }
                 if (p[1] == '-' && p[2] != ']' && p[2] != '\0') {
                     // Range pattern like a-z
                     if (*s >= *p && *s <= p[2]) {

--- a/src/executor.c
+++ b/src/executor.c
@@ -12296,6 +12296,58 @@ static char *parse_parameter_expansion(executor_t *executor,
                         }
                     }
 
+                    /* Apply trailing parameter-expansion operator on an
+                     * indexed/associative element: `${arr[key]:-default}`,
+                     * `${arr[key]:+alt}`, etc. Without this, the array
+                     * branch returned the (possibly empty) element value
+                     * unconditionally, dropping the operator entirely
+                     * (real_world/bash/200 fell back to "" instead of the
+                     * `:-info` default for a missing assoc key). For
+                     * arrays we can't distinguish unset from empty (a
+                     * missing key reads as ""), so both `:-` and `-`
+                     * behave identically here, as do `:+` and `+`. The
+                     * default/alt RHS is variable-expanded so
+                     * `${arr[k]:-$fallback}` works. */
+                    const char *after_bracket = close + 1;
+                    if (*after_bracket != '\0') {
+                        bool value_is_empty = (!result || !*result);
+                        const char *rhs = NULL;
+                        bool want_default_when_empty = false; /* :- / - */
+                        bool want_alt_when_nonempty = false;  /* :+ / + */
+                        if (after_bracket[0] == ':' &&
+                            (after_bracket[1] == '-' ||
+                             after_bracket[1] == '+')) {
+                            rhs = after_bracket + 2;
+                            want_default_when_empty = (after_bracket[1] == '-');
+                            want_alt_when_nonempty = (after_bracket[1] == '+');
+                        } else if (after_bracket[0] == '-' ||
+                                   after_bracket[0] == '+') {
+                            rhs = after_bracket + 1;
+                            want_default_when_empty = (after_bracket[0] == '-');
+                            want_alt_when_nonempty = (after_bracket[0] == '+');
+                        }
+                        if (rhs) {
+                            char *expanded_rhs =
+                                expand_variables_in_string(executor, rhs);
+                            const char *rhs_final =
+                                expanded_rhs ? expanded_rhs : rhs;
+                            if (want_default_when_empty && value_is_empty) {
+                                free(result);
+                                result = strdup(rhs_final);
+                            } else if (want_alt_when_nonempty &&
+                                       !value_is_empty) {
+                                free(result);
+                                result = strdup(rhs_final);
+                            } else if (want_alt_when_nonempty) {
+                                free(result);
+                                result = strdup("");
+                            }
+                            if (expanded_rhs) {
+                                free(expanded_rhs);
+                            }
+                        }
+                    }
+
                     free(subscript);
                     free(arr_name);
                     return result ? result : strdup("");

--- a/src/lush.c
+++ b/src/lush.c
@@ -426,14 +426,17 @@ int main(int argc, char **argv) {
     // Cleanup is handled by atexit() handlers registered in init.c
     // This prevents double cleanup when exit() command is used
 
-    // Cleanup global executor before exit
+    /* Run EXIT traps BEFORE tearing down the executor: the trap body
+     * is parsed and executed by the executor itself, so it must still
+     * exist (otherwise execute_exit_traps falls back to /bin/sh, and
+     * any reference to a user-defined function or shell variable in
+     * the trap body fails). */
+    execute_exit_traps();
+
     if (global_executor) {
         executor_free(global_executor);
         global_executor = NULL;
     }
-
-    // Execute EXIT traps before shell terminates normally
-    execute_exit_traps();
 
     // Exit with the status of the last command executed (POSIX requirement)
     exit(last_exit_status);

--- a/src/parser.c
+++ b/src/parser.c
@@ -4250,8 +4250,21 @@ static node_t *parse_case_statement(parser_t *parser) {
 
     // Parse case items until 'esac'
     parser_loop_guard_t items_guard = PARSER_LOOP_GUARD_INIT;
-    while (!tokenizer_match(parser->tokenizer, TOK_ESAC) &&
-           !tokenizer_match(parser->tokenizer, TOK_EOF)) {
+    while (1) {
+        /* Skip separators (newlines, comments, optional whitespace) between
+         * case items. Without this, a `;;` followed by a `# trailing
+         * comment` newline `esac` pattern (extremely common in real shell
+         * scripts -- see real_world/posix/100) errors with "expected
+         * pattern" when the loop body tries to parse the comment as a
+         * pattern. POSIX 2.10.2: case_item is `pattern_list ')' compound_list
+         * 'DSEMI'` followed by either another case_item or 'esac', with
+         * linebreaks / comments allowed in between. */
+        skip_separators(parser);
+
+        if (tokenizer_match(parser->tokenizer, TOK_ESAC) ||
+            tokenizer_match(parser->tokenizer, TOK_EOF)) {
+            break;
+        }
 
         if (!parser_loop_check_progress(parser, &items_guard,
                                         "parse_case_statement items")) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -68,9 +68,7 @@ static node_t *parse_anonymous_function(parser_t *parser);
 
 // Forward declarations for POSIX compliance
 bool is_posix_mode_enabled(void);
-static char *collect_heredoc_content(parser_t *parser, const char *delimiter,
-                                     bool strip_tabs, bool expand_variables,
-                                     source_location_t op_loc);
+static bool collect_pending_heredocs(parser_t *parser);
 static void set_parser_error(parser_t *parser, const char *message);
 static bool expect_token(parser_t *parser, token_type_t expected);
 
@@ -120,6 +118,9 @@ parser_t *parser_new_with_source(const char *input, const char *source_name,
 
     /* Initialize recursion depth tracking */
     parser->recursion_depth = 0;
+
+    /* No heredocs pending body collection yet */
+    parser->pending_heredoc_count = 0;
 
     return parser;
 }
@@ -618,7 +619,17 @@ node_t *parser_parse(parser_t *parser) {
         return NULL; // Empty input
     }
 
-    return parse_command_list(parser);
+    node_t *ast = parse_command_list(parser);
+
+    /* A heredoc operator on the last line with no body and no
+     * line-terminating newline never reaches the skip_separators
+     * collection trigger. Flush here so the unterminated-heredoc
+     * error is still reported rather than silently dropped. */
+    if (parser->pending_heredoc_count > 0) {
+        collect_pending_heredocs(parser);
+    }
+
+    return ast;
 }
 
 /**
@@ -630,7 +641,11 @@ node_t *parser_parse(parser_t *parser) {
  * @return AST for the command line
  */
 node_t *parser_parse_command_line(parser_t *parser) {
-    return parse_command_list(parser);
+    node_t *ast = parse_command_list(parser);
+    if (parser && parser->pending_heredoc_count > 0) {
+        collect_pending_heredocs(parser);
+    }
+    return ast;
 }
 
 /**
@@ -645,6 +660,16 @@ static void skip_separators(parser_t *parser) {
            tokenizer_match(parser->tokenizer, TOK_NEWLINE) ||
            tokenizer_match(parser->tokenizer, TOK_WHITESPACE) ||
            tokenizer_match(parser->tokenizer, TOK_COMMENT)) {
+        /* A newline that follows a `<<delim` operator is the trigger to
+         * collect the deferred heredoc body/bodies. collect_pending_
+         * heredocs repositions the tokenizer past the last terminator,
+         * so do NOT also advance -- re-evaluate the loop condition
+         * against the freshly tokenized post-heredoc token. */
+        if (tokenizer_match(parser->tokenizer, TOK_NEWLINE) &&
+            parser->pending_heredoc_count > 0) {
+            collect_pending_heredocs(parser);
+            continue;
+        }
         tokenizer_advance(parser->tokenizer);
     }
 }
@@ -835,12 +860,9 @@ static node_t *parse_command_list(parser_t *parser) {
             return NULL;
         }
 
-        // Skip separators, newlines, and comments
-        while (tokenizer_match(parser->tokenizer, TOK_SEMICOLON) ||
-               tokenizer_match(parser->tokenizer, TOK_NEWLINE) ||
-               tokenizer_match(parser->tokenizer, TOK_COMMENT)) {
-            tokenizer_advance(parser->tokenizer);
-        }
+        // Skip separators, newlines, comments -- and collect any
+        // deferred heredoc bodies triggered by a line-ending newline.
+        skip_separators(parser);
 
         if (tokenizer_match(parser->tokenizer, TOK_EOF)) {
             break;
@@ -919,6 +941,13 @@ static node_t *parse_pipeline(parser_t *parser) {
         // Skip newlines after pipe - allows multiline pipelines
         while (tokenizer_match(parser->tokenizer, TOK_NEWLINE) ||
                tokenizer_match(parser->tokenizer, TOK_WHITESPACE)) {
+            /* `cmd <<EOF |` then newline: the heredoc body follows that
+             * newline. Collect it before consuming the newline. */
+            if (tokenizer_match(parser->tokenizer, TOK_NEWLINE) &&
+                parser->pending_heredoc_count > 0) {
+                collect_pending_heredocs(parser);
+                continue;
+            }
             tokenizer_advance(parser->tokenizer);
         }
 
@@ -2532,7 +2561,7 @@ static node_t *parse_redirection(parser_t *parser) {
         }
     }
 
-    // For here documents, collect the content
+    // For here documents, DEFER body collection
     if (node_type == NODE_REDIR_HEREDOC ||
         node_type == NODE_REDIR_HEREDOC_STRIP) {
         // Store delimiter before advancing tokenizer
@@ -2549,18 +2578,8 @@ static node_t *parse_redirection(parser_t *parser) {
         }
         // Only unquoted delimiters allow variable expansion
 
-        // Advance past the delimiter token first
+        // Advance past the delimiter token
         tokenizer_advance(parser->tokenizer);
-
-        // Collect the here document content (this will advance the tokenizer
-        // further)
-        char *content = collect_heredoc_content(parser, delimiter, strip_tabs,
-                                                expand_variables, op_loc);
-        if (!content) {
-            free(delimiter);
-            free_node_tree(redir_node);
-            return NULL;
-        }
 
         // Store delimiter in the redirection node value. The
         // operator text (`<<` / `<<-`) was strdup'd into val.str
@@ -2572,26 +2591,29 @@ static node_t *parse_redirection(parser_t *parser) {
         redir_node->val.str = delimiter; // Transfer ownership
         redir_node->val_type = VAL_STR;
 
-        // Create content node with the collected content
-        node_t *content_node = new_node(NODE_VAR);
-        if (!content_node) {
-            free(content);
+        /* DEFERRED COLLECTION. The heredoc body physically begins on
+         * the line AFTER the operator -- collecting it now would mean
+         * jumping the tokenizer past everything that still follows
+         * `<<delim` on this line (`| wc`, a trailing `; cmd2`, etc.),
+         * losing those tokens. Instead queue the heredoc; the body is
+         * collected by collect_pending_heredocs() when the parser
+         * reaches the line-terminating newline. The content and
+         * expand-flag child nodes are attached there. */
+        if (parser->pending_heredoc_count >= PARSER_MAX_PENDING_HEREDOCS) {
+            parser_error_add(parser, SHELL_ERR_HEREDOC_DELIMITER,
+                             "too many here-documents on one line "
+                             "(maximum %d)",
+                             PARSER_MAX_PENDING_HEREDOCS);
             free_node_tree(redir_node);
             return NULL;
         }
-        content_node->val.str = content; // Transfer ownership
-        content_node->val_type = VAL_STR;
-        add_child_node(redir_node, content_node);
-
-        // Create a second child node to store the expand_variables flag
-        node_t *expand_flag_node = new_node(NODE_VAR);
-        if (!expand_flag_node) {
-            free_node_tree(redir_node);
-            return NULL;
-        }
-        expand_flag_node->val.str = strdup(expand_variables ? "1" : "0");
-        expand_flag_node->val_type = VAL_STR;
-        add_child_node(redir_node, expand_flag_node);
+        pending_heredoc_t *ph =
+            &parser->pending_heredocs[parser->pending_heredoc_count++];
+        ph->redir_node = redir_node;
+        ph->delimiter = redir_node->val.str; /* borrowed; node owns it */
+        ph->strip_tabs = strip_tabs;
+        ph->expand_variables = expand_variables;
+        ph->op_loc = op_loc;
 
         return redir_node;
     } else {
@@ -2656,27 +2678,38 @@ static node_t *parse_redirection(parser_t *parser) {
 }
 
 /**
- * @brief Collect here-document content
+ * @brief Collect a single here-document body
  *
- * Scans input for lines until the delimiter is found alone on a line.
- * Handles <<- (strip leading tabs) variant. Updates tokenizer position
- * to after the here-document.
+ * Scans input lines starting at @p body_start until the delimiter is
+ * found alone on a line, accumulating the body text. Handles the <<-
+ * (strip leading tabs) variant. Pure scan: does NOT touch the
+ * tokenizer's position or token cache -- the caller
+ * (collect_pending_heredocs) is responsible for repositioning the
+ * tokenizer once every pending heredoc on the line is collected.
  *
- * @param parser Parser instance
- * @param delimiter End delimiter string
- * @param strip_tabs If true, strip leading tabs from each line
- * @param expand_variables If true, variables will be expanded during execution
- * @return Collected content string (caller must free)
+ * @param parser    Parser instance (for error reporting)
+ * @param delimiter End delimiter string (may carry surrounding quotes)
+ * @param strip_tabs If true, strip leading tabs from each line (<<-)
+ * @param body_start Absolute input byte offset where the body begins
+ * @param op_loc     Source location of the `<<` operator (for errors)
+ * @param body_end   OUT: input offset just past the terminator line's
+ *                   newline (or input_length); set even on error
+ * @return Collected content string (caller frees), or NULL on an
+ *         unterminated heredoc (parser error already recorded)
  */
-static char *collect_heredoc_content(parser_t *parser, const char *delimiter,
-                                     bool strip_tabs, bool expand_variables,
-                                     source_location_t op_loc) {
-    (void)expand_variables; /* Expansion handled during execution phase */
-    if (!parser || !delimiter) {
+static char *collect_one_heredoc_body(parser_t *parser, const char *delimiter,
+                                      bool strip_tabs, size_t body_start,
+                                      source_location_t op_loc,
+                                      size_t *body_end) {
+    if (!parser || !delimiter || !body_end) {
+        if (body_end) {
+            *body_end = body_start;
+        }
         return NULL;
     }
 
     tokenizer_t *tokenizer = parser->tokenizer;
+    *body_end = body_start;
 
     /* Strip outer quotes from the delimiter if present so body lines
      * compare against the user-visible terminator text (`'END'` →
@@ -2697,57 +2730,28 @@ static char *collect_heredoc_content(parser_t *parser, const char *delimiter,
         }
     }
 
-    /* The heredoc body always begins on the line AFTER the operator's
-     * line. The parser captured the operator's source_location_t into
-     * op_loc before any tokenizer_advance freed the operator token,
-     * so op_loc.offset is a reliable absolute byte position of the
-     * `<<` operator. Scan from just past `<<` to the next newline;
-     * the byte after that newline is content_start.
-     *
-     * The previous implementation searched the entire input from byte
-     * 0 for a literal `<< delimiter` substring match, which had two
-     * unfixable defects:
-     *
-     *   - Issue #51: when two heredocs in the same input shared a
-     *     delimiter, the search for the second always found the first
-     *     and reset tokenizer->position backwards, causing the parser
-     *     to re-parse the second heredoc forever. Anchoring the
-     *     search at op_loc.offset (the previous fix) avoided one
-     *     backward jump but kept the search.
-     *
-     *   - Issue #52: the search couldn't handle shell quote-
-     *     concatenation in the delimiter spec (e.g. `<< ''ai`, where
-     *     the parser correctly resolves the delimiter to "ai" but the
-     *     input bytes show `''ai`). The literal-substring match
-     *     failed, content_start defaulted to the initial value of 0,
-     *     and body collection started at byte 0 of the input — finding
-     *     spurious terminator lines and resetting tokenizer->position
-     *     to inside the live parse, triggering O(N^2) command-list
-     *     growth in the case-arm body parser.
-     *
-     * Both classes are eliminated by computing content_start from
-     * op_loc.offset directly. The delimiter spec text in the input is
-     * not used for content_start; only for the terminator-line match
-     * below. */
-    size_t content_start = op_loc.offset + 2; /* past `<<` */
-    while (content_start < tokenizer->input_length &&
-           tokenizer->input[content_start] != '\n') {
-        content_start++;
-    }
-    if (content_start < tokenizer->input_length) {
-        content_start++; /* skip the newline */
-    }
+    /* The body begins exactly at body_start -- the caller
+     * (collect_pending_heredocs) computed it as the byte just past the
+     * line-terminating newline that followed the `<<delim` operator,
+     * or, for the second and later heredocs declared on the same line,
+     * the byte just past the previous heredoc's terminator. No
+     * scanning for the operator or the delimiter spec is needed here:
+     * deferral guarantees we are always positioned at a body start. */
+    (void)op_loc; /* retained only for the unterminated-heredoc error */
 
     // Collect lines until we find the delimiter
     size_t content_size = 0;
     size_t content_capacity = 1024;
     char *content = malloc(content_capacity);
     if (!content) {
+        if (unquoted_delimiter) {
+            free(unquoted_delimiter);
+        }
         return NULL;
     }
     content[0] = '\0';
 
-    size_t line_start = content_start;
+    size_t line_start = body_start;
     bool found_delimiter_line = false;
     while (line_start < tokenizer->input_length) {
         // Find end of current line
@@ -2762,6 +2766,9 @@ static char *collect_heredoc_content(parser_t *parser, const char *delimiter,
         char *line = malloc(line_len + 1);
         if (!line) {
             free(content);
+            if (unquoted_delimiter) {
+                free(unquoted_delimiter);
+            }
             return NULL;
         }
         strncpy(line, &tokenizer->input[line_start], line_len);
@@ -2777,22 +2784,19 @@ static char *collect_heredoc_content(parser_t *parser, const char *delimiter,
 
         // Check if this line matches the delimiter
         if (strcmp(line_content, match_delimiter) == 0) {
-            // Found delimiter - stop collecting. Advance line_start to
-            // the newline terminating the delimiter line (NOT past it)
-            // so tokenizer->position (set below) emits a NEWLINE token
-            // first. The NEWLINE terminates the simple command holding
-            // the heredoc; only after that does the parser re-enable
-            // keyword recognition for the next statement. Skipping the
-            // newline (line_end + 1) merges the heredoc command with
-            // the following statement, making `fi` etc. parse as a
-            // word instead of a keyword (test_parser_fuzzer
-            // heredoc_in_if). Leaving line_start at the delimiter line
-            // (no advance) re-tokenizes "EOF" as a stray identifier
-            // (real_world/posix/105 -> "EOF: command not found").
-            // Landing exactly on line_end is the correct middle ground.
+            /* Found the terminator. body_end is the byte just past the
+             * terminator line's newline -- the resume point for the
+             * tokenizer (or the start of the next heredoc's body, when
+             * several heredocs share a line). When the terminator line
+             * is the final line with no trailing newline, line_end is
+             * already input_length. Deferral collects the body during
+             * separator-skipping, so landing past the newline is
+             * correct: the parser is between statements and re-enters
+             * keyword-aware tokenization for whatever follows. */
             found_delimiter_line = true;
             free(line);
-            line_start = line_end;
+            *body_end = (line_end < tokenizer->input_length) ? line_end + 1
+                                                             : line_end;
             break;
         }
 
@@ -2805,6 +2809,9 @@ static char *collect_heredoc_content(parser_t *parser, const char *delimiter,
             if (!new_content) {
                 free(line);
                 free(content);
+                if (unquoted_delimiter) {
+                    free(unquoted_delimiter);
+                }
                 return NULL;
             }
             content = new_content;
@@ -2848,24 +2855,10 @@ static char *collect_heredoc_content(parser_t *parser, const char *delimiter,
         if (unquoted_delimiter) {
             free(unquoted_delimiter);
         }
+        /* All input consumed scanning for the missing terminator. */
+        *body_end = tokenizer->input_length;
         return NULL;
     }
-
-    // Update tokenizer position to after the delimiter line
-    tokenizer->position = line_start;
-
-    // Update line and column tracking
-    for (size_t i = content_start; i < tokenizer->position; i++) {
-        if (tokenizer->input[i] == '\n') {
-            tokenizer->line++;
-            tokenizer->column = 1;
-        } else {
-            tokenizer->column++;
-        }
-    }
-
-    // Refresh tokenizer cache from the updated position
-    tokenizer_refresh_from_position(tokenizer);
 
     // Clean up temporary delimiter
     if (unquoted_delimiter) {
@@ -2873,6 +2866,111 @@ static char *collect_heredoc_content(parser_t *parser, const char *delimiter,
     }
 
     return content;
+}
+
+/**
+ * @brief Collect every here-document body pending on the current line
+ *
+ * Called when the parser reaches the newline that terminates a command
+ * line on which one or more `<<delim` operators appeared. The bodies
+ * follow that newline in declaration order; this drains the parser's
+ * pending_heredocs queue, scans each body, attaches the collected
+ * content (and an expand-flag sibling) to the corresponding
+ * NODE_REDIR_HEREDOC node, then repositions the tokenizer past the
+ * final terminator so normal parsing resumes after the last heredoc.
+ *
+ * Must be invoked with the current token being the line-terminating
+ * NEWLINE (or EOF). The tokenizer's token cache is rebuilt from the
+ * post-heredoc position before returning.
+ *
+ * @param parser Parser instance
+ * @return true on success, false if any heredoc was unterminated
+ */
+static bool collect_pending_heredocs(parser_t *parser) {
+    if (!parser || parser->pending_heredoc_count == 0) {
+        return true;
+    }
+
+    tokenizer_t *tk = parser->tokenizer;
+    token_t *cur = tokenizer_current(tk);
+
+    /* The first body begins immediately after the line-terminating
+     * newline. If the line was not newline-terminated (heredoc op on
+     * the final line, no trailing '\n'), there is no body -- scanning
+     * from end-of-input makes collect_one_heredoc_body report the
+     * unterminated-heredoc error. */
+    size_t scan;
+    size_t base_offset;
+    size_t base_line;
+    if (cur && cur->type == TOK_NEWLINE) {
+        scan = cur->position + 1; /* past the '\n' */
+        base_line = cur->line + 1;
+    } else if (cur) {
+        scan = cur->position;
+        base_line = cur->line;
+    } else {
+        scan = tk->position;
+        base_line = tk->line;
+    }
+    base_offset = scan;
+
+    bool ok = true;
+    for (size_t i = 0; i < parser->pending_heredoc_count; i++) {
+        pending_heredoc_t *ph = &parser->pending_heredocs[i];
+        size_t body_end = scan;
+        char *content =
+            collect_one_heredoc_body(parser, ph->delimiter, ph->strip_tabs,
+                                     scan, ph->op_loc, &body_end);
+        scan = body_end;
+        if (!content) {
+            ok = false;
+            break;
+        }
+
+        /* Body content child, then the expand-variables flag child --
+         * the layout the executor's heredoc handling expects. */
+        node_t *content_node = new_node(NODE_VAR);
+        if (!content_node) {
+            free(content);
+            ok = false;
+            break;
+        }
+        content_node->val.str = content;
+        content_node->val_type = VAL_STR;
+        add_child_node(ph->redir_node, content_node);
+
+        node_t *expand_flag_node = new_node(NODE_VAR);
+        if (!expand_flag_node) {
+            ok = false;
+            break;
+        }
+        expand_flag_node->val.str =
+            strdup(ph->expand_variables ? "1" : "0");
+        expand_flag_node->val_type = VAL_STR;
+        add_child_node(ph->redir_node, expand_flag_node);
+    }
+
+    parser->pending_heredoc_count = 0;
+
+    /* Reposition the tokenizer past the last terminator and rebuild
+     * its line/column counters by counting newlines across the span
+     * just consumed as heredoc bodies. */
+    tk->position = scan;
+    size_t line = base_line;
+    size_t column = 1;
+    for (size_t p = base_offset; p < scan && p < tk->input_length; p++) {
+        if (tk->input[p] == '\n') {
+            line++;
+            column = 1;
+        } else {
+            column++;
+        }
+    }
+    tk->line = line;
+    tk->column = column;
+    tokenizer_refresh_from_position(tk);
+
+    return ok;
 }
 
 /**

--- a/src/parser.c
+++ b/src/parser.c
@@ -2777,17 +2777,22 @@ static char *collect_heredoc_content(parser_t *parser, const char *delimiter,
 
         // Check if this line matches the delimiter
         if (strcmp(line_content, match_delimiter) == 0) {
-            // Found delimiter - stop collecting. Advance line_start past
-            // the delimiter line so tokenizer->position (set from
-            // line_start below) lands at the byte AFTER the delimiter
-            // newline. Without this advance, the tokenizer re-scans the
-            // delimiter line as if it were script text and emits an
-            // "EOF: command not found" style error (real_world/posix/105).
+            // Found delimiter - stop collecting. Advance line_start to
+            // the newline terminating the delimiter line (NOT past it)
+            // so tokenizer->position (set below) emits a NEWLINE token
+            // first. The NEWLINE terminates the simple command holding
+            // the heredoc; only after that does the parser re-enable
+            // keyword recognition for the next statement. Skipping the
+            // newline (line_end + 1) merges the heredoc command with
+            // the following statement, making `fi` etc. parse as a
+            // word instead of a keyword (test_parser_fuzzer
+            // heredoc_in_if). Leaving line_start at the delimiter line
+            // (no advance) re-tokenizes "EOF" as a stray identifier
+            // (real_world/posix/105 -> "EOF: command not found").
+            // Landing exactly on line_end is the correct middle ground.
             found_delimiter_line = true;
             free(line);
-            line_start = (line_end < tokenizer->input_length)
-                             ? line_end + 1
-                             : line_end;
+            line_start = line_end;
             break;
         }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -2777,9 +2777,17 @@ static char *collect_heredoc_content(parser_t *parser, const char *delimiter,
 
         // Check if this line matches the delimiter
         if (strcmp(line_content, match_delimiter) == 0) {
-            // Found delimiter - stop collecting
+            // Found delimiter - stop collecting. Advance line_start past
+            // the delimiter line so tokenizer->position (set from
+            // line_start below) lands at the byte AFTER the delimiter
+            // newline. Without this advance, the tokenizer re-scans the
+            // delimiter line as if it were script text and emits an
+            // "EOF: command not found" style error (real_world/posix/105).
             found_delimiter_line = true;
             free(line);
+            line_start = (line_end < tokenizer->input_length)
+                             ? line_end + 1
+                             : line_end;
             break;
         }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -2562,7 +2562,13 @@ static node_t *parse_redirection(parser_t *parser) {
             return NULL;
         }
 
-        // Store delimiter in the redirection node value
+        // Store delimiter in the redirection node value. The
+        // operator text (`<<` / `<<-`) was strdup'd into val.str
+        // earlier as a default; for heredocs val.str holds the
+        // delimiter instead, so free the operator string before
+        // overwriting (caught by LeakSanitizer running fuzz_parser
+        // on a heredoc input -- 3 bytes leaked per parse).
+        free(redir_node->val.str);
         redir_node->val.str = delimiter; // Transfer ownership
         redir_node->val_type = VAL_STR;
 

--- a/src/signals.c
+++ b/src/signals.c
@@ -416,6 +416,25 @@ int get_signal_number(const char *signame) {
  *
  * Clears each bit after executing the trap.
  */
+/* Execute a trap command in the CURRENT shell, not a /bin/sh subshell.
+ * Routing through the global executor preserves the user-defined
+ * functions, variables, aliases, and shell options that the trap body
+ * almost always references (real_world/posix/106 cleanup function was
+ * invisible to `system()`-spawned /bin/sh -> "cleanup: command not
+ * found"). Falls back to system() only if the executor is unavailable
+ * (very early startup or after teardown). */
+static void run_trap_command(const char *command) {
+    if (!command || !*command) {
+        return;
+    }
+    executor_t *exec = get_global_executor();
+    if (exec) {
+        (void)executor_execute_command_line(exec, command, 1);
+    } else {
+        (void)!system(command);
+    }
+}
+
 void execute_pending_traps(void) {
     sig_atomic_t pending = pending_trap_signals;
     if (pending == 0) {
@@ -433,7 +452,7 @@ void execute_pending_traps(void) {
                 /* Trap commands are fire-and-forget; their exit status
                  * is propagated by the surrounding shell context, not by
                  * this trap dispatch. */
-                (void)!system(trap->command);
+                run_trap_command(trap->command);
             }
         }
     }
@@ -448,10 +467,10 @@ void execute_pending_traps(void) {
 void execute_exit_traps(void) {
     trap_entry_t *trap = find_trap(0); // EXIT is signal 0
     if (trap && trap->command) {
-        // Execute the EXIT trap command
-        // For now, we'll use system() - this could be improved to use the
-        // shell's executor.  Exit-trap status is not propagated.
-        (void)!system(trap->command);
+        /* Run in the current shell via the global executor so user
+         * functions, variables, and options are in scope. Exit-trap
+         * status is not propagated. */
+        run_trap_command(trap->command);
     }
 
     // Reset terminal to clean state on exit

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -2368,6 +2368,51 @@ static token_t *tokenize_next_inner(tokenizer_t *tokenizer) {
                             continue;
                         }
                     }
+                    /* Check for a trailing zsh glob qualifier:
+                     * `*.txt(N)`, `foo(.@)`, etc. A '(' that follows a
+                     * word character and encloses ONLY glob-qualifier
+                     * characters, with the matching ')' ending the
+                     * word, is part of the glob word -- not a subshell.
+                     * (`*(.N)` is already absorbed by the extglob
+                     * branch above via prev=='*'; this handles the
+                     * prefixed-pattern form the extglob branch misses.)
+                     */
+                    else if (shell_mode_allows(FEATURE_GLOB_QUALIFIERS)) {
+                        size_t scan_pos = tokenizer->position + 1;
+                        bool only_qual = true;
+                        bool found_close = false;
+                        while (scan_pos < tokenizer->input_length) {
+                            char sc = tokenizer->input[scan_pos];
+                            if (sc == ')') {
+                                found_close = true;
+                                break;
+                            }
+                            if (!strchr("./@*rwND,", sc)) {
+                                only_qual = false;
+                                break;
+                            }
+                            scan_pos++;
+                        }
+                        if (found_close && only_qual &&
+                            scan_pos > tokenizer->position + 1) {
+                            /* The qualifier must end the word: after
+                             * ')' expect whitespace, EOF, or a token
+                             * boundary (incl. the ')' of an enclosing
+                             * array literal). */
+                            size_t after = scan_pos + 1;
+                            char ac = (after < tokenizer->input_length)
+                                          ? tokenizer->input[after]
+                                          : '\0';
+                            if (ac == '\0' || isspace((unsigned char)ac) ||
+                                strchr(")|&;<>", ac)) {
+                                is_numeric = false;
+                                size_t old_pos = tokenizer->position;
+                                tokenizer->position = after;
+                                tokenizer->column += (after - old_pos);
+                                continue;
+                            }
+                        }
+                    }
                     // Not an extglob pattern or array literal - end the word
                     // here
                     break;

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -787,7 +787,12 @@ static token_t *tokenize_next_inner(tokenizer_t *tokenizer) {
                     tokenizer->position++;
                 }
             }
-            // Unterminated single-quoted string
+            // Unterminated single-quoted string -- free the segment
+            // builder buffer before returning, otherwise every input
+            // with an unbalanced quote leaks 256+ bytes (caught via
+            // LeakSanitizer running fuzz_parser; see corresponding
+            // fix at the unterminated-double-quote site below).
+            free(result);
             return token_new(TOK_ERROR, &tokenizer->input[start_pos],
                              tokenizer->position - start_pos, start_line,
                              start_column, start_pos);
@@ -1004,7 +1009,10 @@ static token_t *tokenize_next_inner(tokenizer_t *tokenizer) {
             }
         }
 
-        // Unterminated double-quoted string
+        // Unterminated double-quoted string -- free the segment
+        // builder buffer before returning, otherwise every input
+        // with an unbalanced double quote leaks 256+ bytes.
+        free(result);
         return token_new(TOK_ERROR, &tokenizer->input[start_pos],
                          tokenizer->position - start_pos, start_line,
                          start_column, start_pos);

--- a/tests/real_world/README.md
+++ b/tests/real_world/README.md
@@ -1,0 +1,68 @@
+# Real-world script corpus
+
+Scripts representative of patterns lush will encounter in actual use, run
+through `diff_oracle` against the matching reference shell. Failures
+here are 1.5.0 release-readiness signals: each one is something a real
+user's script can't run.
+
+## Layout
+
+```
+tests/real_world/
+├── posix/   POSIX-portable patterns (oracle: dash)
+├── bash/    Bash-leaning idioms     (oracle: bash)
+├── zsh/     Zsh-leaning idioms      (oracle: zsh)
+└── lush/    Polyglot intermix       (no oracle; verifies lush parses+runs)
+```
+
+Naming: `NNN_short_description.sh`, three-digit prefix grouped 100-199
+for posix, 200-299 bash, 300-399 zsh, 400-499 lush.
+
+## Running
+
+The same `diff_oracle` binary that drives the small grammar-seed corpus
+in `tests/fuzz/differential/corpus/` reads this corpus too -- subdirs
+under any root are mode-tagged by parent dir name.
+
+```sh
+meson compile -C build diff_oracle
+find tests/real_world -name '*.sh' | xargs ./build/diff_oracle
+```
+
+## Selection criteria
+
+Scripts in this corpus must be:
+
+- **Self-contained** -- no network, no `sudo`, no shared system files.
+  Side effects only in `$TMPDIR` if any. `/tmp/<name>.pid` style is fine;
+  `/var/run/...` is not.
+- **Deterministic** -- no timing, `$RANDOM`, `$$`, or date-dependent
+  output (or stripped from the diff oracle's compare).
+- **Hermetic** -- no `command -v X` checks that depend on the runner's
+  PATH (stub them with a fixed result), no `git` against a real repo,
+  etc.
+- **Representative** -- mirror an idiom that appears in real-world
+  scripts from reputable sources (autoconf, init.d, common bash libs,
+  oh-my-zsh, etc.). Don't include adversarial or pathological inputs --
+  those go in `tests/fuzz/`.
+
+## What "passes" means
+
+`diff_oracle` produces JSON per script. A pass:
+- `agree: true` -- stdout, stderr, and exit code match the oracle
+- OR `agree: false, allowed: true` -- a deliberate known-divergence
+  (curated in `tests/fuzz/differential/known_divergences.txt`)
+
+Anything else is a 1.5.0 punch-list item.
+
+## Adding scripts
+
+For each addition, verify:
+
+1. The script runs cleanly under its oracle (`dash script.sh` for posix,
+   `bash script.sh` for bash, `zsh script.sh` for zsh).
+2. The script's output is fully reproducible -- no `$RANDOM`, no
+   timestamps that change between runs.
+3. The script doesn't touch anything outside `$TMPDIR` / `/tmp`.
+
+Then run `diff_oracle` on the new file alone to see whether lush matches.

--- a/tests/real_world/bash/200_associative_array_config.sh
+++ b/tests/real_world/bash/200_associative_array_config.sh
@@ -1,0 +1,39 @@
+# Bash associative-array as a config map. Pattern from many bash CLIs
+# (kubectl helpers, dev scripts, etc.): declare -A, populate, iterate.
+
+declare -A config
+config[host]="localhost"
+config[port]="8080"
+config[user]="admin"
+config[timeout]="30"
+
+# Iterate by key
+echo "=== keys ==="
+for key in "${!config[@]}"; do
+    echo "  $key"
+done | sort
+
+# Iterate by key+value
+echo "=== entries ==="
+for key in "${!config[@]}"; do
+    echo "  $key=${config[$key]}"
+done | sort
+
+# Direct access
+echo "host: ${config[host]}"
+echo "port: ${config[port]}"
+
+# Count
+echo "entry count: ${#config[@]}"
+
+# Conditional default via parameter expansion on assoc lookup
+debug_level="${config[debug]:-info}"
+echo "debug: $debug_level"
+
+# Update
+config[timeout]="60"
+echo "updated timeout: ${config[timeout]}"
+
+# Delete
+unset 'config[user]'
+echo "after-unset count: ${#config[@]}"

--- a/tests/real_world/bash/201_function_library.sh
+++ b/tests/real_world/bash/201_function_library.sh
@@ -1,0 +1,72 @@
+# Bash library-of-functions pattern: many real CLI tools structure their
+# logic as 30-100 small functions in a single script, dispatched by a
+# main case. This exercises function defs, local vars, return codes,
+# and argument passing.
+
+log_info() {
+    echo "[INFO] $*"
+}
+
+log_warn() {
+    echo "[WARN] $*" >&2
+}
+
+log_error() {
+    echo "[ERROR] $*" >&2
+    return 1
+}
+
+trim() {
+    local s="$1"
+    # Strip leading whitespace
+    s="${s#"${s%%[![:space:]]*}"}"
+    # Strip trailing whitespace
+    s="${s%"${s##*[![:space:]]}"}"
+    echo "$s"
+}
+
+join_by() {
+    local separator="$1"
+    shift
+    local first="$1"
+    shift
+    printf '%s' "$first"
+    for item in "$@"; do
+        printf '%s%s' "$separator" "$item"
+    done
+    printf '\n'
+}
+
+is_in() {
+    local needle="$1"
+    shift
+    local item
+    for item in "$@"; do
+        [[ "$item" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+# Use them
+log_info "starting"
+log_warn "this is a warning"
+
+trimmed=$(trim "   padded   text   ")
+echo "trimmed: [$trimmed]"
+
+joined=$(join_by ", " alpha beta gamma delta)
+echo "joined: $joined"
+
+if is_in "beta" alpha beta gamma; then
+    echo "found beta"
+else
+    echo "no beta"
+fi
+
+if is_in "epsilon" alpha beta gamma; then
+    echo "found epsilon"
+else
+    echo "no epsilon"
+fi
+
+log_info "done"

--- a/tests/real_world/bash/202_argparse_getopts.sh
+++ b/tests/real_world/bash/202_argparse_getopts.sh
@@ -1,0 +1,44 @@
+# Bash CLI argparse via getopts -- the standard pattern for any script
+# that takes -f, -v, --foo, etc. Tests positional args, optargs, and
+# missing-argument handling.
+
+verbose=0
+config_file=""
+target=""
+
+usage() {
+    cat <<EOF
+Usage: $0 [-v] [-f config] [-t target] [args...]
+  -v          verbose mode
+  -f FILE     config file path
+  -t TARGET   build target
+EOF
+}
+
+# Use set -- to install simulated argv so the script is hermetic
+set -- -v -f /etc/example.conf -t release left over args
+
+while getopts ":vf:t:h" opt; do
+    case "$opt" in
+        v) verbose=1 ;;
+        f) config_file="$OPTARG" ;;
+        t) target="$OPTARG" ;;
+        h) usage; exit 0 ;;
+        :) echo "missing arg for -$OPTARG" >&2; exit 2 ;;
+        \?) echo "unknown option -$OPTARG" >&2; exit 2 ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+echo "verbose=$verbose"
+echo "config=$config_file"
+echo "target=$target"
+echo "remaining: $*"
+echo "remaining count: $#"
+
+# Iterate positionals
+i=1
+for arg in "$@"; do
+    echo "  arg $i: $arg"
+    i=$((i + 1))
+done

--- a/tests/real_world/bash/203_bash_string_manipulation.sh
+++ b/tests/real_world/bash/203_bash_string_manipulation.sh
@@ -1,0 +1,35 @@
+# Bash string manipulation: case mods, replacement, substring. Used
+# everywhere from prompt builders to log processors.
+
+text="Hello, World!"
+
+# Case modification
+echo "upper:    ${text^^}"
+echo "lower:    ${text,,}"
+echo "first-up: ${text^}"
+echo "first-lo: ${text,}"
+
+# Substring extraction
+echo "first-5:  ${text:0:5}"
+echo "from-7:   ${text:7}"
+echo "last-6:   ${text: -6}"
+
+# Replacement
+echo "replace-first: ${text/o/0}"
+echo "replace-all:   ${text//o/0}"
+echo "replace-front: ${text/#Hello/Hi}"
+echo "replace-back:  ${text/%!/?}"
+
+# Length
+echo "length:   ${#text}"
+
+# Building a path
+basedir="/var/log"
+project="my-app"
+suffix="latest.log"
+logfile="${basedir}/${project}/${suffix}"
+echo "path: $logfile"
+
+# Variable indirection
+ref="text"
+echo "indirect: ${!ref}"

--- a/tests/real_world/bash/204_bash_arrays_full.sh
+++ b/tests/real_world/bash/204_bash_arrays_full.sh
@@ -1,0 +1,37 @@
+# Bash indexed array idioms beyond the basics: slicing, appending,
+# array as function argument, sparse indices.
+
+# Basic
+arr=(alpha beta gamma delta epsilon)
+echo "count: ${#arr[@]}"
+echo "all:   ${arr[*]}"
+echo "first: ${arr[0]}"
+echo "last:  ${arr[-1]}"
+
+# Slicing
+echo "slice 1-3: ${arr[@]:1:3}"
+echo "from 2:    ${arr[@]:2}"
+
+# Append
+arr+=(zeta eta)
+echo "after-append: ${arr[*]}"
+
+# Sparse indices
+sparse=([10]=ten [20]=twenty [30]=thirty)
+echo "sparse count: ${#sparse[@]}"
+echo "sparse keys: ${!sparse[@]}"
+echo "sparse[20]: ${sparse[20]}"
+
+# Iterate by index
+for i in "${!arr[@]}"; do
+    echo "  [$i] = ${arr[$i]}"
+done
+
+# Array as function argument (by reference via nameref or by value)
+print_each() {
+    local item
+    for item in "$@"; do
+        echo "  - $item"
+    done
+}
+print_each "${arr[@]}"

--- a/tests/real_world/bash/205_bash_conditional_expr.sh
+++ b/tests/real_world/bash/205_bash_conditional_expr.sh
@@ -1,0 +1,41 @@
+# Bash [[ ]] conditional expression -- string/regex/file/numeric tests
+# in one syntax. Replaces the POSIX `[ ]` for bash scripts.
+
+s="hello world"
+
+# String tests
+[[ "$s" == "hello world" ]] && echo "eq-string ok"
+[[ "$s" != "goodbye" ]] && echo "ne-string ok"
+
+# Pattern match (no quotes around RHS for pattern)
+[[ "$s" == hello* ]] && echo "prefix-match ok"
+[[ "$s" == *world ]] && echo "suffix-match ok"
+[[ "$s" == *o*o* ]] && echo "multi-match ok"
+
+# Regex
+if [[ "$s" =~ ^([a-z]+)\ ([a-z]+)$ ]]; then
+    echo "regex matched"
+    echo "  group 1: ${BASH_REMATCH[1]}"
+    echo "  group 2: ${BASH_REMATCH[2]}"
+fi
+
+# Numeric
+n=42
+[[ $n -eq 42 ]] && echo "num-eq ok"
+[[ $n -gt 10 ]] && echo "num-gt ok"
+(( n == 42 )) && echo "(( )) num-eq ok"
+(( n > 10 && n < 100 )) && echo "(( )) range ok"
+
+# Logical combos
+a=1; b=2; c=3
+[[ $a -lt $b && $b -lt $c ]] && echo "chained AND ok"
+[[ $a -gt $b || $b -lt $c ]] && echo "chained OR ok"
+
+# File tests
+[[ -d /tmp ]] && echo "/tmp dir ok"
+[[ -e /etc/hosts ]] && echo "/etc/hosts exists"
+[[ -r /etc/hosts ]] && echo "/etc/hosts readable"
+
+# Empty/non-empty
+[[ -z "" ]] && echo "empty ok"
+[[ -n "$s" ]] && echo "non-empty ok"

--- a/tests/real_world/bash/206_bash_brace_expansion.sh
+++ b/tests/real_world/bash/206_bash_brace_expansion.sh
@@ -1,0 +1,31 @@
+# Bash brace expansion: list and range forms, nesting, prefix/suffix.
+
+# List form
+echo {a,b,c,d}
+echo prefix-{1,2,3}.txt
+echo {one,two,three}-{1,2,3}
+
+# Range form
+echo {1..5}
+echo {a..e}
+echo {01..10}
+echo {0..20..5}
+
+# Negative ranges
+echo {5..1}
+echo {-3..3}
+
+# Nested
+echo {{1..3},{a..c}}
+echo file{1..3}.{log,txt}
+
+# Inside command
+for i in {1..5}; do
+    echo "iter $i"
+done
+
+# Path constructs
+mkdir_paths=(/tmp/test/{src,build,docs}/sub)
+for p in "${mkdir_paths[@]}"; do
+    echo "  $p"
+done

--- a/tests/real_world/lush/400_polyglot_user_script.sh
+++ b/tests/real_world/lush/400_polyglot_user_script.sh
@@ -1,0 +1,47 @@
+# Lush polyglot script: a user who knows both bash and zsh syntax idioms
+# mixes them freely because lush understands both. No mode switching --
+# just write whatever feels natural for the task at hand.
+
+# Bash-style associative array for config
+declare -A settings
+settings[shell]="lush"
+settings[version]="1.5.0"
+settings[mode]="polyglot"
+
+# Bash-style ${var^^} uppercase
+shell_name="${settings[shell]}"
+echo "shell: ${shell_name^^}"
+
+# Zsh-style (U) flag does the same -- both should work
+echo "shell-zsh: ${(U)shell_name}"
+
+# Bash array indexed
+versions=(0.9 1.0 1.1 1.5.0)
+echo "bash-last: ${versions[-1]}"   # bash 4.3+: negative index
+echo "zsh-last: ${versions[-1]}"     # zsh: same syntax, native support
+
+# Bash brace expansion
+files=(/tmp/test.{log,err,out})
+for f in "${files[@]}"; do
+    echo "expanded: $f"
+done
+
+# Zsh ${arr[1,3]} slicing -- only zsh has this, but we use it freely
+# Sub-array via slicing
+slice=(${versions[1,3]})
+echo "slice count: ${#slice[@]}"
+
+# Bash-style printf %q quoting
+text="hello world; rm -rf /"
+echo "bash-quoted: $(printf %q "$text")"
+
+# Zsh ${(q)var} same idea
+echo "zsh-quoted: ${(q)text}"
+
+# Function definition: POSIX form
+greet() {
+    local name="${1:-anonymous}"
+    echo "Hello, $name"
+}
+greet
+greet "Alice"

--- a/tests/real_world/lush/401_polyglot_history_lookup.sh
+++ b/tests/real_world/lush/401_polyglot_history_lookup.sh
@@ -1,0 +1,28 @@
+# Lush polyglot script: a user mixes bash assoc arrays with zsh param
+# flags to build a small lookup tool.
+
+# Bash-style declare for assoc array
+declare -A users
+users[alice]="alice@example.com"
+users[bob]="bob@example.com"
+users[carol]="carol@example.com"
+
+# Bash array of names
+names=(alice bob carol dave)
+
+# Iterate names; for each, look up email and pretty-print using zsh
+# parameter flags
+for name in "${names[@]}"; do
+    email="${users[$name]:-<unknown>}"
+    # zsh (C) flag for capitalization (lush should accept either form)
+    pretty="${(C)name}"
+    echo "$pretty: $email"
+done
+
+# Bash count assertion
+echo "total users registered: ${#users[@]}"
+echo "total names checked: ${#names[@]}"
+
+# Zsh sort using (o) flag, then bash iterate
+sorted=("${(o)names}")
+echo "sorted (zsh-flag): ${sorted[*]}"

--- a/tests/real_world/posix/100_autoconf_feature_detection.sh
+++ b/tests/real_world/posix/100_autoconf_feature_detection.sh
@@ -1,0 +1,37 @@
+# Pattern lifted from autoconf-generated `configure` scripts: detect a
+# command, fall through alternatives, build up a result variable. This
+# shape appears in tens of thousands of OSS configure scripts.
+
+# Simulate "find a usable awk"
+awk_candidates="gawk mawk nawk awk"
+found_awk=""
+for cand in $awk_candidates; do
+    # Stub the check: just pretend we're looking for the command in PATH
+    # without actually calling command -v (so the script is hermetic).
+    case "$cand" in
+        nawk) found_awk="$cand"; break ;;  # pretend nawk is the first hit
+    esac
+done
+
+if [ -z "$found_awk" ]; then
+    echo "no awk found" >&2
+    exit 1
+fi
+
+echo "selected: $found_awk"
+
+# Version probe pattern: parse a "vX.Y.Z" string into components
+version="v1.23.456"
+major=$(echo "$version" | sed -n 's/^v\([0-9]\{1,\}\)\..*/\1/p')
+minor=$(echo "$version" | sed -n 's/^v[0-9]\{1,\}\.\([0-9]\{1,\}\)\..*/\1/p')
+patch=$(echo "$version" | sed -n 's/^v[0-9]\{1,\}\.[0-9]\{1,\}\.\([0-9]\{1,\}\).*/\1/p')
+
+echo "major=$major minor=$minor patch=$patch"
+
+# Conditional based on version: "if major >= 1, enable feature"
+if [ "$major" -ge 1 ] 2>/dev/null; then
+    feature="enabled"
+else
+    feature="disabled"
+fi
+echo "feature: $feature"

--- a/tests/real_world/posix/101_init_script_shape.sh
+++ b/tests/real_world/posix/101_init_script_shape.sh
@@ -1,0 +1,61 @@
+# Pattern from /etc/init.d/* scripts and systemd shell wrappers: usage
+# function, action dispatch via case, helper functions, exit codes.
+
+NAME="example-service"
+PIDFILE="/tmp/${NAME}.pid"
+
+usage() {
+    cat <<EOF
+Usage: $0 {start|stop|restart|status|reload}
+Manage the $NAME service.
+EOF
+}
+
+is_running() {
+    [ -f "$PIDFILE" ] && return 0
+    return 1
+}
+
+do_start() {
+    if is_running; then
+        echo "$NAME is already running"
+        return 0
+    fi
+    # Simulate writing a pidfile
+    echo "12345" > "$PIDFILE"
+    echo "$NAME started"
+    return 0
+}
+
+do_stop() {
+    if ! is_running; then
+        echo "$NAME is not running"
+        return 0
+    fi
+    rm -f "$PIDFILE"
+    echo "$NAME stopped"
+    return 0
+}
+
+do_status() {
+    if is_running; then
+        echo "$NAME is running (pid $(cat "$PIDFILE"))"
+        return 0
+    else
+        echo "$NAME is stopped"
+        return 3
+    fi
+}
+
+case "${1:-status}" in
+    start)   do_start ;;
+    stop)    do_stop ;;
+    restart) do_stop; do_start ;;
+    status)  do_status; exit $? ;;
+    reload)  echo "$NAME reloaded" ;;
+    *)       usage; exit 2 ;;
+esac
+
+# Clean up before exit
+rm -f "$PIDFILE"
+exit 0

--- a/tests/real_world/posix/102_parameter_expansion_idioms.sh
+++ b/tests/real_world/posix/102_parameter_expansion_idioms.sh
@@ -1,0 +1,53 @@
+# POSIX parameter expansion patterns: ${var:-default}, ${var:=...},
+# ${var:?...}, ${var:+...}, ${var#prefix}, ${var##prefix}, ${var%suffix},
+# ${var%%suffix}. These appear in basically every nontrivial POSIX shell
+# script -- if any are broken, lots of real scripts break.
+
+# Defaults
+unset GREETING
+greeting="${GREETING:-hello}"
+echo "default: $greeting"
+
+# Assign-default
+unset CONFIG
+: "${CONFIG:=/etc/example.conf}"
+echo "assigned: $CONFIG"
+
+# Conditional substitution
+NAME="world"
+salutation="${NAME:+Hello, $NAME!}"
+echo "conditional: $salutation"
+
+# Empty case
+unset MAYBE
+absent="${MAYBE:+seen}"
+echo "absent: [$absent]"
+
+# Prefix strip (shortest)
+path="/usr/local/bin/lush"
+tail="${path#*/}"
+echo "shortest-prefix: $tail"
+
+# Prefix strip (longest)
+basename="${path##*/}"
+echo "longest-prefix: $basename"
+
+# Suffix strip (shortest)
+file="archive.tar.gz"
+without_ext="${file%.*}"
+echo "shortest-suffix: $without_ext"
+
+# Suffix strip (longest)
+without_all_ext="${file%%.*}"
+echo "longest-suffix: $without_all_ext"
+
+# String length
+text="lush shell"
+echo "length: ${#text}"
+
+# Combined: extract directory, then basename, then strip extension
+fullpath="/var/log/messages.1.gz"
+dir="${fullpath%/*}"
+base="${fullpath##*/}"
+stem="${base%%.*}"
+echo "dir=$dir base=$base stem=$stem"

--- a/tests/real_world/posix/103_command_sub_arith_pipelines.sh
+++ b/tests/real_world/posix/103_command_sub_arith_pipelines.sh
@@ -1,0 +1,43 @@
+# Command substitution + arithmetic + pipelines in idiomatic combinations.
+# Classic patterns: counting lines, building a sum from a stream, capturing
+# multi-line output.
+
+# Counting via wc -l + capturing
+items="one
+two
+three
+four
+five"
+count=$(printf '%s\n' "$items" | wc -l | tr -d ' ')
+echo "count: $count"
+
+# Sum a column of numbers using arithmetic + pipeline
+numbers="10 20 30 40 50"
+total=0
+for n in $numbers; do
+    total=$((total + n))
+done
+echo "total: $total"
+
+# Backtick form (legacy but still in many scripts)
+backtick_result=`echo hello`
+echo "backtick: $backtick_result"
+
+# Nested command substitution
+inner_then_outer=$(echo $(echo "deep"))
+echo "nested: $inner_then_outer"
+
+# Pipelines feeding command substitution
+words=$(printf 'apple\nbanana\ncherry\n' | sort | head -2 | tr '\n' ' ')
+echo "pipeline: $words"
+
+# Arithmetic with conditional
+n=15
+parity=$(( n % 2 == 0 ? 0 : 1 ))
+[ $parity -eq 0 ] && echo "$n is even" || echo "$n is odd"
+
+# Multi-stage transformation
+csv="alpha,beta,gamma,delta"
+first=$(echo "$csv" | cut -d, -f1)
+last=$(echo "$csv" | awk -F, '{print $NF}')
+echo "first=$first last=$last"

--- a/tests/real_world/posix/104_heredoc_patterns.sh
+++ b/tests/real_world/posix/104_heredoc_patterns.sh
@@ -1,0 +1,33 @@
+# Heredoc idioms: variable expansion in body, quoted delimiter, <<-,
+# heredocs feeding commands. Used in every install script.
+
+name="world"
+cat <<EOF
+hello, $name
+EOF
+
+# Quoted delimiter -> no expansion
+cat <<'EOF'
+literal $name here
+EOF
+
+# <<- strips leading tabs
+	cat <<-EOF
+	indented heredoc
+	$name still expands
+	EOF
+
+# Heredoc feeding a pipeline
+cat <<EOF | tr '[:lower:]' '[:upper:]'
+mixed case input
+EOF
+
+# Heredoc to a variable via command substitution
+result=$(cat <<EOF
+captured
+multi-line
+content
+EOF
+)
+echo "captured-len: ${#result}"
+echo "$result"

--- a/tests/real_world/posix/105_while_read_loop.sh
+++ b/tests/real_world/posix/105_while_read_loop.sh
@@ -1,0 +1,31 @@
+# while-read loop: the canonical pattern for processing line-oriented
+# data. Appears in basically every log-processing script.
+
+input="alpha 100
+beta 200
+gamma 300
+delta 400"
+
+total=0
+count=0
+while IFS=' ' read -r name value; do
+    total=$((total + value))
+    count=$((count + 1))
+    echo "  $name=$value"
+done <<EOF
+$input
+EOF
+
+echo "count: $count"
+echo "total: $total"
+
+# IFS-driven CSV parsing
+csv="alice,30,engineer
+bob,45,manager
+carol,28,designer"
+
+while IFS=',' read -r name age role; do
+    echo "$name is a $age-year-old $role"
+done <<EOF
+$csv
+EOF

--- a/tests/real_world/posix/106_trap_cleanup.sh
+++ b/tests/real_world/posix/106_trap_cleanup.sh
@@ -1,0 +1,23 @@
+# Trap-based cleanup: the standard hermetic-script pattern. EXIT
+# handler ensures tempfiles get removed even on error.
+
+tmpdir=$(mktemp -d -t test_trap.XXXXXX)
+cleanup() {
+    rm -rf "$tmpdir"
+    echo "cleaned up $tmpdir"
+}
+trap cleanup EXIT
+
+# Create some work in the tmpdir
+echo "data1" > "$tmpdir/file1"
+echo "data2" > "$tmpdir/file2"
+
+# Verify state
+ls "$tmpdir" | sort | sed 's/^/  /'
+
+# Read it back
+cat "$tmpdir/file1"
+cat "$tmpdir/file2"
+
+# Script exits here -- trap fires
+echo "before exit"

--- a/tests/real_world/posix/106_trap_cleanup.sh
+++ b/tests/real_world/posix/106_trap_cleanup.sh
@@ -4,7 +4,9 @@
 tmpdir=$(mktemp -d -t test_trap.XXXXXX)
 cleanup() {
     rm -rf "$tmpdir"
-    echo "cleaned up $tmpdir"
+    # Don't echo the tmpdir path - mktemp randomness would defeat
+    # the scorecard's stdout match across lush/bash invocations.
+    echo "cleaned up"
 }
 trap cleanup EXIT
 

--- a/tests/real_world/posix/107_printf_formatting.sh
+++ b/tests/real_world/posix/107_printf_formatting.sh
@@ -1,0 +1,25 @@
+# printf formatting -- string padding, number formatting, hex/oct,
+# repeated format. Common in any script producing structured output.
+
+# Field padding
+printf '%-10s %s\n' "Name" "Value"
+printf '%-10s %s\n' "----" "-----"
+printf '%-10s %d\n' "alpha" 42
+printf '%-10s %d\n' "beta" 100
+printf '%-10s %d\n' "gamma" 7
+
+# Number formats
+printf 'decimal: %d\n' 255
+printf 'hex:     %x\n' 255
+printf 'octal:   %o\n' 255
+printf 'padded:  %05d\n' 42
+
+# Format reuses across arguments
+printf '%s=%s\n' a 1 b 2 c 3
+
+# Floating point
+printf 'pi: %.4f\n' 3.14159265
+printf 'pct: %.1f%%\n' 87.5
+
+# Escape sequences (printf interprets, echo doesn't always)
+printf 'tab\there\nline2\n'

--- a/tests/real_world/posix/108_subshell_vs_braces.sh
+++ b/tests/real_world/posix/108_subshell_vs_braces.sh
@@ -1,0 +1,31 @@
+# Subshell () vs brace group {} -- the critical distinction many
+# scripts depend on for variable scoping.
+
+# Subshell: variables don't leak out
+x=outer
+(
+    x=inner
+    echo "inside subshell: x=$x"
+)
+echo "after subshell: x=$x"   # still outer
+
+# Brace group: variables DO leak out
+y=outer
+{
+    y=inner
+    echo "inside braces: y=$y"
+}
+echo "after braces: y=$y"   # now inner
+
+# Subshell as conditional context
+if (cd /tmp && [ -d . ]); then
+    echo "subshell condition: ok"
+fi
+# Confirm we didn't actually change directory
+echo "still in: $(basename "$PWD" 2>/dev/null || echo unknown)" | head -c 40
+echo
+
+# Brace group return value
+result=$({ echo "first"; echo "second"; })
+echo "brace-output: $result" | tr '\n' '|'
+echo

--- a/tests/real_world/zsh/300_zsh_param_pipeline.sh
+++ b/tests/real_world/zsh/300_zsh_param_pipeline.sh
@@ -1,0 +1,41 @@
+# Zsh parameter-flag pipeline -- the heart of "why zsh users love zsh".
+# Pattern: build up a list, transform via parameter flags, join.
+
+words=(apple banana cherry date elderberry fig)
+
+# Length
+echo "count: ${#words}"
+
+# Upper-case all (zsh: (U))
+echo "upper: ${(U)words}"
+
+# Lower-case (already lower, just test the flag round-trips)
+echo "lower: ${(L)words}"
+
+# Capitalize first letter of each
+echo "caps: ${(C)words}"
+
+# Sort ascending (zsh: (o))
+echo "sorted: ${(o)words}"
+
+# Reverse-sort (zsh: (O))
+echo "reversed: ${(O)words}"
+
+# Sort with i (case-insensitive)
+mixed=(Banana apple Cherry date Elderberry fig)
+echo "case-insensitive: ${(oi)mixed}"
+
+# Unique (u flag)
+dup=(a b a c b a d)
+echo "unique: ${(u)dup}"
+
+# Join with separator
+echo "joined: ${(j:,:)words}"
+
+# Split a string back into an array
+csv="alpha,beta,gamma,delta"
+parts=("${(s:,:)csv}")
+echo "split count: ${#parts}"
+for p in $parts; do
+    echo "  part: $p"
+done

--- a/tests/real_world/zsh/301_zsh_array_idioms.sh
+++ b/tests/real_world/zsh/301_zsh_array_idioms.sh
@@ -1,0 +1,42 @@
+# Zsh 1-indexed arrays + zsh-specific subscript syntax. Pattern from
+# oh-my-zsh plugins and zsh-syntax-highlighting: heavy array manipulation
+# via slicing and negative indices.
+
+fruits=(apple banana cherry date elderberry)
+
+# First / last via 1-indexed access
+echo "first: $fruits[1]"
+echo "last: $fruits[-1]"
+echo "second-to-last: $fruits[-2]"
+
+# Slice
+echo "first two: $fruits[1,2]"
+echo "middle three: $fruits[2,4]"
+echo "last two: $fruits[-2,-1]"
+
+# Length forms
+echo "len with #: ${#fruits}"
+echo "len with @: ${#fruits[@]}"
+
+# Iteration order
+i=1
+for f in $fruits; do
+    echo "  [$i] = $f"
+    i=$((i + 1))
+done
+
+# Append
+fruits+=(fig grape)
+echo "after append: ${(j:,:)fruits}"
+
+# Replace by index
+fruits[3]="CHANGED"
+echo "after replace: ${(j:,:)fruits}"
+
+# Search: index of element (zsh: ${arr[(i)pattern]})
+position=${fruits[(i)CHANGED]}
+echo "position of CHANGED: $position"
+
+# Subscript with pattern match (zsh: ${arr[(r)pattern]})
+found=${fruits[(r)f*]}
+echo "first matching f*: $found"

--- a/tests/real_world/zsh/302_zsh_glob_qualifiers.sh
+++ b/tests/real_world/zsh/302_zsh_glob_qualifiers.sh
@@ -1,0 +1,33 @@
+# Zsh glob qualifiers (*(.)/(.D)/etc.) -- one of zsh's killer features
+# for shell-pipeline file selection. Used heavily in oh-my-zsh.
+
+# Set up a tmp area
+tmpdir=$(mktemp -d -t zsh_glob.XXXXXX)
+trap "rm -rf $tmpdir" EXIT
+
+cd $tmpdir
+touch file1.txt file2.txt file3.log
+mkdir subdir
+touch subdir/inner.txt
+touch .hidden
+
+# Glob qualifier: only regular files
+files=(*(.N))
+echo "regular files: ${#files[@]}"
+for f in $files; do echo "  $f"; done | sort
+
+# Only directories
+dirs=(*(/N))
+echo "directories: ${#dirs[@]}"
+for d in $dirs; do echo "  $d"; done
+
+# Include dotfiles
+all=(*(DN))
+echo "with-dotfiles: ${#all[@]}"
+
+# By extension
+txts=(*.txt(N))
+echo "txt count: ${#txts[@]}"
+
+# Specific glob features (just print pattern, don't necessarily expect matches)
+echo "done"

--- a/tests/real_world/zsh/303_zsh_anonymous_func.sh
+++ b/tests/real_world/zsh/303_zsh_anonymous_func.sh
@@ -1,0 +1,30 @@
+# Zsh anonymous functions: a heavy-use feature in oh-my-zsh plugins
+# for one-shot scoped logic.
+
+# Anonymous func with no args
+() {
+    local x=10
+    local y=20
+    echo "sum: $((x + y))"
+}
+
+# With args
+() {
+    local greeting="$1"
+    local name="$2"
+    echo "$greeting, $name!"
+} "Hello" "Alice"
+
+# Used to scope local variables in a sequence
+result=$(
+    () {
+        local data="(scoped)"
+        echo "$data"
+    }
+)
+echo "captured: $result"
+
+# Multiple anonymous funcs in a script (each totally independent)
+() { echo "first anonymous"; }
+() { echo "second anonymous"; }
+() { echo "third with args: $*"; } one two three

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 /* The pre-existing local ASSERT(cond, msg) used a 2-arg signature
@@ -1674,6 +1675,251 @@ TEST(local_variable_in_function) {
 }
 
 /* ============================================================================
+ * REGRESSION TESTS -- 2026-05 real-world hardening wave (PR #113)
+ *
+ * Behavioural coverage for the defects the real-world script corpus
+ * surfaced. Every test runs a shell snippet in-process and asserts on
+ * observable behaviour; each names the fix it guards.
+ * ============================================================================
+ */
+
+/* Create an empty file -- fixture helper for the glob tests. */
+static void rt_touch(const char *path) {
+    FILE *f = fopen(path, "w");
+    if (f) {
+        fclose(f);
+    }
+}
+
+/* --- Deferred here-document collection -------------------------------- */
+
+TEST(rt_heredoc_through_pipe) {
+    /* The body must reach `tr`; the parser once collected the heredoc
+     * inline and lost the `| tr` that followed `<<EOF` on the line. */
+    run_result_t r = run_shell("cat <<EOF | tr a-z A-Z\nhello world\nEOF\n");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "HELLO WORLD\n");
+}
+
+TEST(rt_heredoc_trailing_command) {
+    run_result_t r = run_shell("cat <<EOF; echo after\nbody\nEOF\n");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "body\nafter\n");
+}
+
+TEST(rt_heredoc_in_if_body) {
+    run_result_t r = run_shell("if true; then\ncat <<EOF\ninside\nEOF\nfi\n");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "inside\n");
+}
+
+TEST(rt_heredoc_loop_redirection) {
+    run_result_t r = run_shell(
+        "while read l; do echo \"got $l\"; done <<EOF\nx\ny\nEOF\n");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "got x\ngot y\n");
+}
+
+TEST(rt_heredoc_strip_tabs) {
+    /* <<- strips leading tabs from body lines and the terminator. */
+    run_result_t r = run_shell("cat <<-EOF\n\t\tindented\n\t\tEOF\n");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "indented\n");
+}
+
+TEST(rt_heredoc_quoted_delimiter) {
+    /* A quoted delimiter disables expansion of the body. */
+    run_result_t r = run_shell("cat <<'EOF'\nliteral $UNSET here\nEOF\n");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "literal $UNSET here\n");
+}
+
+TEST(rt_heredoc_multiline_var_body) {
+    /* Body referencing a multi-line variable -- posix/105 regression. */
+    run_result_t r =
+        run_shell("x=\"line1\nline2\"\ncat <<EOF\n$x\nEOF\necho done\n");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "line1\nline2\ndone\n");
+}
+
+TEST(rt_heredoc_unterminated_error) {
+    run_result_t r = run_shell("cat <<EOF\nno terminator follows\n");
+    ASSERT_TRUE(r.exit_status != 0, "unterminated heredoc must fail");
+}
+
+/* --- Glob expansion in for-loops, arrays, and zsh qualifiers ---------- */
+
+TEST(rt_glob_for_array_qualifiers) {
+    char saved_cwd[4096];
+    ASSERT_NOT_NULL(getcwd(saved_cwd, sizeof saved_cwd), "getcwd");
+
+    char dir[] = "/tmp/lush_glob_test.XXXXXX";
+    ASSERT_NOT_NULL(mkdtemp(dir), "mkdtemp");
+    ASSERT_EQ(chdir(dir), 0, "chdir into temp dir");
+
+    /* Fixture: three regular files, one subdirectory, one dotfile. */
+    rt_touch("alpha.txt");
+    rt_touch("beta.txt");
+    rt_touch("gamma.log");
+    mkdir("subdir", 0700);
+    rt_touch(".hidden");
+
+    /* for-loop word list globs (previously iterated the literal "*"). */
+    run_result_t r =
+        run_shell("n=0; for f in *; do n=$((n+1)); done; echo $n");
+    ASSERT_STDOUT_EQ(r, "4\n");
+
+    /* indexed-array initializer globs. */
+    r = run_shell("arr=(*.txt); echo ${#arr[@]}");
+    ASSERT_STDOUT_EQ(r, "2\n");
+
+    /* zsh (.N) qualifier -- regular files only. */
+    r = run_shell("arr=(*(.N)); echo ${#arr[@]}");
+    ASSERT_STDOUT_EQ(r, "3\n");
+
+    /* zsh (/N) qualifier -- directories only. */
+    r = run_shell("arr=(*(/N)); echo ${#arr[@]}");
+    ASSERT_STDOUT_EQ(r, "1\n");
+
+    /* zsh (DN) qualifier -- include dotfiles. */
+    r = run_shell("arr=(*(DN)); echo ${#arr[@]}");
+    ASSERT_STDOUT_EQ(r, "5\n");
+
+    /* qualifier on a prefixed pattern -- *.txt(N). */
+    r = run_shell("arr=(*.txt(N)); echo ${#arr[@]}");
+    ASSERT_STDOUT_EQ(r, "2\n");
+
+    /* Teardown: remove the fixture while still inside the temp dir. */
+    unlink("alpha.txt");
+    unlink("beta.txt");
+    unlink("gamma.log");
+    unlink(".hidden");
+    rmdir("subdir");
+    ASSERT_EQ(chdir(saved_cwd), 0, "restore cwd");
+    rmdir(dir);
+}
+
+/* --- return / exit propagation out of loops and case arms ------------- */
+
+TEST(rt_return_from_for_loop) {
+    run_result_t r = run_shell(
+        "f() { for x in 1 2 3; do if [ \"$x\" = 2 ]; then return 5; fi; "
+        "done; return 0; }\nf\necho $?\n");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "5\n");
+}
+
+TEST(rt_return_from_while_loop) {
+    run_result_t r =
+        run_shell("f() { while true; do return 3; done; }\nf\necho $?\n");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "3\n");
+}
+
+TEST(rt_case_arm_runs_all) {
+    /* A case arm is a command list -- a non-zero command must not
+     * short-circuit the rest of the arm. */
+    run_result_t r =
+        run_shell("case x in x) echo one; false; echo two ;; esac\n");
+    ASSERT_STDOUT_EQ(r, "one\ntwo\n");
+}
+
+TEST(rt_case_arm_return_status) {
+    /* posix/101 init-script shape: a function returning non-zero in a
+     * case arm, its status captured by a following command. */
+    run_result_t r = run_shell(
+        "do_status() { return 3; }\n"
+        "case status in status) do_status; rc=$?; esac\necho $rc\n");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "3\n");
+}
+
+/* --- printf flag forwarding ------------------------------------------- */
+
+TEST(rt_printf_flags) {
+    run_result_t r = run_shell("printf '%05d\\n' 42");
+    ASSERT_STDOUT_EQ(r, "00042\n");
+    r = run_shell("printf '%+d\\n' 42");
+    ASSERT_STDOUT_EQ(r, "+42\n");
+    r = run_shell("printf '%#x\\n' 255");
+    ASSERT_STDOUT_EQ(r, "0xff\n");
+    r = run_shell("printf '[%-5d]\\n' 42");
+    ASSERT_STDOUT_EQ(r, "[42   ]\n");
+    r = run_shell("printf '% d\\n' 42");
+    ASSERT_STDOUT_EQ(r, " 42\n");
+}
+
+/* --- brace expansion -------------------------------------------------- */
+
+TEST(rt_brace_nested) {
+    run_result_t r = run_shell("echo {{1..3},{a..c}}");
+    ASSERT_STDOUT_EQ(r, "1 2 3 a b c\n");
+}
+
+TEST(rt_brace_cartesian) {
+    run_result_t r = run_shell("echo file{1..2}.{log,txt}");
+    ASSERT_STDOUT_EQ(r, "file1.log file1.txt file2.log file2.txt\n");
+}
+
+TEST(rt_brace_in_array_init) {
+    run_result_t r =
+        run_shell("arr=(x{1,2,3}y); echo ${#arr[@]} ${arr[0]} ${arr[2]}");
+    ASSERT_STDOUT_EQ(r, "3 x1y x3y\n");
+}
+
+/* --- parameter expansion operators on array elements ------------------ */
+
+TEST(rt_array_elem_default_missing) {
+    run_result_t r =
+        run_shell("declare -A m; m[a]=1; echo \"[${m[b]:-fallback}]\"");
+    ASSERT_STDOUT_EQ(r, "[fallback]\n");
+}
+
+TEST(rt_array_elem_default_present) {
+    run_result_t r =
+        run_shell("declare -A m; m[a]=hi; echo \"[${m[a]:-fallback}]\"");
+    ASSERT_STDOUT_EQ(r, "[hi]\n");
+}
+
+TEST(rt_array_elem_alt_present) {
+    run_result_t r =
+        run_shell("declare -A m; m[a]=hi; echo \"[${m[a]:+set}]\"");
+    ASSERT_STDOUT_EQ(r, "[set]\n");
+}
+
+TEST(rt_array_elem_alt_missing) {
+    run_result_t r =
+        run_shell("declare -A m; m[a]=hi; echo \"[${m[b]:+set}]\"");
+    ASSERT_STDOUT_EQ(r, "[]\n");
+}
+
+/* --- POSIX character classes in pattern matching ---------------------- */
+
+TEST(rt_char_class_space) {
+    /* [[:space:]] non-negated class -- strips trailing whitespace. */
+    run_result_t r = run_shell("s='a   '; echo \"[${s%%[[:space:]]*}]\"");
+    ASSERT_STDOUT_EQ(r, "[a]\n");
+}
+
+TEST(rt_char_class_negated) {
+    /* [![:space:]] -- the building block of the whitespace-trim idiom. */
+    run_result_t r = run_shell("s='  hi'; echo \"[${s%%[![:space:]]*}]\"");
+    ASSERT_STDOUT_EQ(r, "[  ]\n");
+}
+
+TEST(rt_char_class_digit) {
+    /* [[:digit:]] in a parameter-expansion suffix-removal pattern. */
+    run_result_t r = run_shell("s=abc123; echo \"[${s%%[[:digit:]]*}]\"");
+    ASSERT_STDOUT_EQ(r, "[abc]\n");
+}
+
+TEST(rt_char_class_upper) {
+    /* [![:upper:]] negated class. */
+    run_result_t r = run_shell("s=ABCdef; echo \"[${s%%[![:upper:]]*}]\"");
+    ASSERT_STDOUT_EQ(r, "[ABC]\n");
+}
+
+/* ============================================================================
  * MAIN
  * ============================================================================
  */
@@ -1835,12 +2081,47 @@ int main(void) {
     printf("\nLocal variable tests:\n");
     RUN_TEST(local_variable_in_function);
 
-    printf("\n========================================\n");
-    printf("All executor integration tests PASSED!\n");
-    printf("========================================\n");
+    printf("\nRegression: deferred here-documents:\n");
+    RUN_TEST(rt_heredoc_through_pipe);
+    RUN_TEST(rt_heredoc_trailing_command);
+    RUN_TEST(rt_heredoc_in_if_body);
+    RUN_TEST(rt_heredoc_loop_redirection);
+    RUN_TEST(rt_heredoc_strip_tabs);
+    RUN_TEST(rt_heredoc_quoted_delimiter);
+    RUN_TEST(rt_heredoc_multiline_var_body);
+    RUN_TEST(rt_heredoc_unterminated_error);
+
+    printf("\nRegression: glob expansion and qualifiers:\n");
+    RUN_TEST(rt_glob_for_array_qualifiers);
+
+    printf("\nRegression: return/case control flow:\n");
+    RUN_TEST(rt_return_from_for_loop);
+    RUN_TEST(rt_return_from_while_loop);
+    RUN_TEST(rt_case_arm_runs_all);
+    RUN_TEST(rt_case_arm_return_status);
+
+    printf("\nRegression: printf flags:\n");
+    RUN_TEST(rt_printf_flags);
+
+    printf("\nRegression: brace expansion:\n");
+    RUN_TEST(rt_brace_nested);
+    RUN_TEST(rt_brace_cartesian);
+    RUN_TEST(rt_brace_in_array_init);
+
+    printf("\nRegression: array-element parameter expansion:\n");
+    RUN_TEST(rt_array_elem_default_missing);
+    RUN_TEST(rt_array_elem_default_present);
+    RUN_TEST(rt_array_elem_alt_present);
+    RUN_TEST(rt_array_elem_alt_missing);
+
+    printf("\nRegression: POSIX character classes:\n");
+    RUN_TEST(rt_char_class_space);
+    RUN_TEST(rt_char_class_negated);
+    RUN_TEST(rt_char_class_digit);
+    RUN_TEST(rt_char_class_upper);
 
     /* Cleanup global symbol table */
     free_global_symtable();
 
-    return 0;
+    return TEST_RESULT();
 }

--- a/tools/real_world_scorecard.sh
+++ b/tools/real_world_scorecard.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Real-world script scorecard. Runs diff_oracle on every script under the
+# given root and prints a summary suitable for release-readiness review.
+#
+# Usage: real_world_scorecard.sh <diff_oracle path> <corpus root>
+#
+# Exit code: 0 (always). The test target is informational -- divergences
+# are concrete 1.5.0 punch-list items rather than CI failures, so the
+# scorecard does not fail the test suite. If you want this to gate CI,
+# wrap it in a stricter front-end.
+
+set -e
+DIFF_ORACLE="${1:?diff_oracle binary path required}"
+ROOT="${2:?corpus root required}"
+LUSH_BIN="${3:-./build/lush}"
+
+if [ ! -x "$DIFF_ORACLE" ]; then
+    echo "diff_oracle not built at $DIFF_ORACLE" >&2
+    exit 0
+fi
+
+if [ ! -d "$ROOT" ]; then
+    echo "corpus root not found: $ROOT" >&2
+    exit 0
+fi
+
+SCRIPTS=$(find "$ROOT" -name '*.sh' -type f | sort)
+if [ -z "$SCRIPTS" ]; then
+    echo "no scripts under $ROOT (yet)"
+    exit 0
+fi
+
+# Capture diff_oracle output and parse with python3 for the summary
+TMP=$(mktemp -t real_world.XXXXXX)
+trap 'rm -f "$TMP"' EXIT
+
+# shellcheck disable=SC2086  # SCRIPTS is intentionally word-split
+"$DIFF_ORACLE" --lush "$LUSH_BIN" $SCRIPTS > "$TMP" 2>&1 || true
+
+python3 - "$TMP" "$ROOT" <<'PYEOF'
+import json, sys, os
+log_path, root = sys.argv[1], sys.argv[2]
+agree=diverge=allowed=oracle_missing=0
+diverged=[]
+with open(log_path) as f:
+    for line in f:
+        line=line.strip()
+        if not line.startswith('{'): continue
+        try: d=json.loads(line)
+        except Exception: continue
+        if not d.get('oracle', True):
+            oracle_missing += 1
+            continue
+        if d['agree']:
+            agree += 1
+        elif d.get('allowed'):
+            allowed += 1
+        else:
+            diverge += 1
+            path=d['path'].replace(root.rstrip('/')+'/', '')
+            le=d['lush'].get('exit')
+            oe=d['oracle_result'].get('exit')
+            tag=[]
+            if le != oe: tag.append(f'exit {le}!={oe}')
+            if d['lush'].get('stdout','') != d['oracle_result'].get('stdout',''):
+                tag.append('stdout')
+            if d['lush'].get('stderr','') != d['oracle_result'].get('stderr',''):
+                tag.append('stderr')
+            diverged.append((path, ', '.join(tag) or 'misc'))
+
+total = agree+diverge+allowed
+print('=== real-world scorecard ===')
+print(f'Total scripts:     {total}')
+print(f'Pass:              {agree}')
+print(f'Allowed-divergent: {allowed}')
+print(f'DIVERGE:           {diverge}')
+print(f'Oracle missing:    {oracle_missing}')
+print()
+if total:
+    pct = 100.0 * (agree + allowed) / total
+    print(f'Pass rate: {pct:.1f}%')
+print()
+if diverged:
+    print('=== divergences (1.5.0 punch list) ===')
+    for path, tag in diverged:
+        print(f'  {path}  ({tag})')
+PYEOF


### PR DESCRIPTION
## Summary

Two bodies of work from one session on `grammar-fuzzing`.

### Real-world script hardening

A real-world script corpus (`tests/real_world/`, 22 scripts across
posix/bash/zsh/lush) plus a `diff_oracle`-driven scorecard was added
as the concrete 1.5.0 readiness signal, then driven from **50.0%
(11/22) to 95.5% (21/22)** by fixing the divergences it surfaced --
each a root-cause fix, no bandaids:

- **Deferred here-document collection** -- the parser collected
  heredoc bodies inline, discarding tokens that followed `<<EOF` on
  the same line (`cat <<EOF | wc` lost the pipe). Bodies are now
  collected at the line-terminating newline.
- **`exit` / `return` propagation** -- `exit` no longer runs trailing
  statements; `return` now unwinds out of every loop type; a case arm
  now runs all its commands instead of short-circuiting on non-zero.
- **Glob expansion** in for-loop word lists and array initializers
  (`for x in *`, `arr=(*.txt)` never globbed); zsh `(N)` nullglob and
  `(D)` dotglob qualifiers; tokenizer support for qualifiers on
  prefixed patterns (`*.txt(N)`).
- **Traps** now run through the live executor instead of `system()`,
  so user-defined functions are in scope on EXIT.
- printf flag forwarding, nested brace expansion, `${arr[k]:-default}`
  on array elements, POSIX `[[:space:]]` character classes, and two
  libfuzzer-surfaced leaks.

### Lush Semantics specification

`docs/SEMANTICS.md` -- a new foundational document (peer to VISION and
PHILOSOPHY) specifying lush's value model and scoping discipline: the
engine/preset two-layer rule, a bounded scalar/list/map value model,
no implicit list-to-string coercion, subscript-driven presentation,
and declaration-form-determined scoping. It ratifies the existing
`known_divergences.txt` entries and includes an honest gap table of
current implementation versus the model.

## Test plan

- [x] `meson test -C build` -- 110/110 passing
- [x] Clean build, `-Werror`, macOS clang
- [x] Real-world scorecard at 95.5% (21/22); the one remaining
      divergence (zsh/300) is scoped in SEMANTICS.md section 8
- [ ] CI green on Linux (gcc) after merge