### PR TITLE
LLE: enumerate setopt completion from the feature matrix via a bridge (#126)

### DIFF
--- a/src/lle/completion/builtin_completions.c
+++ b/src/lle/completion/builtin_completions.c
@@ -718,50 +718,19 @@ generate_alias_completions(lle_memory_pool_t *pool,
     return lle_completion_source_aliases(pool, context, result);
 }
 
-/**
- * @brief Shell feature names for completion
- *
- * Static list of shell feature names matching shell_mode.h.
- * This avoids linking dependency on shell_mode for test binaries.
- */
-/// setopt/unsetopt feature names offered by completion. Hand-maintained
-/// here rather than read from shell_mode.c's feature matrix because this
-/// module lives in liblle, which links standalone and must not depend on
-/// the main shell's symbols (see the lle_shell_* weak-symbol bridge). The
-/// list has drifted from the matrix over time; converting it to a
-/// weak-symbol bridge is tracked separately.
-static const char *shell_feature_names[] = {
-    /// Arrays
-    "indexed_arrays", "associative_arrays", "array_zero_indexed",
-    "array_append",
-    /// Arithmetic
-    "arith_command", "let_builtin",
-    /// Tests
-    "extended_test", "regex_match", "pattern_match",
-    /// Redirection
-    "process_substitution", "pipe_stderr", "append_both", "coproc",
-    /// Parameter expansion
-    "case_modification", "substring_expansion", "pattern_substitution",
-    "indirect_expansion", "param_transformation",
-    /// Globbing
-    "extended_glob", "null_glob", "dot_glob",
-    /// Brace expansion
-    "brace_expansion",
-    /// Control flow
-    "case_fallthrough", "select_loop", "time_keyword",
-    /// Behavior
-    "word_split_default", "auto_cd", "auto_pushd", "cdable_vars",
-    "assign_error_exits",
-    /// Advanced
-    "nameref", "anonymous_functions", "return_anywhere",
-    /// Zsh-specific
-    "glob_qualifiers", "hook_functions", "zsh_param_flags", "plugin_system",
-    NULL};
+/// Shell feature-name bridge: liblle cannot call shell_mode.c directly,
+/// so it reads the matrix through the lle_shell_feature_* weak/strong
+/// symbols (strong versions in completion_sources.c enumerate the real
+/// matrix; the weak fallbacks in completion_types.c yield nothing in a
+/// standalone liblle build).
+extern int lle_shell_feature_count(void);
+extern const char *lle_shell_feature_name(int index);
 
 /**
  * @brief Generate shell feature completions for setopt/unsetopt
  *
- * Provides completion for shell feature names.
+ * Enumerates the shell's feature matrix through the bridge so the offered
+ * names are always the single source of truth and never drift.
  */
 static lle_result_t
 generate_feature_completions(lle_memory_pool_t *pool, const char *prefix,
@@ -769,11 +738,15 @@ generate_feature_completions(lle_memory_pool_t *pool, const char *prefix,
     (void)pool; /// Completions allocated via result's pool
     size_t prefix_len = prefix ? strlen(prefix) : 0;
 
-    /// Iterate through all shell feature names
-    for (const char **name = shell_feature_names; *name != NULL; name++) {
-        if (prefix_len == 0 || strncmp(*name, prefix, prefix_len) == 0) {
+    int count = lle_shell_feature_count();
+    for (int i = 0; i < count; i++) {
+        const char *name = lle_shell_feature_name(i);
+        if (!name) {
+            continue;
+        }
+        if (prefix_len == 0 || strncmp(name, prefix, prefix_len) == 0) {
             lle_result_t res = lle_completion_result_add(
-                result, *name, " ", LLE_COMPLETION_TYPE_CUSTOM, 600);
+                result, name, " ", LLE_COMPLETION_TYPE_CUSTOM, 600);
             if (res != LLE_SUCCESS) {
                 return res;
             }

--- a/src/lle/completion/completion_types.c
+++ b/src/lle/completion/completion_types.c
@@ -27,6 +27,8 @@
 /// These will be properly integrated via completion_sources module
 extern bool lle_shell_is_builtin(const char *text);
 extern bool lle_shell_is_alias(const char *text);
+extern int lle_shell_feature_count(void);
+extern const char *lle_shell_feature_name(int index);
 
 /// ============================================================================
 /// TYPE INFORMATION DATABASE
@@ -775,6 +777,17 @@ __attribute__((weak)) bool lle_shell_is_builtin(const char *text) {
 __attribute__((weak)) bool lle_shell_is_alias(const char *text) {
     (void)text;
     return false;
+}
+
+/// Weak fallbacks for the setopt/unsetopt feature-name bridge. The
+/// strong versions in completion_sources.c enumerate the shell's feature
+/// matrix (shell_mode.c); a standalone liblle.a has no shell_mode, so
+/// completion simply offers no feature names.
+__attribute__((weak)) int lle_shell_feature_count(void) { return 0; }
+
+__attribute__((weak)) const char *lle_shell_feature_name(int index) {
+    (void)index;
+    return NULL;
 }
 
 /// Weak ASCII-only fallback for the shell identifier predicate used by

--- a/src/shell_mode.c
+++ b/src/shell_mode.c
@@ -803,6 +803,26 @@ const char *shell_feature_name(shell_feature_t feature) {
     return feature_names[feature];
 }
 
+/// Bridge for liblle's completion module. liblle links standalone and so
+/// cannot include shell_mode.h or call shell_feature_name() directly; it
+/// reaches the feature matrix through these int-typed wrappers (declared
+/// weak in src/lle/completion/completion_types.c). This strong definition
+/// is linked only into the full shell, so setopt/unsetopt completion
+/// enumerates the matrix itself -- the offered option list can never
+/// drift from shell_mode.c. A standalone liblle build gets the weak
+/// fallbacks (count 0 / name NULL) and simply offers no feature names.
+int lle_shell_feature_count(void);
+const char *lle_shell_feature_name(int index);
+
+int lle_shell_feature_count(void) { return (int)FEATURE_COUNT; }
+
+const char *lle_shell_feature_name(int index) {
+    if (index < 0 || index >= (int)FEATURE_COUNT) {
+        return NULL;
+    }
+    return shell_feature_name((shell_feature_t)index);
+}
+
 bool shell_mode_feature_default(shell_mode_t mode, shell_feature_t feature) {
     if (mode >= SHELL_MODE_COUNT || feature >= FEATURE_COUNT) {
         return false;

--- a/tests/lle/unit/test_completion_types.c
+++ b/tests/lle/unit/test_completion_types.c
@@ -210,6 +210,17 @@ TEST(error_handling) {
     ASSERT(result == LLE_ERROR_INVALID_PARAMETER);
 }
 
+TEST(feature_bridge_weak_fallback) {
+    /// In a standalone liblle build (no shell_mode.c) the setopt feature
+    /// bridge resolves to its weak fallbacks: zero features, NULL names.
+    /// This is the path that keeps completion linking without the shell.
+    extern int lle_shell_feature_count(void);
+    extern const char *lle_shell_feature_name(int index);
+    ASSERT(lle_shell_feature_count() == 0);
+    ASSERT(lle_shell_feature_name(0) == NULL);
+    ASSERT(lle_shell_feature_name(-1) == NULL);
+}
+
 int main(void) {
     printf("=== LLE Completion Types Unit Tests ===\n");
     RUN_TEST(type_info_queries);
@@ -219,5 +230,6 @@ int main(void) {
     RUN_TEST(completion_result_sorting);
     RUN_TEST(classification);
     RUN_TEST(error_handling);
+    RUN_TEST(feature_bridge_weak_fallback);
     return TEST_RESULT();
 }

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -3209,6 +3209,31 @@ TEST(rt_declare_combined_flags_attributes) {
     ASSERT_STDOUT_EQ(r, "[ix][ix][ir]\n");
 }
 
+TEST(rt_lle_feature_bridge_enumerates_matrix) {
+    /// setopt/unsetopt completion enumerates the feature matrix through
+    /// this bridge instead of a hand-maintained list, so it can never
+    /// drift (issue #126). Names the old static completion list omitted
+    /// must be reachable through the bridge.
+    extern int lle_shell_feature_count(void);
+    extern const char *lle_shell_feature_name(int index);
+    int n = lle_shell_feature_count();
+    ASSERT_TRUE(n > 30, "feature matrix should expose many features");
+    bool found_errexit = false;
+    bool found_xpg = false;
+    for (int i = 0; i < n; i++) {
+        const char *nm = lle_shell_feature_name(i);
+        if (nm && strcmp(nm, "errexit_in_loops") == 0) {
+            found_errexit = true;
+        }
+        if (nm && strcmp(nm, "xpg_echo") == 0) {
+            found_xpg = true;
+        }
+    }
+    ASSERT_TRUE(found_errexit,
+                "errexit_in_loops must be enumerable via the bridge");
+    ASSERT_TRUE(found_xpg, "xpg_echo must be enumerable via the bridge");
+}
+
 TEST(rt_pe_at_value_transform_on_map_still_errors) {
     /// Only @a bypasses the guard; a value-shaped @ transform on a bare
     /// collection remains a type error (needs [@] to vectorize).
@@ -4339,6 +4364,7 @@ int main(void) {
     RUN_TEST(rt_pe_at_attr_query_on_list);
     RUN_TEST(rt_pe_at_attr_query_scalar_unaffected);
     RUN_TEST(rt_declare_combined_flags_attributes);
+    RUN_TEST(rt_lle_feature_bridge_enumerates_matrix);
     RUN_TEST(rt_pe_at_value_transform_on_map_still_errors);
     RUN_TEST(rt_pe_catalog_conditional_on_map);
     RUN_TEST(rt_pe_catalog_scalar_slice_still_works);

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -13,6 +13,9 @@
 #include "executor.h"
 #include "identifier.h"
 #include "lle/buffer_management.h"
+#include "lle/completion/builtin_completions.h"
+#include "lle/completion/completion_types.h"
+#include "lle/completion/word_context.h"
 #include "lle/lle_editor.h"
 #include "lle/syntax_highlighting.h"
 #include "symtable.h"
@@ -3234,6 +3237,35 @@ TEST(rt_lle_feature_bridge_enumerates_matrix) {
     ASSERT_TRUE(found_xpg, "xpg_echo must be enumerable via the bridge");
 }
 
+TEST(rt_setopt_completion_lists_matrix_features) {
+    /// End-to-end: setopt completion routes through the bridge and offers
+    /// names from the live feature matrix, including ones the old static
+    /// completion list omitted (issue #126). Drives the public builtin
+    /// completion entry with a minimal "setopt err" context.
+    lle_memory_pool_t *pool = (lle_memory_pool_t *)1; /// LLE pool sentinel
+    lle_completion_result_t *result = NULL;
+    lle_result_t r = lle_completion_result_create(pool, 8, &result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "completion result create");
+
+    lle_word_context_t ctx;
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.command_name = "setopt";
+    ctx.dequoted_filename_prefix = (char *)"err";
+
+    r = lle_builtin_completions_generate(pool, &ctx, result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "builtin completions generate");
+
+    bool found = false;
+    for (size_t i = 0; i < result->count; i++) {
+        if (result->items[i].text &&
+            strcmp(result->items[i].text, "errexit_in_loops") == 0) {
+            found = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(found, "setopt completion must offer errexit_in_loops");
+}
+
 TEST(rt_pe_at_value_transform_on_map_still_errors) {
     /// Only @a bypasses the guard; a value-shaped @ transform on a bare
     /// collection remains a type error (needs [@] to vectorize).
@@ -4365,6 +4397,7 @@ int main(void) {
     RUN_TEST(rt_pe_at_attr_query_scalar_unaffected);
     RUN_TEST(rt_declare_combined_flags_attributes);
     RUN_TEST(rt_lle_feature_bridge_enumerates_matrix);
+    RUN_TEST(rt_setopt_completion_lists_matrix_features);
     RUN_TEST(rt_pe_at_value_transform_on_map_still_errors);
     RUN_TEST(rt_pe_catalog_conditional_on_map);
     RUN_TEST(rt_pe_catalog_scalar_slice_still_works);


### PR DESCRIPTION
## Summary
- The `setopt`/`unsetopt` completion list in `builtin_completions.c` was a hand-maintained static array that had drifted from the feature matrix in `shell_mode.c` — ~15 valid option names (`errexit_in_loops`, `xpg_echo`, `share_history`, `kind_sigils`, `unicode_identifiers`, …) were missing from completion. `setopt` with no args already enumerated the matrix correctly; only completion kept a stale copy, because liblle links standalone and cannot call `shell_mode.c` directly.
- Add an `lle_shell_feature_count` / `lle_shell_feature_name` bridge following the existing `lle_shell_*` weak/strong pattern: weak fallbacks (0 / NULL) in `completion_types.c` keep standalone liblle linking; strong definitions in `shell_mode.c` (full-shell only) enumerate the real matrix. Completion reads through the bridge and the static list is deleted — the option set is the matrix itself and can never drift again.
- The strong bridge lives in `src/shell_mode.c` rather than liblle's `completion_sources.c` (where `lle_shell_is_builtin` sits and forces every liblle-only test to stub `builtins[]`), so **no new per-test stub is required**.

## Verified
- `setopt` (live) now lists 54 options including the previously-missing ones.
- Full suite: 118/118 meson tests pass; standalone liblle completion tests link via the weak fallback.

## Test plan
- [x] Full-shell-linked guard asserts the bridge enumerates the matrix and surfaces `errexit_in_loops` / `xpg_echo`
- [x] 0 warnings (werror); clang-format clean

Fixes #126