### PR TITLE
executor: support negative length in ${var:offset:length} (#131)

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -10070,9 +10070,11 @@ static bool is_empty_or_null(const char *str) { return !str || str[0] == '\0'; }
  *
  * Implements ${var:offset:length} substring expansion. Offsets and
  * lengths are measured in Unicode grapheme clusters (TR#29), not bytes,
- * so multi-byte UTF-8 sequences are never split mid-character. Negative
- * offsets count from the end of the string in graphemes; length of -1
- * means "to end".
+ * so multi-byte UTF-8 sequences are never split mid-character. A
+ * negative offset counts from the end of the string in graphemes. A
+ * negative length is an offset from the end: the substring ends
+ * |length| graphemes before the string's end (bash semantics). When no
+ * length is given (@p has_length false), the substring runs to the end.
  *
  * Uses the project's TR#29 primitives (lle_utf8_count_graphemes +
  * slice_string_graphemes) so user content with combining marks, emoji
@@ -10081,10 +10083,12 @@ static bool is_empty_or_null(const char *str) { return !str || str[0] == '\0'; }
  *
  * @param str Source string (UTF-8)
  * @param offset Starting grapheme position (negative for from-end)
- * @param length Number of graphemes to extract (-1 for rest of string)
+ * @param length Grapheme count; negative = from-end (see above)
+ * @param has_length false when ${var:offset} was written with no length
  * @return Newly malloc'd substring (caller must free)
  */
-static char *extract_substring(const char *str, int offset, int length) {
+static char *extract_substring(const char *str, int offset, int length,
+                               bool has_length) {
     if (!str) {
         return strdup("");
     }
@@ -10102,10 +10106,25 @@ static char *extract_substring(const char *str, int offset, int length) {
         return strdup("");
     }
     int remaining = total - offset;
-    if (length < 0 || length > remaining) {
-        length = remaining;
+    int final_len;
+    if (!has_length) {
+        /// ${var:offset} -- to end.
+        final_len = remaining;
+    } else if (length < 0) {
+        /// Negative length: end |length| graphemes before the string
+        /// end, i.e. keep (remaining - |length|) graphemes. An end that
+        /// falls at or before the offset yields the empty string.
+        final_len = remaining + length;
+        if (final_len < 0) {
+            final_len = 0;
+        }
+    } else {
+        final_len = (length > remaining) ? remaining : length;
     }
-    char *result = slice_string_graphemes(str, byte_len, offset, length);
+    if (final_len <= 0) {
+        return strdup("");
+    }
+    char *result = slice_string_graphemes(str, byte_len, offset, final_len);
     return result ? result : strdup("");
 }
 
@@ -14448,13 +14467,16 @@ static char *parse_parameter_expansion(executor_t *executor,
                     expand_variables_in_string(executor, expanded_default);
                 char *endptr;
                 int offset = strtol(expanded_offset_str, &endptr, 10);
-                int length = -1;
+                int length = 0;
+                bool has_length = false;
 
                 if (*endptr == ':') {
                     length = strtol(endptr + 1, NULL, 10);
+                    has_length = true;
                 }
 
-                result = extract_substring(var_value, offset, length);
+                result =
+                    extract_substring(var_value, offset, length, has_length);
                 free(expanded_offset_str);
             } else {
                 result = strdup("");

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -1884,6 +1884,27 @@ TEST(param_substring_removal_suffix) {
     executor_free(exec);
 }
 
+TEST(param_substring_offset_length) {
+    /// ${var:offset:length} including a negative length, which is an
+    /// offset from the end (bash semantics): the result ends |length|
+    /// graphemes before the string end. Issue #131.
+    run_result_t r = run_shell("s=abcdefgh\n"
+                               "echo \"${s:2}\"\n"
+                               "echo \"${s:2:3}\"\n"
+                               "echo \"${s: -3}\"\n"
+                               "echo \"${s:1:-2}\"\n"
+                               "echo \"${s:1:-1}\"\n"
+                               "echo \"${s: -4:-1}\"\n"
+                               "echo \"[${s:2:0}]\"\n");
+    ASSERT_STDOUT_EQ(r, "cdefgh\n"
+                        "cde\n"
+                        "fgh\n"
+                        "bcdef\n"
+                        "bcdefg\n"
+                        "efg\n"
+                        "[]\n");
+}
+
 TEST(param_pattern_substitution) {
     executor_t *exec = executor_new();
     ASSERT_NOT_NULL(exec, "executor_new failed");
@@ -4167,6 +4188,7 @@ int main(void) {
     RUN_TEST(param_string_length);
     RUN_TEST(param_substring_removal_prefix);
     RUN_TEST(param_substring_removal_suffix);
+    RUN_TEST(param_substring_offset_length);
     RUN_TEST(param_pattern_substitution);
     RUN_TEST(param_global_substitution);
 


### PR DESCRIPTION
## Summary
- A negative length in substring expansion is an offset from the end of the string (bash semantics): `${s:1:-2}` keeps everything from index 1 up to two graphemes before the end. `extract_substring` collapsed any negative length to "to end" because the caller used `length=-1` as the "no length given" sentinel, which also swallowed an explicit `:-1`.
- Thread a `has_length` flag from the caller so "no length" (`${var:offset}`) is distinct from an explicit length, and compute a negative length as `remaining + length` (grapheme-counted, TR#29-aware); an end at or before the offset yields the empty string.

## Verified vs bash
```
s=abcdefgh
${s:1:-2}   -> bcdef    (was bcdefgh)
${s:1:-1}   -> bcdefg   (was bcdefgh; the ambiguous sentinel case)
${s: -4:-1} -> efg
${s:2:0}    -> (empty)
${s:2} ${s:2:3} ${s: -3} ${s: -4:2}  unchanged (already correct)
```

## Test plan
- [x] New regression test covering positive/negative offsets and lengths (incl. `:-1`, negative-offset + negative-length, zero length)
- [x] Full suite: 118/118 meson tests pass
- [x] 0 compiler warnings (werror build)
- [x] clang-format clean

Fixes #131

Found during differential-corpus growth. (An out-of-range negative length, e.g. `${s:1:-10}`, yields empty in lush where bash raises a substring-expression error; scoped as acceptable in the issue.)