### PR TITLE
Fix $(( )) mis-parsing ${var} as command substitution (#118)

### DIFF
--- a/include/tokenizer.h
+++ b/include/tokenizer.h
@@ -336,4 +336,23 @@ void tokenizer_refresh_current_and_lookahead(tokenizer_t *tokenizer);
  */
 void tokenizer_refresh_from_position(tokenizer_t *tokenizer);
 
+/**
+ * @brief Disambiguate `$((` content: arithmetic vs anonymous-function cmdsub
+ *
+ * `$((` is ambiguous: arithmetic expansion `$((expr))` or command
+ * substitution of an anonymous function `$(() { body; })` (issue #99).
+ * This scans the content beginning immediately after `$((`, with the
+ * paren depth already at 2, and returns whether it looks like
+ * arithmetic. A bare `{` / `}` (function body), `;`, or newline before
+ * the matching `))` means command substitution; `${...}` parameter
+ * expansions are skipped (their braces are legal inside arithmetic and
+ * must not disqualify it). Shared by the tokenizer and the executor's
+ * two string-expansion `$((` sites so the rule lives in one place.
+ *
+ * @param content Pointer to the first byte after `$((`
+ * @param remaining Bytes available at @p content
+ * @return true if the span looks like arithmetic, false for command sub
+ */
+bool lush_dollar_paren_is_arithmetic(const char *content, size_t remaining);
+
 #endif /// TOKENIZER_H

--- a/src/executor.c
+++ b/src/executor.c
@@ -158,6 +158,11 @@ static void cleanup_procsub_fds(executor_t *executor);
 bool is_posix_mode_enabled(void);
 bool is_pipefail_enabled(void);
 bool is_pipeline_diagnostic_enabled(void);
+
+/// `$((` arithmetic-vs-command-sub disambiguation, shared with the
+/// tokenizer (defined in tokenizer.c, declared in tokenizer.h which the
+/// executor does not include).
+bool lush_dollar_paren_is_arithmetic(const char *content, size_t remaining);
 static int execute_external_command_with_setup(executor_t *executor,
                                                char **argv,
                                                bool redirect_stderr,
@@ -6099,34 +6104,12 @@ char *expand_if_needed(executor_t *executor, const char *text) {
             }
             return strdup(text);
         } else if (strncmp(text, "$((", 3) == 0) {
-            /// Disambiguate `$((` between arithmetic and command-sub
-            /// of an anonymous function `$(() {...})`. Same shape as
-            /// the tokenizer and expand_variables_in_string detectors
-            /// (issue #99): if the lookahead from after $(( finds {,
-            /// }, ;, or \n before matched )), route to command-sub.
-            bool looks_arith = true;
-            {
-                size_t tlen = strlen(text);
-                size_t s = 3;
-                int d = 2;
-                while (s < tlen && d > 0) {
-                    char sc = text[s];
-                    if (sc == '(') {
-                        d++;
-                    } else if (sc == ')') {
-                        d--;
-                        if (d == 0) {
-                            break;
-                        }
-                    } else if (sc == '{' || sc == '}' || sc == ';' ||
-                               sc == '\n') {
-                        looks_arith = false;
-                        break;
-                    }
-                    s++;
-                }
-            }
-            if (looks_arith) {
+            /// Disambiguate `$((` between arithmetic and command-sub of an
+            /// anonymous function `$(() {...})` (issue #99). Shared helper
+            /// with the tokenizer; `${...}` parameter expansions inside the
+            /// arithmetic are handled there (issue #118).
+            size_t tlen = strlen(text);
+            if (lush_dollar_paren_is_arithmetic(text + 3, tlen - 3)) {
                 return expand_arithmetic(executor, text);
             }
             return expand_command_substitution(executor, text);
@@ -11411,27 +11394,8 @@ static char *expand_variables_in_string(executor_t *executor, const char *str) {
                 /// branch's $(...) handler instead. Walk the lookahead;
                 /// if it doesn't pass the arithmetic shape check, fall
                 /// through to the $(...) handler below.
-                bool looks_arith = true;
-                {
-                    size_t s = i + 3;
-                    int d = 2;
-                    while (s < len && d > 0) {
-                        char sc = str[s];
-                        if (sc == '(') {
-                            d++;
-                        } else if (sc == ')') {
-                            d--;
-                            if (d == 0) {
-                                break;
-                            }
-                        } else if (sc == '{' || sc == '}' || sc == ';' ||
-                                   sc == '\n') {
-                            looks_arith = false;
-                            break;
-                        }
-                        s++;
-                    }
-                }
+                bool looks_arith =
+                    lush_dollar_paren_is_arithmetic(str + i + 3, len - (i + 3));
                 if (!looks_arith) {
                     /// Re-route into the $(...) command-sub handler at
                     /// the next branch (else-if on str[i + 1] == '('),
@@ -15989,27 +15953,8 @@ static char *expand_quoted_string(executor_t *executor, const char *str,
                 /// anonymous function. Same shape as tokenizer +
                 /// expand_variables_in_string + expand_if_needed
                 /// (issue #99).
-                bool qs_looks_arith = true;
-                {
-                    size_t s = i + 3;
-                    int d = 2;
-                    while (s < len && d > 0) {
-                        char sc = str[s];
-                        if (sc == '(') {
-                            d++;
-                        } else if (sc == ')') {
-                            d--;
-                            if (d == 0) {
-                                break;
-                            }
-                        } else if (sc == '{' || sc == '}' || sc == ';' ||
-                                   sc == '\n') {
-                            qs_looks_arith = false;
-                            break;
-                        }
-                        s++;
-                    }
-                }
+                bool qs_looks_arith =
+                    lush_dollar_paren_is_arithmetic(str + i + 3, len - (i + 3));
                 if (!qs_looks_arith) {
                     /// Fall through to the $(...) command-sub handler
                     /// later in this function -- which is exactly the

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -19,6 +19,48 @@
 #include <stdlib.h>
 #include <string.h>
 
+bool lush_dollar_paren_is_arithmetic(const char *content, size_t remaining) {
+    if (!content) {
+        return true;
+    }
+    size_t s = 0;
+    int depth = 2; /// the two outer `(` of `$((`
+    while (s < remaining && depth > 0) {
+        char sc = content[s];
+        if (sc == '$' && s + 1 < remaining && content[s + 1] == '{') {
+            /// `${...}` parameter expansion is legal inside arithmetic
+            /// (`$((${a}+1))`). Its braces are not the anonymous-function
+            /// body braces this guard rejects, so skip the whole span.
+            /// Brace-balanced to tolerate nested `${...}` forms.
+            s += 2; /// past "${"
+            int bdepth = 1;
+            while (s < remaining && bdepth > 0) {
+                if (content[s] == '{') {
+                    bdepth++;
+                } else if (content[s] == '}') {
+                    bdepth--;
+                }
+                s++;
+            }
+            continue;
+        }
+        if (sc == '(') {
+            depth++;
+        } else if (sc == ')') {
+            depth--;
+            if (depth == 0) {
+                return true; /// matched `))` -- arithmetic
+            }
+        } else if (sc == '{' || sc == '}' || sc == ';' || sc == '\n') {
+            return false; /// bare brace / separator -- command substitution
+        }
+        s++;
+    }
+    /// Ran out of input without a disqualifier: treat as arithmetic; the
+    /// caller's extraction handles an unterminated `$((`.
+    return true;
+}
+
 /// Keyword lookup table
 static const struct {
     const char *text;
@@ -1191,31 +1233,10 @@ static token_t *tokenize_next_inner(tokenizer_t *tokenizer) {
                     /// the input is really `$(` followed by a `(` -- back
                     /// up the second `(` and reparse as command sub.
                     /// Issue #99.
-                    size_t scan = tokenizer->position + 1;
-                    int depth = 2; /// counting the two outer `(`
-                    bool looks_arith = true;
-                    while (scan < tokenizer->input_length && depth > 0) {
-                        char sc = tokenizer->input[scan];
-                        if (sc == '(') {
-                            depth++;
-                        } else if (sc == ')') {
-                            depth--;
-                            if (depth == 0) {
-                                /// Verify the closing is actually `))`
-                                /// by checking we came down from 2 with
-                                /// the immediately preceding char also
-                                /// being `)` (i.e. the inner closes
-                                /// before the outer). Walking the depth
-                                /// counter has already ensured this.
-                                break;
-                            }
-                        } else if (sc == '{' || sc == '}' || sc == ';' ||
-                                   sc == '\n') {
-                            looks_arith = false;
-                            break;
-                        }
-                        scan++;
-                    }
+                    /// position is at the second `(`; content begins after it.
+                    bool looks_arith = lush_dollar_paren_is_arithmetic(
+                        &tokenizer->input[tokenizer->position + 1],
+                        tokenizer->input_length - (tokenizer->position + 1));
 
                     if (looks_arith) {
                         /// Arithmetic expansion $((expr))

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -1298,6 +1298,54 @@ TEST(arithmetic_increment) {
     executor_free(exec);
 }
 
+TEST(arithmetic_brace_param_echo) {
+    /// `${var}` parameter expansion inside arithmetic. The `$((`
+    /// disambiguation must skip the `${...}` braces rather than
+    /// mistaking them for an anonymous-function body (issue #118).
+    run_result_t r = run_shell("a=10\n"
+                               "echo $((${a}))\n");
+    ASSERT_STDOUT_EQ(r, "10\n");
+}
+
+TEST(arithmetic_brace_param_add) {
+    run_result_t r = run_shell("a=10\n"
+                               "echo $((${a}+1))\n");
+    ASSERT_STDOUT_EQ(r, "11\n");
+}
+
+TEST(arithmetic_brace_param_two_operands) {
+    run_result_t r = run_shell("a=10\n"
+                               "b=5\n"
+                               "echo $((${a}+${b}))\n");
+    ASSERT_STDOUT_EQ(r, "15\n");
+}
+
+TEST(arithmetic_brace_param_assignment) {
+    /// Assignment RHS routes through executor string expansion, a
+    /// different `$((` detection site than the echo argument path;
+    /// both share the disambiguation helper (issue #118).
+    run_result_t r = run_shell("a=10\n"
+                               "x=$((${a}+1))\n"
+                               "echo $x\n");
+    ASSERT_STDOUT_EQ(r, "11\n");
+}
+
+TEST(arithmetic_brace_param_nested_parens) {
+    run_result_t r = run_shell("a=10\n"
+                               "b=5\n"
+                               "echo $(( ${a} * (${b} + 2) ))\n");
+    ASSERT_STDOUT_EQ(r, "70\n");
+}
+
+TEST(anon_function_cmdsub_still_routes) {
+    /// Guard the other side of the disambiguation: `$(() {...})` is
+    /// command substitution of an anonymous function, not arithmetic.
+    /// The brace skip added for issue #118 must not swallow the
+    /// anonymous-function body braces (issue #99).
+    run_result_t r = run_shell("echo \"$( () { echo anonret; } )\"\n");
+    ASSERT_STDOUT_EQ(r, "anonret\n");
+}
+
 /* ============================================================================
  * SUBSHELL AND GROUPING TESTS
  * ============================================================================
@@ -3871,6 +3919,12 @@ int main(void) {
     RUN_TEST(arithmetic_multiply);
     RUN_TEST(arithmetic_variable);
     RUN_TEST(arithmetic_increment);
+    RUN_TEST(arithmetic_brace_param_echo);
+    RUN_TEST(arithmetic_brace_param_add);
+    RUN_TEST(arithmetic_brace_param_two_operands);
+    RUN_TEST(arithmetic_brace_param_assignment);
+    RUN_TEST(arithmetic_brace_param_nested_parens);
+    RUN_TEST(anon_function_cmdsub_still_routes);
 
     printf("\nSubshell and grouping tests:\n");
     RUN_TEST(subshell_isolation);


### PR DESCRIPTION
## Summary
- `$((${a}))` and `$((${a}+1))` were routed to command substitution instead of arithmetic. The `$((` disambiguation heuristic (added for anonymous-function cmdsub `$(() { body; })`, issue #99) rejected any `{`/`}` before the matching `))` as a function body, which wrongly rejected `${var}` parameter expansions that are legal arithmetic operands.
- Extract the heuristic into a single `lush_dollar_paren_is_arithmetic` helper that skips brace-balanced `${...}` spans, replacing four duplicated inline copies: the tokenizer's `$((` path and the executor's `expand_if_needed`, `expand_variables_in_string`, and `expand_quoted_string` sites.

## Verified
- `echo $((${a}))`, `echo $((${a}+1))`, `echo $((${a}+${b}))`, `x=$((${a}+1))`, and `$(( ${a} * (${b} + 2) ))` all evaluate arithmetically.
- The #99 anonymous-function command substitution `$( () { echo anonret; } )` still routes to command sub.

## Test plan
- [x] 6 new regression tests in `test_executor.c` (brace-param echo/add/two-operands/assignment/nested-parens + #99 guard)
- [x] Full suite: 118/118 meson tests pass
- [x] 0 compiler warnings (werror build)
- [x] clang-format clean

Fixes #118