### PR TITLE
declare: combined -i flags retain export/readonly/case attributes (#123)

### DIFF
--- a/src/builtins/bin_declare.c
+++ b/src/builtins/bin_declare.c
@@ -519,8 +519,28 @@ int bin_declare(int argc, char **argv) {
             /// Without this, `declare -i n=5; n=n+10` would only
             /// apply arithmetic to the initial 5; the n=n+10 line
             /// would store the literal string "n+10".
-            symvar_flags_t flags = symtable_get_flags(manager, name);
-            symtable_set_flags(manager, name, flags | SYMVAR_INTEGER_ATTR);
+            ///
+            /// Also carry the other attribute flags requested alongside
+            /// -i: this dedicated integer branch otherwise skipped them,
+            /// so `declare -ix n` set integer but left SYMVAR_EXPORTED
+            /// unset and ${n@a} reported "i" instead of "ix" (the actual
+            /// export still happened via the unconditional setenv below).
+            /// Issue #123.
+            symvar_flags_t flags =
+                symtable_get_flags(manager, name) | SYMVAR_INTEGER_ATTR;
+            if (opt_export) {
+                flags |= SYMVAR_EXPORTED;
+            }
+            if (opt_readonly) {
+                flags |= SYMVAR_READONLY;
+            }
+            if (opt_lowercase) {
+                flags |= SYMVAR_LOWERCASE;
+            }
+            if (opt_uppercase) {
+                flags |= SYMVAR_UPPERCASE;
+            }
+            symtable_set_flags(manager, name, flags);
         }
         /// Handle nameref declaration (-n)
         else if (opt_nameref) {

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -3197,6 +3197,18 @@ TEST(rt_pe_at_attr_query_scalar_unaffected) {
     ASSERT_STDOUT_EQ(r, "[i][r]\n");
 }
 
+TEST(rt_declare_combined_flags_attributes) {
+    /// declare with combined attribute flags including -i must record
+    /// every attribute, not just integer: ${var@a} reflects all of them
+    /// (issue #123). The integer branch previously dropped export and the
+    /// other attributes.
+    run_result_t r = run_shell("declare -ix ex=3\n"
+                               "declare -xi xe=4\n"
+                               "declare -ir ir=5\n"
+                               "echo \"[${ex@a}][${xe@a}][${ir@a}]\"\n");
+    ASSERT_STDOUT_EQ(r, "[ix][ix][ir]\n");
+}
+
 TEST(rt_pe_at_value_transform_on_map_still_errors) {
     /// Only @a bypasses the guard; a value-shaped @ transform on a bare
     /// collection remains a type error (needs [@] to vectorize).
@@ -4314,6 +4326,7 @@ int main(void) {
     RUN_TEST(rt_pe_at_attr_query_on_map);
     RUN_TEST(rt_pe_at_attr_query_on_list);
     RUN_TEST(rt_pe_at_attr_query_scalar_unaffected);
+    RUN_TEST(rt_declare_combined_flags_attributes);
     RUN_TEST(rt_pe_at_value_transform_on_map_still_errors);
     RUN_TEST(rt_pe_catalog_conditional_on_map);
     RUN_TEST(rt_pe_catalog_scalar_slice_still_works);


### PR DESCRIPTION
## Summary
- `declare`'s dedicated integer branch set `SYMVAR_INTEGER_ATTR` but skipped the other attribute flags, so `declare -ix n` recorded integer without `SYMVAR_EXPORTED` and `${n@a}` reported `i` instead of bash's `ix`.
- The variable was still actually exported (the `setenv` at the end of the loop runs unconditionally) — only the attribute *flag* was missing, which is what `${var@a}` reads.
- Apply `opt_export`/`opt_readonly`/`opt_lowercase`/`opt_uppercase` in the integer branch alongside `SYMVAR_INTEGER_ATTR`, mirroring the general declaration path.

## Verified vs bash
```
declare -ix e3=3 ; ${e3@a} -> ix   (was i)
declare -xi e4=4 ; ${e4@a} -> ix   (was i)
declare -ir ro=5 ; ${ro@a} -> ir   (was i)
declare -ix EVAR=42 -> visible in child env
declare -ir RC=10; RC=20 -> readonly-enforced
```

## Test plan
- [x] New regression test (`declare -ix`/`-xi`/`-ir` attribute strings)
- [x] Full suite: 118/118 meson tests pass
- [x] 0 warnings (werror); clang-format clean

Fixes #123

Found during differential-corpus growth.