### PR TITLE
Fix ${var@a} attribute query on list/map values (#121)

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -13832,7 +13832,17 @@ static char *parse_parameter_expansion(executor_t *executor,
         /// single-element. The bare-name check fires only when the
         /// operator's left operand is a complete collection
         /// identifier with no subscript.
-        if (var_len > 0) {
+        ///
+        /// Exception: the @a attribute query is metadata-only and
+        /// kind-agnostic. It reports the declared-attribute letters
+        /// (a / A for indexed / associative arrays, plus i/r/x/...)
+        /// and must work on a collection, unlike the value-shaped @
+        /// transforms (@Q/@E/@U/...) which do need an explicit [@] to
+        /// vectorize. Let @a fall through to the case 17 dispatch,
+        /// where get_variable_attributes handles every kind even when
+        /// the scalar value lookup misses (arrays have a NULL scalar).
+        bool attr_query = (op_type == 17 && op_pos[1] == 'a');
+        if (var_len > 0 && !attr_query) {
             array_value_t *bare_array = symtable_get_array(var_name);
             if (bare_array) {
                 const char *op_str = operators[op_type];

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -3077,6 +3077,38 @@ TEST(rt_pe_catalog_at_transform_on_bare_list) {
     ASSERT_EXIT_STATUS(r, 1);
 }
 
+TEST(rt_pe_at_attr_query_on_map) {
+    /// ${map@a} is the kind-agnostic attribute query: it reports the
+    /// declared-attribute letters and must work on a collection, unlike
+    /// the value-shaped @ transforms above which require [@] (#121).
+    run_result_t r = run_shell("declare -A m=([x]=1)\n"
+                               "echo \"[${m@a}]\"\n");
+    ASSERT_STDOUT_EQ(r, "[A]\n");
+}
+
+TEST(rt_pe_at_attr_query_on_list) {
+    run_result_t r = run_shell("declare -a idx=(a b c)\n"
+                               "echo \"[${idx@a}]\"\n");
+    ASSERT_STDOUT_EQ(r, "[a]\n");
+}
+
+TEST(rt_pe_at_attr_query_scalar_unaffected) {
+    /// The bare-name guard exception is limited to @a; the scalar
+    /// attribute paths are unchanged.
+    run_result_t r = run_shell("declare -i n=5\n"
+                               "declare -r ro=locked\n"
+                               "echo \"[${n@a}][${ro@a}]\"\n");
+    ASSERT_STDOUT_EQ(r, "[i][r]\n");
+}
+
+TEST(rt_pe_at_value_transform_on_map_still_errors) {
+    /// Only @a bypasses the guard; a value-shaped @ transform on a bare
+    /// collection remains a type error (needs [@] to vectorize).
+    run_result_t r = run_shell("declare -A m=([x]=1)\n"
+                               "echo \"[${m@U}]\"\n");
+    ASSERT_EXIT_STATUS(r, 1);
+}
+
 TEST(rt_pe_catalog_conditional_on_map) {
     run_result_t r = run_shell("declare -A m=([a]=1 [b]=2)\n"
                                "echo \"[${m:-default}]\"\n");
@@ -4092,6 +4124,10 @@ int main(void) {
     RUN_TEST(rt_pe_catalog_pattern_strip_on_bare_list);
     RUN_TEST(rt_pe_catalog_substring_on_bare_list);
     RUN_TEST(rt_pe_catalog_at_transform_on_bare_list);
+    RUN_TEST(rt_pe_at_attr_query_on_map);
+    RUN_TEST(rt_pe_at_attr_query_on_list);
+    RUN_TEST(rt_pe_at_attr_query_scalar_unaffected);
+    RUN_TEST(rt_pe_at_value_transform_on_map_still_errors);
     RUN_TEST(rt_pe_catalog_conditional_on_map);
     RUN_TEST(rt_pe_catalog_scalar_slice_still_works);
     RUN_TEST(rt_pe_catalog_per_element_case_mod_via_slice);


### PR DESCRIPTION
## Summary
- `${var@a}` reports a variable's declared-attribute letters and is kind-agnostic, but the bare-name scalar-operator guard rejected *every* `@` transform on a list or map with `E1133` before the `@`-transform dispatch ran. `${m@a}` on an associative array therefore errored where bash returns `A`.
- Exempt `@a` from the guard so it falls through to `get_variable_attributes`, which already reports `a`/`A` for indexed/associative arrays alongside the scalar `i`/`r`/`x` letters.
- The value-shaped transforms (`@Q`/`@E`/`@U`/`@u`/`@L`/`@P`) still error on a bare collection — those require explicit `[@]` vectorization.

## Verified vs bash 5.3.9
```
declare -A m=([x]=1); echo ${m@a}   # A
declare -a idx=(a b c); echo ${idx@a} # a
declare -i n=5; echo ${n@a}          # i
declare -r ro=x; echo ${ro@a}        # r
declare -A m=([x]=1); echo ${m@U}    # still a type error (needs [@])
```

## Test plan
- [x] 4 new regression tests in `test_executor.c` (`@a` on map/list, scalar unchanged, value-transform on map still errors)
- [x] Full suite: 118/118 meson tests pass
- [x] 0 compiler warnings (werror build)
- [x] clang-format clean
- [x] Differential harness seed `bash/217_bash_param_transform.sh` now agrees with bash

Fixes #121

Found by the mode-aware differential harness (`tests/fuzz/differential`).