### PR TITLE
LLE: read full CSI sequences so nav keys + modifier forms stop leaking

### DIFF
--- a/src/lle/lle_readline.c
+++ b/src/lle/lle_readline.c
@@ -3419,6 +3419,15 @@ char *lle_readline(const char *prompt) {
             } else if (event->data.special_key.key == LLE_KEY_DOWN) {
                 execute_keybinding_action(&ctx, "DOWN", handle_arrow_down);
             }
+            /// PageUp/PageDown move through history like UP/DOWN in the line
+            /// editor (the natural "previous/next screenful" analogue when
+            /// there is no scrollable viewport here; pager and completion
+            /// menus do their own screenful pagination).
+            else if (event->data.special_key.key == LLE_KEY_PAGE_UP) {
+                execute_keybinding_action(&ctx, "PAGEUP", handle_arrow_up);
+            } else if (event->data.special_key.key == LLE_KEY_PAGE_DOWN) {
+                execute_keybinding_action(&ctx, "PAGEDOWN", handle_arrow_down);
+            }
             /// GROUP 1 MIGRATION: Home/End keys routed through keybinding
             ///                manager
             else if (event->data.special_key.key == LLE_KEY_HOME) {

--- a/src/lle/terminal/terminal_unix_interface.c
+++ b/src/lle/terminal/terminal_unix_interface.c
@@ -1233,53 +1233,126 @@ lle_result_t lle_unix_interface_read_event(lle_unix_interface_t *interface,
             ssize_t read2 = read(interface->terminal_fd, &second_byte, 1);
 
             if (read2 == 1 && second_byte == '[') {
-                /// CSI sequence - read the final byte
-                unsigned char final_byte;
-                ssize_t read3 = read(interface->terminal_fd, &final_byte, 1);
-
-                if (read3 == 1) {
-                    /// Detect common arrow key sequences: ESC [ A/B/C/D
-                    event->type = LLE_INPUT_TYPE_SPECIAL_KEY;
-                    event->timestamp = lle_get_current_time_microseconds();
-                    event->data.special_key.modifiers = 0;
-
-                    switch (final_byte) {
-                    case 'A':
-                        event->data.special_key.key = LLE_KEY_UP;
-                        return LLE_SUCCESS;
-                    case 'B':
-                        event->data.special_key.key = LLE_KEY_DOWN;
-                        return LLE_SUCCESS;
-                    case 'C':
-                        event->data.special_key.key = LLE_KEY_RIGHT;
-                        return LLE_SUCCESS;
-                    case 'D':
-                        event->data.special_key.key = LLE_KEY_LEFT;
-                        return LLE_SUCCESS;
-                    case 'H':
-                        event->data.special_key.key = LLE_KEY_HOME;
-                        return LLE_SUCCESS;
-                    case 'F':
-                        event->data.special_key.key = LLE_KEY_END;
-                        return LLE_SUCCESS;
-                    case '3':
-                        /// Delete key: ESC [ 3 ~ - need to read the ~
-                        {
-                            unsigned char tilde;
-                            ssize_t read4 =
-                                read(interface->terminal_fd, &tilde, 1);
-                            if (read4 == 1 && tilde == '~') {
-                                event->data.special_key.key = LLE_KEY_DELETE;
-                                return LLE_SUCCESS;
-                            }
-                        }
-                        break;
-                    default:
-                        /// Unknown CSI sequence - fall through to return as
-                        /// character
+                /// CSI sequence: ESC [ <params> <final>. Read parameter and
+                /// intermediate bytes until the final byte (0x40-0x7E), so the
+                /// ENTIRE sequence is consumed. The previous reader read only
+                /// one byte after `[` and handled A/B/C/D/H/F plus a special
+                /// 3~ for Delete; every other form (PageUp ESC[5~, PageDown
+                /// ESC[6~, Insert ESC[2~, numeric Home/End ESC[1~/ESC[4~, and
+                /// all modified forms like Shift+PageUp ESC[5;2~) hit the
+                /// default case, leaving the trailing `~` / `;2~` unread to
+                /// leak into the line as literal text.
+                char csi_params[16];
+                size_t csi_len = 0;
+                unsigned char final_byte = 0;
+                bool have_final = false;
+                while (csi_len < sizeof(csi_params) - 1) {
+                    unsigned char b;
+                    if (read(interface->terminal_fd, &b, 1) != 1) {
+                        break; /// incomplete sequence; nothing leaks
+                    }
+                    if (b >= 0x40 && b <= 0x7E) {
+                        final_byte = b;
+                        have_final = true;
                         break;
                     }
+                    csi_params[csi_len++] = (char)b;
                 }
+                csi_params[csi_len] = '\0';
+
+                event->type = LLE_INPUT_TYPE_SPECIAL_KEY;
+                event->timestamp = lle_get_current_time_microseconds();
+                event->data.special_key.key = LLE_KEY_UNKNOWN;
+                event->data.special_key.modifiers = 0;
+
+                if (have_final) {
+                    /// Parse a leading numeric parameter and an optional
+                    /// ;modifier. xterm encodes the modifier as 1 + a bitmask
+                    /// (Shift=1, Alt=2, Ctrl=4): 2=Shift, 3=Alt, 5=Ctrl, ...
+                    int num = 0;
+                    int mod_param = 0;
+                    const char *p = csi_params;
+                    while (*p >= '0' && *p <= '9') {
+                        num = num * 10 + (*p - '0');
+                        p++;
+                    }
+                    if (*p == ';') {
+                        p++;
+                        while (*p >= '0' && *p <= '9') {
+                            mod_param = mod_param * 10 + (*p - '0');
+                            p++;
+                        }
+                    }
+                    if (mod_param > 1) {
+                        int bits = mod_param - 1;
+                        if (bits & 1) {
+                            event->data.special_key.modifiers |= LLE_MOD_SHIFT;
+                        }
+                        if (bits & 2) {
+                            event->data.special_key.modifiers |= LLE_MOD_ALT;
+                        }
+                        if (bits & 4) {
+                            event->data.special_key.modifiers |= LLE_MOD_CTRL;
+                        }
+                    }
+
+                    if (final_byte == '~') {
+                        /// Tilde-form keys are keyed by the numeric parameter.
+                        switch (num) {
+                        case 1:
+                        case 7:
+                            event->data.special_key.key = LLE_KEY_HOME;
+                            break;
+                        case 2:
+                            event->data.special_key.key = LLE_KEY_INSERT;
+                            break;
+                        case 3:
+                            event->data.special_key.key = LLE_KEY_DELETE;
+                            break;
+                        case 4:
+                        case 8:
+                            event->data.special_key.key = LLE_KEY_END;
+                            break;
+                        case 5:
+                            event->data.special_key.key = LLE_KEY_PAGE_UP;
+                            break;
+                        case 6:
+                            event->data.special_key.key = LLE_KEY_PAGE_DOWN;
+                            break;
+                        default:
+                            break;
+                        }
+                    } else {
+                        /// Letter-final keys (optionally ESC[1;<mod> prefixed).
+                        switch (final_byte) {
+                        case 'A':
+                            event->data.special_key.key = LLE_KEY_UP;
+                            break;
+                        case 'B':
+                            event->data.special_key.key = LLE_KEY_DOWN;
+                            break;
+                        case 'C':
+                            event->data.special_key.key = LLE_KEY_RIGHT;
+                            break;
+                        case 'D':
+                            event->data.special_key.key = LLE_KEY_LEFT;
+                            break;
+                        case 'H':
+                            event->data.special_key.key = LLE_KEY_HOME;
+                            break;
+                        case 'F':
+                            event->data.special_key.key = LLE_KEY_END;
+                            break;
+                        default:
+                            break;
+                        }
+                    }
+                }
+
+                /// Recognized or not, the whole CSI sequence has been drained.
+                /// A mapped key dispatches; an unmapped one is a no-op special
+                /// key (never inserted as text), so nothing leaks.
+                return LLE_SUCCESS;
             } else if (read2 == 1 && second_byte == 'O') {
                 /// SS3 sequence - alternate function keys
                 unsigned char final_byte;

--- a/tests/lle/unit/test_terminal_event_reading.c
+++ b/tests/lle/unit/test_terminal_event_reading.c
@@ -545,6 +545,134 @@ TEST(mixed_event_types) {
 }
 
 /* ============================================================================
+ * CSI navigation-key tests (PageUp/PageDown/Insert/Home/End + modifiers)
+ *
+ * Regression coverage for the CSI reader: the previous one-byte-after-ESC[
+ * reader handled only A/B/C/D/H/F and a special 3~ for Delete, leaving the
+ * trailing bytes of every other sequence (PageUp ESC[5~, Shift+PageUp
+ * ESC[5;2~, ...) unread to leak into the line as literal text.
+ * ============================================================================
+ */
+
+/// Feed `data` through the unix interface via a pipe and read up to
+/// `n_events` events. Returns the count of SUCCESS events read.
+static int feed_and_read_events(const void *data, size_t len,
+                                lle_input_event_t *events, int n_events) {
+    int pipe_fd = create_pipe_with_data(data, len, NULL);
+    if (pipe_fd < 0) {
+        return -1;
+    }
+    lle_unix_interface_t *interface = NULL;
+    if (lle_unix_interface_init(&interface) != LLE_SUCCESS) {
+        close(pipe_fd);
+        return -1;
+    }
+    int saved_stdin = dup(STDIN_FILENO);
+    dup2(pipe_fd, STDIN_FILENO);
+    interface->terminal_fd = STDIN_FILENO;
+
+    int got = 0;
+    for (int i = 0; i < n_events; i++) {
+        if (lle_unix_interface_read_event(interface, &events[i], 1000) !=
+            LLE_SUCCESS) {
+            break;
+        }
+        got++;
+    }
+
+    dup2(saved_stdin, STDIN_FILENO);
+    close(saved_stdin);
+    close(pipe_fd);
+    lle_unix_interface_destroy(interface);
+    return got;
+}
+
+TEST(csi_pageup) {
+    unsigned char d[] = {0x1B, '[', '5', '~'};
+    lle_input_event_t ev;
+    ASSERT(feed_and_read_events(d, sizeof(d), &ev, 1) == 1);
+    ASSERT(ev.type == LLE_INPUT_TYPE_SPECIAL_KEY);
+    ASSERT(ev.data.special_key.key == LLE_KEY_PAGE_UP);
+    ASSERT(ev.data.special_key.modifiers == 0);
+}
+
+TEST(csi_pagedown) {
+    unsigned char d[] = {0x1B, '[', '6', '~'};
+    lle_input_event_t ev;
+    ASSERT(feed_and_read_events(d, sizeof(d), &ev, 1) == 1);
+    ASSERT(ev.data.special_key.key == LLE_KEY_PAGE_DOWN);
+}
+
+TEST(csi_insert) {
+    unsigned char d[] = {0x1B, '[', '2', '~'};
+    lle_input_event_t ev;
+    ASSERT(feed_and_read_events(d, sizeof(d), &ev, 1) == 1);
+    ASSERT(ev.data.special_key.key == LLE_KEY_INSERT);
+}
+
+TEST(csi_home_numeric) {
+    unsigned char d[] = {0x1B, '[', '1', '~'};
+    lle_input_event_t ev;
+    ASSERT(feed_and_read_events(d, sizeof(d), &ev, 1) == 1);
+    ASSERT(ev.data.special_key.key == LLE_KEY_HOME);
+}
+
+TEST(csi_end_numeric) {
+    unsigned char d[] = {0x1B, '[', '4', '~'};
+    lle_input_event_t ev;
+    ASSERT(feed_and_read_events(d, sizeof(d), &ev, 1) == 1);
+    ASSERT(ev.data.special_key.key == LLE_KEY_END);
+}
+
+TEST(csi_shift_pageup_modifier) {
+    unsigned char d[] = {0x1B, '[', '5', ';', '2', '~'};
+    lle_input_event_t ev;
+    ASSERT(feed_and_read_events(d, sizeof(d), &ev, 1) == 1);
+    ASSERT(ev.data.special_key.key == LLE_KEY_PAGE_UP);
+    ASSERT((ev.data.special_key.modifiers & LLE_MOD_SHIFT) != 0);
+}
+
+TEST(csi_shift_home_letter_modifier) {
+    unsigned char d[] = {0x1B, '[', '1', ';', '2', 'H'};
+    lle_input_event_t ev;
+    ASSERT(feed_and_read_events(d, sizeof(d), &ev, 1) == 1);
+    ASSERT(ev.data.special_key.key == LLE_KEY_HOME);
+    ASSERT((ev.data.special_key.modifiers & LLE_MOD_SHIFT) != 0);
+}
+
+TEST(csi_ctrl_right_modifier) {
+    unsigned char d[] = {0x1B, '[', '1', ';', '5', 'C'};
+    lle_input_event_t ev;
+    ASSERT(feed_and_read_events(d, sizeof(d), &ev, 1) == 1);
+    ASSERT(ev.data.special_key.key == LLE_KEY_RIGHT);
+    ASSERT((ev.data.special_key.modifiers & LLE_MOD_CTRL) != 0);
+}
+
+TEST(csi_pageup_no_trailing_leak) {
+    /// The whole ESC[5~ must be consumed: the byte after it ('X') is the
+    /// next event, not a leaked '~'. This is the core regression guard.
+    unsigned char d[] = {0x1B, '[', '5', '~', 'X'};
+    lle_input_event_t ev[2];
+    ASSERT(feed_and_read_events(d, sizeof(d), ev, 2) == 2);
+    ASSERT(ev[0].type == LLE_INPUT_TYPE_SPECIAL_KEY);
+    ASSERT(ev[0].data.special_key.key == LLE_KEY_PAGE_UP);
+    ASSERT(ev[1].type == LLE_INPUT_TYPE_CHARACTER);
+    ASSERT(ev[1].data.character.codepoint == 'X');
+}
+
+TEST(csi_shift_pageup_no_trailing_leak) {
+    /// Shift+PageUp ESC[5;2~ then 'Y': the ';2~' tail must be fully
+    /// consumed, so 'Y' is the next event rather than leaked ';2~' text.
+    unsigned char d[] = {0x1B, '[', '5', ';', '2', '~', 'Y'};
+    lle_input_event_t ev[2];
+    ASSERT(feed_and_read_events(d, sizeof(d), ev, 2) == 2);
+    ASSERT(ev[0].data.special_key.key == LLE_KEY_PAGE_UP);
+    ASSERT((ev[0].data.special_key.modifiers & LLE_MOD_SHIFT) != 0);
+    ASSERT(ev[1].type == LLE_INPUT_TYPE_CHARACTER);
+    ASSERT(ev[1].data.character.codepoint == 'Y');
+}
+
+/* ============================================================================
  * TEST RUNNER
  * ============================================================================
  */
@@ -580,6 +708,18 @@ int main(void) {
     printf("\nIntegration Tests:\n");
     RUN_TEST(multiple_events_sequence);
     RUN_TEST(mixed_event_types);
+
+    printf("\nCSI Navigation Key Tests:\n");
+    RUN_TEST(csi_pageup);
+    RUN_TEST(csi_pagedown);
+    RUN_TEST(csi_insert);
+    RUN_TEST(csi_home_numeric);
+    RUN_TEST(csi_end_numeric);
+    RUN_TEST(csi_shift_pageup_modifier);
+    RUN_TEST(csi_shift_home_letter_modifier);
+    RUN_TEST(csi_ctrl_right_modifier);
+    RUN_TEST(csi_pageup_no_trailing_leak);
+    RUN_TEST(csi_shift_pageup_no_trailing_leak);
 
     return TEST_RESULT();
 }


### PR DESCRIPTION
## Problem
On a 75% keyboard, holding Shift and pressing PageUp/PageDown/Home inserts garbage (`;2~`, `;2H`, ...) into the line; plain PageUp/PageDown insert a stray `~`. The same affects End, Insert, and modified Home/End.

## Root cause
The live terminal reader (`terminal_unix_interface.c`) read only **one** byte after `ESC[` and switched on it — handling `A/B/C/D/H/F` plus a special `3~` for Delete. Every other CSI form hit the `default` case having already consumed `ESC [ <byte>` but left the rest of the sequence unread, so the trailing bytes leaked into the line as literal text:
- PageUp `ESC[5~` → leaks `~`
- Shift+PageUp `ESC[5;2~` → leaks `;2~`
- Shift+Home `ESC[1;2H` → leaks `;2H`
- PageDown, Insert, numeric Home/End, all modified nav keys → same

## Fix
Replace the one-byte reader with a full CSI reader: accumulate parameter/intermediate bytes until the final byte (`0x40–0x7E`) so the whole sequence is always drained. Parse the numeric parameter and the xterm `;modifier` (2=Shift, 3=Alt, 5=Ctrl), then map:
- tilde-form by number: `1`/`7`=Home, `2`=Insert, `3`=Delete, `4`/`8`=End, `5`=PageUp, `6`=PageDown
- letter-final: `A-D`=arrows, `H`=Home, `F`=End

with the modifier attached. A well-formed but unmapped sequence becomes a no-op special key (never leaks). PageUp/PageDown drive history previous/next in the line editor; modified nav keys perform their base action.

## Test plan
- [x] 10 new tests in `test_terminal_event_reading.c` feeding raw bytes through a pipe: PageUp/PageDown/Insert/numeric-Home/numeric-End, Shift+PageUp / Shift+Home / Ctrl+Right modifier parsing, and **two no-leak guards** (`ESC[5~X` and `ESC[5;2~Y` must yield PageUp then literal `X`/`Y`, never a leaked `~`/`;2~`)
- [x] Full suite: 118/118 meson tests pass
- [x] 0 compiler warnings (werror build); clang-format clean
- [x] Pure POSIX `select`/`read` + xterm-standard sequences — same on Linux/macOS (CI verifies Linux)

Reported from a 75% keyboard (no dedicated nav cluster). The `(lush-debug)` prompt shares this input path and benefits too.