### PR TITLE
ci: drop push trigger for the deleted feature/lle branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master, feature/lle]
+    branches: [master]
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
## Summary

The `feature/lle` branch was deleted; the `push.branches` trigger in `ci.yml` referenced a branch that no longer exists and could never fire. Removes it so the push trigger lists `master` only. PR CI on `master` is unchanged.

## Test plan

- [ ] PR CI green (build-and-test + memory-check matrix) confirms the workflow still parses and runs