### PR TITLE
Readonly assignment error aborts the AND-OR list; posix/zsh exit (#120)

### DIFF
--- a/include/executor.h
+++ b/include/executor.h
@@ -108,6 +108,22 @@ typedef struct executor {
     bool shell_exit_requested;
     int shell_exit_status;
 
+    /* Variable-assignment error abort. A failed assignment to a readonly
+     * variable is not an ordinary command failure: per bash/zsh/dash it
+     * must abort the current AND-OR list WITHOUT feeding `||`/`&&`, and
+     * its diagnostic is a shell-level message reported on the real
+     * stderr after the command's transient redirections are torn down
+     * (so a `2>/dev/null` on the assignment does not swallow it). The
+     * detector (execute_assignment) sets command_abort and stashes the
+     * pending diagnostic; the execute_command chokepoint emits it after
+     * redirect restore and applies the mode policy (posix: exit a
+     * non-interactive shell; other modes: abort the list, continue the
+     * script). command_abort is reset per command in
+     * execute_command_inner; the AND-OR handlers consume it. */
+    bool command_abort;
+    char *pending_readonly_var;
+    source_location_t pending_readonly_loc;
+
     /// Error context stack (Phase 3: context-aware error management)
     char *context_stack[EXECUTOR_CONTEXT_STACK_MAX]; ///< "while executing X"
     source_location_t context_locations[EXECUTOR_CONTEXT_STACK_MAX];

--- a/include/shell_mode.h
+++ b/include/shell_mode.h
@@ -175,6 +175,17 @@ typedef enum {
                                         ///< inherited names are external bytes,
                                         ///< not lush-authored identifiers.
 
+    FEATURE_ASSIGN_ERROR_EXITS, ///< A variable-assignment error (e.g. a
+                                ///< write to a readonly variable) exits a
+                                ///< non-interactive shell, per POSIX 2.8.1.
+                                ///< On in posix and zsh modes (dash and zsh
+                                ///< both exit); off in bash and lush modes
+                                ///< (bash continues -- aborting only the
+                                ///< current AND-OR list). Independent of the
+                                ///< AND-OR abort itself, which is uniform
+                                ///< across modes. Toggleable per-script via
+                                ///< setopt/unsetopt.
+
     /// Sentinel - must be last
     FEATURE_COUNT ///< Number of features (for array sizing)
 } shell_feature_t;

--- a/src/executor.c
+++ b/src/executor.c
@@ -351,6 +351,8 @@ executor_t *executor_new(void) {
     executor->expansion_exit_status = 0;
     executor->shell_exit_requested = false;
     executor->shell_exit_status = 0;
+    executor->command_abort = false;
+    executor->pending_readonly_var = NULL;
     executor->loop_control = LOOP_NORMAL;
     executor->loop_depth = 0;
     executor->source_depth = 0;
@@ -418,6 +420,8 @@ executor_t *executor_new_with_symtable(symtable_manager_t *symtable) {
     executor->expansion_exit_status = 0;
     executor->shell_exit_requested = false;
     executor->shell_exit_status = 0;
+    executor->command_abort = false;
+    executor->pending_readonly_var = NULL;
     executor->loop_control = LOOP_NORMAL;
     executor->loop_depth = 0;
     executor->source_depth = 0;
@@ -490,6 +494,11 @@ void executor_free(executor_t *executor) {
 
         /// Free script context
         free(executor->current_script_file);
+
+        /// Free any unconsumed readonly-abort diagnostic (defensive;
+        /// the execute_command chokepoint clears it under normal flow).
+        free(executor->pending_readonly_var);
+        executor->pending_readonly_var = NULL;
 
         /// Free error context stack
         executor_clear_context(executor);
@@ -1607,6 +1616,31 @@ static int execute_command(executor_t *executor, node_t *command) {
     source_location_t saved_active_loc = executor->active_loc;
     executor->active_loc = command->loc;
     int result = execute_command_inner(executor, command);
+
+    /// A readonly variable-assignment error was detected inside this
+    /// command. Emit it now -- redirections set up by the assignment-only
+    /// path have already been restored, so the shell-level diagnostic
+    /// reaches the real stderr rather than a `2>/dev/null` the command
+    /// requested (matching bash). command_abort stays set for the
+    /// enclosing AND-OR handler to consume.
+    if (executor->pending_readonly_var) {
+        executor_error_report(
+            executor, SHELL_ERR_READONLY_VAR, executor->pending_readonly_loc,
+            "%s: readonly variable", executor->pending_readonly_var);
+        free(executor->pending_readonly_var);
+        executor->pending_readonly_var = NULL;
+        set_exit_status(1);
+        result = 1;
+        /// POSIX 2.8.1: a variable-assignment error causes a
+        /// non-interactive shell to exit. dash and zsh do this; bash
+        /// continues, aborting only the current AND-OR list. Gated by
+        /// FEATURE_ASSIGN_ERROR_EXITS (on in posix/zsh, off in
+        /// bash/lush; per-script via `setopt assign_error_exits`).
+        if (shell_mode_allows(FEATURE_ASSIGN_ERROR_EXITS)) {
+            executor_request_posix_exit(executor, 1);
+        }
+    }
+
     executor->active_loc = saved_active_loc;
     return result;
 }
@@ -1617,6 +1651,10 @@ static int execute_command_inner(executor_t *executor, node_t *command) {
     /// Reset expansion error flags for this command
     executor->expansion_error = false;
     executor->expansion_exit_status = 0;
+    /// Clear the per-command assignment-abort signal. A prior command's
+    /// readonly abort has already been consumed by the enclosing AND-OR
+    /// handler; the next command starts clean.
+    executor->command_abort = false;
 
     /// Check for assignment (legacy lone-assignment shape: val.str is
     /// "var=value" with no NODE_ASSIGN children).
@@ -4273,6 +4311,14 @@ static int execute_logical_and(executor_t *executor, node_t *and_node) {
     /// Execute left command
     int left_result = execute_node(executor, left);
 
+    /// A variable-assignment error (readonly) on the left aborts the
+    /// whole AND-OR list -- it is not an ordinary failure that the
+    /// operator gets to react to. Skip the right operand regardless of
+    /// the && / || sense.
+    if (executor->command_abort) {
+        return left_result;
+    }
+
     /// Only execute right command if left succeeded (exit code 0)
     if (left_result == 0) {
         return execute_node(executor, right);
@@ -4307,6 +4353,13 @@ static int execute_logical_or(executor_t *executor, node_t *or_node) {
 
     /// Execute left command
     int left_result = execute_node(executor, left);
+
+    /// A variable-assignment error (readonly) on the left aborts the
+    /// whole AND-OR list -- the `||` must not treat it as an ordinary
+    /// failure and run the right operand. Skip the right operand.
+    if (executor->command_abort) {
+        return left_result;
+    }
 
     /// Only execute right command if left failed (non-zero exit code)
     if (left_result != 0) {
@@ -9142,12 +9195,22 @@ static int execute_assignment(executor_t *executor, const char *assignment,
 
     /// Readonly enforcement: symtable_assign_var / symtable_set_var
     /// return SYMTABLE_ERR_READONLY when the target carries the
-    /// readonly attribute anywhere in the scope chain. Surface the
-    /// user-facing diagnostic through the structured-error system
-    /// before the generic failure return below.
+    /// readonly attribute anywhere in the scope chain.
+    ///
+    /// This is a variable-assignment error, not an ordinary command
+    /// failure: bash, zsh, and dash all decline to feed it into a
+    /// following `||`/`&&`. Signal command_abort so the enclosing
+    /// AND-OR handler skips its right operand, and stash the diagnostic
+    /// rather than emitting it here -- the assignment may be running
+    /// under a transient redirection (`ro=x 2>/dev/null`), and the
+    /// shell-level diagnostic must reach the real stderr after that
+    /// redirection is torn down. The execute_command chokepoint emits it
+    /// and applies the mode-exit policy.
     if (result == SYMTABLE_ERR_READONLY) {
-        executor_error_report(executor, SHELL_ERR_READONLY_VAR, loc,
-                              "%s: readonly variable", var_name);
+        executor->command_abort = true;
+        free(executor->pending_readonly_var);
+        executor->pending_readonly_var = strdup(var_name);
+        executor->pending_readonly_loc = loc;
         free(var_name);
         free(value);
         if (resolved_to_free) {

--- a/src/lle/completion/builtin_completions.c
+++ b/src/lle/completion/builtin_completions.c
@@ -724,6 +724,12 @@ generate_alias_completions(lle_memory_pool_t *pool,
  * Static list of shell feature names matching shell_mode.h.
  * This avoids linking dependency on shell_mode for test binaries.
  */
+/// setopt/unsetopt feature names offered by completion. Hand-maintained
+/// here rather than read from shell_mode.c's feature matrix because this
+/// module lives in liblle, which links standalone and must not depend on
+/// the main shell's symbols (see the lle_shell_* weak-symbol bridge). The
+/// list has drifted from the matrix over time; converting it to a
+/// weak-symbol bridge is tracked separately.
 static const char *shell_feature_names[] = {
     /// Arrays
     "indexed_arrays", "associative_arrays", "array_zero_indexed",
@@ -745,6 +751,7 @@ static const char *shell_feature_names[] = {
     "case_fallthrough", "select_loop", "time_keyword",
     /// Behavior
     "word_split_default", "auto_cd", "auto_pushd", "cdable_vars",
+    "assign_error_exits",
     /// Advanced
     "nameref", "anonymous_functions", "return_anywhere",
     /// Zsh-specific

--- a/src/shell_mode.c
+++ b/src/shell_mode.c
@@ -98,6 +98,8 @@ static const bool feature_matrix[SHELL_MODE_COUNT][FEATURE_COUNT] = {
                             [FEATURE_CDABLE_VARS] = false,
                             [FEATURE_ERREXIT_IN_LOOPS] =
                 false, /// POSIX permits failing loop bodies; do not deviate
+            [FEATURE_ASSIGN_ERROR_EXITS] =
+                true, /// POSIX 2.8.1: assignment error exits non-interactive sh
             [FEATURE_XPG_ECHO] = true, /// POSIX XSI mandates escape interp
 
             /// History Behavior
@@ -184,6 +186,9 @@ static const bool feature_matrix[SHELL_MODE_COUNT][FEATURE_COUNT] = {
                             [FEATURE_CDABLE_VARS] = false,
                             [FEATURE_ERREXIT_IN_LOOPS] =
                 false, /// bash permits failing loop bodies; preserve parity
+            [FEATURE_ASSIGN_ERROR_EXITS] =
+                false, /// bash continues after a readonly assignment error,
+                       /// aborting only the current AND-OR list
             [FEATURE_XPG_ECHO] = false, /// shopt xpg_echo, off by default
 
             /// History Behavior
@@ -273,6 +278,9 @@ static const bool feature_matrix[SHELL_MODE_COUNT][FEATURE_COUNT] = {
                             [FEATURE_CDABLE_VARS] = false,
                             [FEATURE_ERREXIT_IN_LOOPS] =
                 false, /// zsh permits failing loop bodies; preserve parity
+            [FEATURE_ASSIGN_ERROR_EXITS] =
+                true, /// zsh exits a non-interactive shell on a readonly
+                      /// assignment error, like dash; match it in zsh mode
             [FEATURE_XPG_ECHO] = true, /* zsh: BSD_ECHO off → escapes interp'd
                             by default in zsh's echo builtin */
 
@@ -367,6 +375,15 @@ static const bool feature_matrix[SHELL_MODE_COUNT][FEATURE_COUNT] = {
                             5+ seconds. Off in POSIX/bash/zsh modes for
                             polyglot parity. Toggle per-script via
                             `unsetopt errexit_in_loops`. */
+            [FEATURE_ASSIGN_ERROR_EXITS] =
+                false, /* Curated lush default: a readonly assignment error
+                            aborts the current AND-OR list and is reported on
+                            stderr, but does not tear down the whole session.
+                            Exiting the shell on one bad assignment is hostile
+                            in an interactive-first shell; the abort already
+                            stops the dangerous `||` fallthrough. Opt into the
+                            strict posix/zsh behavior with
+                            `setopt assign_error_exits`. */
             [FEATURE_XPG_ECHO] =
                 true, /* Curated zsh-style: echo interprets escapes by
                             default. More predictable and modern than bash's
@@ -478,6 +495,7 @@ static const char *feature_names[FEATURE_COUNT] = {
     [FEATURE_AUTO_PUSHD] = "auto_pushd",
     [FEATURE_CDABLE_VARS] = "cdable_vars",
     [FEATURE_ERREXIT_IN_LOOPS] = "errexit_in_loops",
+    [FEATURE_ASSIGN_ERROR_EXITS] = "assign_error_exits",
     [FEATURE_XPG_ECHO] = "xpg_echo",
 
     /// History Behavior

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -3707,6 +3707,89 @@ TEST(rt_readonly_blocks_same_scope_reassign) {
     ASSERT_STDOUT_EQ(r, "final 1\n");
 }
 
+TEST(rt_readonly_assign_aborts_or_list) {
+    /// A readonly assignment error must NOT feed `||`: bash, zsh, and
+    /// dash all decline to run the right operand (#120). In a non-posix
+    /// preset the script continues to the next statement with $?=1.
+    run_result_t r = run_shell("readonly RO_OR=1\n"
+                               "RO_OR=2 || echo SHOULD_NOT_RUN\n"
+                               "echo \"after $?\"\n");
+    ASSERT_STDERR_CONTAINS(r, "readonly variable");
+    ASSERT_STDOUT_EQ(r, "after 1\n");
+}
+
+TEST(rt_readonly_assign_aborts_and_list) {
+    /// Same for `&&`: the readonly error aborts the current AND-OR list,
+    /// the right operand is skipped, and the script continues.
+    run_result_t r = run_shell("readonly RO_AND=1\n"
+                               "RO_AND=2 && echo SHOULD_NOT_RUN\n"
+                               "echo \"after $?\"\n");
+    ASSERT_STDERR_CONTAINS(r, "readonly variable");
+    ASSERT_STDOUT_EQ(r, "after 1\n");
+}
+
+TEST(rt_readonly_assign_diag_bypasses_redirect) {
+    /// The readonly diagnostic is a shell-level message reported on the
+    /// real stderr after the command's transient redirection is torn
+    /// down, so a `2>/dev/null` on the assignment does not swallow it
+    /// (matching bash). The `||` right operand still does not run.
+    run_result_t r = run_shell("readonly RO_RED=1\n"
+                               "RO_RED=2 2>/dev/null || echo SHOULD_NOT_RUN\n"
+                               "echo \"after $?\"\n");
+    ASSERT_STDERR_CONTAINS(r, "readonly variable");
+    ASSERT_STDOUT_EQ(r, "after 1\n");
+}
+
+TEST(rt_readonly_normal_or_still_fires) {
+    /// Regression guard: an ordinary command failure must still feed
+    /// `||`. The abort signal is specific to assignment errors.
+    run_result_t r = run_shell("false || echo normal-or-ran\n");
+    ASSERT_STDOUT_EQ(r, "normal-or-ran\n");
+}
+
+TEST(rt_readonly_assign_posix_mode_exits) {
+    /// POSIX 2.8.1: a variable-assignment error exits a non-interactive
+    /// shell. In posix mode the statement after the readonly error must
+    /// not run.
+    run_result_t r = run_shell("mode posix\n"
+                               "readonly RO_PX=1\n"
+                               "RO_PX=2\n"
+                               "echo SHOULD_NOT_RUN\n");
+    /// `mode` mutates global shell state the harness does not reset
+    /// between tests; restore the native default before asserting (an
+    /// assertion failure longjmps out and would otherwise leave every
+    /// later test running under posix mode).
+    run_shell("mode lush\n");
+    ASSERT_STDERR_CONTAINS(r, "readonly variable");
+    ASSERT_STDOUT_EQ(r, "");
+}
+
+TEST(rt_readonly_assign_zsh_mode_exits) {
+    /// zsh exits a non-interactive shell on a readonly assignment error
+    /// (like dash); zsh mode matches it via FEATURE_ASSIGN_ERROR_EXITS.
+    run_result_t r = run_shell("mode zsh\n"
+                               "readonly RO_ZX=1\n"
+                               "RO_ZX=2\n"
+                               "echo SHOULD_NOT_RUN\n");
+    run_shell("mode lush\n");
+    ASSERT_STDERR_CONTAINS(r, "readonly variable");
+    ASSERT_STDOUT_EQ(r, "");
+}
+
+TEST(rt_readonly_assign_setopt_toggles_exit) {
+    /// The exit policy is a feature gate reachable from the central
+    /// config: enabling assign_error_exits in an otherwise-continue
+    /// preset (bash) makes the readonly error exit the shell.
+    run_result_t r = run_shell("mode bash\n"
+                               "setopt assign_error_exits\n"
+                               "readonly RO_TOG=1\n"
+                               "RO_TOG=2\n"
+                               "echo SHOULD_NOT_RUN\n");
+    run_shell("mode lush\nunsetopt assign_error_exits\n");
+    ASSERT_STDERR_CONTAINS(r, "readonly variable");
+    ASSERT_STDOUT_EQ(r, "");
+}
+
 TEST(rt_readonly_blocks_via_readonly_keyword) {
     /// `readonly NAME` without a value promotes an existing scalar
     /// to readonly; later writes must be refused.
@@ -4218,6 +4301,13 @@ int main(void) {
 
     printf("\nRegression: readonly enforcement:\n");
     RUN_TEST(rt_readonly_blocks_same_scope_reassign);
+    RUN_TEST(rt_readonly_assign_aborts_or_list);
+    RUN_TEST(rt_readonly_assign_aborts_and_list);
+    RUN_TEST(rt_readonly_assign_diag_bypasses_redirect);
+    RUN_TEST(rt_readonly_normal_or_still_fires);
+    RUN_TEST(rt_readonly_assign_posix_mode_exits);
+    RUN_TEST(rt_readonly_assign_zsh_mode_exits);
+    RUN_TEST(rt_readonly_assign_setopt_toggles_exit);
     RUN_TEST(rt_readonly_blocks_via_readonly_keyword);
     RUN_TEST(rt_readonly_blocks_across_function_scope);
     RUN_TEST(rt_readonly_blocks_via_declare_r);


### PR DESCRIPTION
## Summary
- A failed assignment to a readonly variable was treated as an ordinary command failure: it fed the following `||`, left `$?`=0, and never halted. bash, zsh, and dash all decline to run the right operand of a following `||`/`&&` after such an error.
- Make a variable-assignment error a shell-level command abort: `execute_assignment` sets a `command_abort` signal and stashes the diagnostic; the AND-OR handlers consume it and skip their right operand; the `execute_command` chokepoint emits the diagnostic after the command's transient redirections are torn down, so it reaches the real stderr (a `2>/dev/null` on the assignment no longer swallows it — matching bash). `$?` is set to 1. Normal command failures still feed `||`/`&&` unchanged.
- Whether the error additionally **exits** a non-interactive shell is gated by the new `FEATURE_ASSIGN_ERROR_EXITS`: on in posix and zsh modes (dash and zsh both exit, POSIX 2.8.1), off in bash and lush modes (bash continues). Per-script via `setopt assign_error_exits`. The setopt/unsetopt completion list gains the option name.

## Verified vs reference shells
```
readonly r=1; r=2 || echo X; echo "after $?"
  posix -> error on stderr, shell exits 1        (matches dash)
  zsh   -> error on stderr, shell exits 1        (matches zsh)
  bash  -> error on stderr, X NOT run, after 1   (matches bash)
  lush  -> error on stderr, X NOT run, after 1
setopt assign_error_exits in bash mode -> exits;  unsetopt in zsh mode -> continues
```

## Test plan
- [x] 7 new regression tests (`||`/`&&` abort, redirect-bypassed diagnostic, posix+zsh mode exit, setopt toggle, ordinary-failure-still-feeds-`||` guard)
- [x] Full suite: 118/118 meson tests pass
- [x] 0 compiler warnings (werror build)
- [x] clang-format clean
- [x] Differential harness seed `bash/210_bash_declare_attrs.sh` now agrees with bash

Fixes #120

Found by the mode-aware differential harness (`tests/fuzz/differential`).