### PR TITLE
executor: apply @U/@u/@L per element in vectorized transforms (#124)

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -14225,6 +14225,15 @@ static char *parse_parameter_expansion(executor_t *executor,
                             }
                             break;
                         }
+                        case 'U': /// uppercase all
+                            converted = convert_case_all_upper(elems[i]);
+                            break;
+                        case 'u': /// uppercase first character
+                            converted = convert_case_first_upper(elems[i]);
+                            break;
+                        case 'L': /// lowercase all
+                            converted = convert_case_all_lower(elems[i]);
+                            break;
                         case 'E': /// backslash-escape processing
                             /// Passthrough for now; per-element parity
                             /// with the scalar @E path.

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -3268,6 +3268,18 @@ TEST(rt_pe_catalog_per_element_at_q_via_slice) {
     ASSERT_STDOUT_EQ(r, "['hello' 'world']\n");
 }
 
+TEST(rt_pe_vectorized_case_transform) {
+    /// ${arr[@]@U}/@u/@L apply the case transform per element (issue
+    /// #124); previously only @Q was handled and these passed through.
+    run_result_t r = run_shell("arr=(foo Bar baz)\n"
+                               "echo \"[${arr[@]@U}]\"\n"
+                               "echo \"[${arr[@]@u}]\"\n"
+                               "echo \"[${arr[@]@L}]\"\n");
+    ASSERT_STDOUT_EQ(r, "[FOO BAR BAZ]\n"
+                        "[Foo Bar Baz]\n"
+                        "[foo bar baz]\n");
+}
+
 TEST(rt_pipeline_three_stages) {
     /// Three-stage plumbing: producer | middle | terminator. The
     /// original form used `wc -c` to count bytes, but `wc -c`
@@ -4336,6 +4348,7 @@ int main(void) {
     RUN_TEST(rt_pe_catalog_per_element_replace_first_via_slice);
     RUN_TEST(rt_pe_catalog_per_element_replace_all_via_slice);
     RUN_TEST(rt_pe_catalog_per_element_at_q_via_slice);
+    RUN_TEST(rt_pe_vectorized_case_transform);
     RUN_TEST(rt_pipeline_three_stages);
     RUN_TEST(rt_pipeline_four_stages);
     RUN_TEST(rt_pipeline_pipestatus_three_stages);


### PR DESCRIPTION
## Summary
- The per-element `${arr[@]@op}` transform switch handled `@Q` but had no cases for `@U` (upper all), `@u` (upper first), `@L` (lower all), so they fell to the default passthrough and returned each element unchanged. The scalar `@U`/`@u`/`@L` path worked; only the `[@]` vectorized form was missing.
- Route the three case codes through the existing case helpers (`convert_case_all_upper` / `convert_case_first_upper` / `convert_case_all_lower`) already used by the per-element `^^`/`,,` path.

## Verified vs bash
```
arr=(foo Bar baz)
${arr[@]@U} -> FOO BAR BAZ
${arr[@]@u} -> Foo Bar Baz
${arr[@]@L} -> foo bar baz
${arr[@]@Q} -> 'foo' 'Bar' 'baz'   (unchanged, already worked)
```

## Test plan
- [x] New regression test for `${arr[@]@U}`/`@u`/`@L`
- [x] Full suite: 118/118 meson tests pass
- [x] 0 warnings (werror); clang-format clean

Fixes #124

Found during differential-corpus growth.