### PR TITLE
Disable the exit-status prompt segment by default (starship parity)

### DIFF
--- a/src/lle/prompt/theme.c
+++ b/src/lle/prompt/theme.c
@@ -1019,12 +1019,17 @@ lle_theme_t *lle_theme_create_powerline(void) {
     /// Powerline rendering mode — composer routes to lle_powerline_render()
     theme->layout.style = LLE_PROMPT_STYLE_POWERLINE;
 
-    /// Segment order for powerline rendering
+    /// Segment order for powerline rendering. The exit-status segment is
+    /// configured below (see segment_configs) but deliberately NOT enabled
+    /// by default -- starship parity: its `status` module is off out of the
+    /// box, so a routine non-zero exit (e.g. SIGPIPE -> 141 from quitting a
+    /// pager) does not paint an alarming segment. Users opt in by adding
+    /// "status" to enabled_segments in their theme config, at which point
+    /// the configured styling below applies.
     snprintf(theme->enabled_segments[0], 32, "user");
     snprintf(theme->enabled_segments[1], 32, "directory");
     snprintf(theme->enabled_segments[2], 32, "git");
-    snprintf(theme->enabled_segments[3], 32, "status");
-    theme->enabled_segment_count = 4;
+    theme->enabled_segment_count = 3;
 
     /// Per-segment powerline colors: bold white text on colored backgrounds.
     /// Use true color #ffffff for fg (palette index 255 gets remapped by

--- a/tests/lle/unit/test_powerline_renderer.c
+++ b/tests/lle/unit/test_powerline_renderer.c
@@ -434,6 +434,16 @@ TEST(composer_powerline_context_affects_output) {
     setup();
 
     lle_composer_set_theme(&g_composer, "powerline");
+
+    /// The status segment is disabled by default (starship parity), so opt
+    /// it in here to exercise the exit-code-affects-output path: with status
+    /// enabled, a non-zero exit adds the segment and changes the prompt.
+    lle_theme_t *theme = lle_theme_registry_find(&g_themes, "powerline");
+    ASSERT_NOT_NULL(theme);
+    snprintf(theme->enabled_segments[theme->enabled_segment_count], 32,
+             "status");
+    theme->enabled_segment_count++;
+
     lle_composer_refresh_directory(&g_composer);
 
     /// Render with exit code 0 (status segment hidden)
@@ -478,12 +488,14 @@ TEST(powerline_theme_has_correct_segments) {
     lle_theme_t *theme = lle_theme_create_powerline();
     ASSERT_NOT_NULL(theme);
 
-    /// Built-in powerline theme should have 4 segments
-    ASSERT_EQ(theme->enabled_segment_count, 4);
+    /// Built-in powerline theme enables three segments by default. The
+    /// exit-status segment is configured (see segment_configs) but NOT
+    /// enabled by default -- starship parity, so a routine non-zero exit
+    /// (e.g. SIGPIPE -> 141 from quitting a pager) draws no segment.
+    ASSERT_EQ(theme->enabled_segment_count, 3);
     ASSERT_STR_EQ(theme->enabled_segments[0], "user");
     ASSERT_STR_EQ(theme->enabled_segments[1], "directory");
     ASSERT_STR_EQ(theme->enabled_segments[2], "git");
-    ASSERT_STR_EQ(theme->enabled_segments[3], "status");
 
     free(theme);
 }


### PR DESCRIPTION
## Summary

The powerline theme enabled the exit-status segment unconditionally, so any non-zero exit drew a segment — and routine signal terminations (`SIGPIPE` → 141 from quitting a pager, `SIGINT` → 130 from Ctrl-C) rendered as an alarming red "error" block despite being expected, controlled outcomes. The 141 itself is correct (git dies on SIGPIPE when its pager quits; bash/zsh report it identically) — the problem was the prompt styling it as a failure.

Matching starship (whose `status` module is `disabled = true` by default), the exit-status segment is no longer in the powerline theme's default `enabled_segments`. Out of the box nothing renders for any exit code. The segment's styling config is retained, so opting in (adding `status` to `enabled_segments`) restores the existing code + error-color display. Per-code color control and signal-name recognition are deferred until prompt parity grows further.

## Test plan

- [x] macOS clang: full suite + powerline renderer tests pass, 0 warnings
- [x] `powerline_theme_has_correct_segments` asserts the 3-segment default (no status)
- [x] `composer_powerline_context_affects_output` opts status in to still exercise exit-code-affects-output
- [ ] CI matrix (Ubuntu + macOS) + valgrind green

Closes #116.