### PR TITLE
read: strip leading/trailing IFS whitespace when assigning (#129)

### DIFF
--- a/src/builtins/bin_read.c
+++ b/src/builtins/bin_read.c
@@ -69,6 +69,14 @@ static char *read_line_from_fd(int fd) {
     return line;
 }
 
+/// True if c is an IFS *white space* character: a space, tab, or newline
+/// that is also present in the active IFS. POSIX read ignores leading and
+/// trailing IFS white space; non-whitespace IFS characters (e.g. ':') are
+/// field delimiters but are not trimmed from the ends of the value.
+static bool read_is_ifs_white(char c, const char *ifs) {
+    return (c == ' ' || c == '\t' || c == '\n') && strchr(ifs, c) != NULL;
+}
+
 int bin_read(int argc, char **argv) {
     /// Option flags
     char *prompt = NULL;
@@ -397,7 +405,31 @@ int bin_read(int argc, char **argv) {
     /// leading fields and assign the remainder (preserving internal
     /// IFS chars) to the last variable.
     if (n_varnames == 1) {
-        symtable_set_global(varname, line ? line : "");
+        /// POSIX: leading and trailing IFS white space is stripped even
+        /// for a single variable (the line otherwise assigned verbatim).
+        /// Non-whitespace IFS chars are not trimmed.
+        const char *src = line ? line : "";
+        char *ifs_val = symtable_get_var(current_executor->symtable, "IFS");
+        const char *ifs = ifs_val ? ifs_val : " \t\n";
+        while (*src && read_is_ifs_white(*src, ifs)) {
+            src++;
+        }
+        const char *end = src + strlen(src);
+        while (end > src && read_is_ifs_white(end[-1], ifs)) {
+            end--;
+        }
+        size_t vlen = (size_t)(end - src);
+        char *val = malloc(vlen + 1);
+        if (!val) {
+            free(ifs_val);
+            free(line);
+            return 1;
+        }
+        memcpy(val, src, vlen);
+        val[vlen] = '\0';
+        symtable_set_global(varname, val);
+        free(val);
+        free(ifs_val);
     } else {
         const char *src = line ? line : "";
         /// POSIX IFS default is space, tab, newline. Honor a user-set
@@ -431,13 +463,27 @@ int bin_read(int argc, char **argv) {
             symtable_set_global(argv[opt_index + i], field);
             free(field);
         }
-        /// Last variable: skip one leading IFS-whitespace run then
-        /// take everything else verbatim (including internal IFS
-        /// chars).
+        /// Last variable: skip the leading inter-field delimiter run,
+        /// keep internal IFS chars, but strip trailing IFS white space
+        /// (POSIX trims trailing IFS white space from the line).
         while (*src && strchr(ifs, *src)) {
             src++;
         }
-        symtable_set_global(argv[opt_index + n_varnames - 1], src);
+        const char *end = src + strlen(src);
+        while (end > src && read_is_ifs_white(end[-1], ifs)) {
+            end--;
+        }
+        size_t vlen = (size_t)(end - src);
+        char *val = malloc(vlen + 1);
+        if (!val) {
+            free(ifs_val);
+            free(line);
+            return 1;
+        }
+        memcpy(val, src, vlen);
+        val[vlen] = '\0';
+        symtable_set_global(argv[opt_index + n_varnames - 1], val);
+        free(val);
         free(ifs_val);
     }
 

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -1544,6 +1544,38 @@ TEST(builtin_readonly) {
     executor_free(exec);
 }
 
+TEST(rt_read_strips_leading_trailing_ifs_whitespace) {
+    /// POSIX read trims leading and trailing IFS white space, even for a
+    /// single variable (the line is otherwise assigned verbatim). #129.
+    run_result_t r = run_shell("read -r x <<'EOF'\n"
+                               "  a b  \n"
+                               "EOF\n"
+                               "echo \"[$x]\"\n");
+    ASSERT_STDOUT_EQ(r, "[a b]\n");
+}
+
+TEST(rt_read_multi_var_trims_trailing_ws) {
+    /// The last variable keeps internal IFS chars but has trailing IFS
+    /// white space stripped.
+    run_result_t r = run_shell("read -r x y <<'EOF'\n"
+                               "  a b c  \n"
+                               "EOF\n"
+                               "echo \"x=[$x] y=[$y]\"\n");
+    ASSERT_STDOUT_EQ(r, "x=[a] y=[b c]\n");
+}
+
+TEST(rt_read_non_whitespace_ifs_not_trimmed) {
+    /// Non-whitespace IFS chars (here ':') delimit fields but are not
+    /// trimmed from the ends of a single-variable read.
+    run_result_t r = run_shell("IFS=:\n"
+                               "read -r x <<'EOF'\n"
+                               ":a:b:\n"
+                               "EOF\n"
+                               "echo \"[$x]\"\n"
+                               "unset IFS\n");
+    ASSERT_STDOUT_EQ(r, "[:a:b:]\n");
+}
+
 TEST(builtin_eval) {
     executor_t *exec = executor_new();
     ASSERT_NOT_NULL(exec, "executor_new failed");
@@ -4102,6 +4134,9 @@ int main(void) {
     RUN_TEST(builtin_export);
     RUN_TEST(builtin_unset);
     RUN_TEST(builtin_readonly);
+    RUN_TEST(rt_read_strips_leading_trailing_ifs_whitespace);
+    RUN_TEST(rt_read_multi_var_trims_trailing_ws);
+    RUN_TEST(rt_read_non_whitespace_ifs_not_trimmed);
     RUN_TEST(builtin_eval);
     RUN_TEST(builtin_shift);
     RUN_TEST(builtin_set_positional);


### PR DESCRIPTION
## Summary
- POSIX `read` ignores leading and trailing IFS white space when assigning the line to variables. The single-variable fast path assigned the whole line verbatim, so `read -r x` on `"  a b  "` kept the surrounding spaces; bash, zsh, and dash all yield `a b`. The multi-variable last field also retained trailing IFS white space.
- Add a `read_is_ifs_white` helper (a space/tab/newline that is also in IFS) and trim leading+trailing IFS white space from the single-variable value, and trailing IFS white space from the multi-variable last field. Internal IFS characters and non-whitespace IFS delimiters (e.g. `:`) are preserved.

## Verified vs bash
```
"  a b  "  read x      -> [a b]          (was [  a b])
"  a b c  " read x y   -> x=[a] y=[b c]  (trailing trimmed)
":a:b:" IFS=: read x   -> [:a:b:]        (non-ws IFS not trimmed)
"a:b:c" IFS=: read x y -> x=[a] y=[b:c]  (internal preserved)
```

## Test plan
- [x] 3 new regression tests (single-var leading+trailing trim, multi-var trailing trim with internal spaces preserved, non-whitespace-IFS no-trim)
- [x] Full suite: 118/118 meson tests pass
- [x] 0 compiler warnings (werror build)
- [x] clang-format clean
- [x] The held differential-corpus while-read seed now agrees with dash

Fixes #129

Found during differential-corpus growth.