### PR TITLE
LLE: enumerate the keybinding hashtable; drop false libhashtable-bug claims

### DIFF
--- a/include/lle/hashtable.h
+++ b/include/lle/hashtable.h
@@ -157,8 +157,9 @@ struct lle_strstr_hashtable {
     pthread_rwlock_t *lock;                       ///< Thread safety lock
     bool is_concurrent;                           ///< Thread-safe flag
     const char *name;                             ///< Hashtable name
-    size_t entry_count; /**< Entry count (workaround for libhashtable
-                           enumeration bug) */
+    size_t entry_count; ///< Cached entry count: libhashtable exposes no
+                        ///< O(1) size query, so the wrapper tracks it on
+                        ///< insert/delete for lle_strstr_hashtable_size().
 };
 
 /**
@@ -172,8 +173,9 @@ struct lle_generic_hashtable {
     pthread_rwlock_t *lock;                       ///< Thread safety lock
     bool is_concurrent;                           ///< Thread-safe flag
     const char *name;                             ///< Hashtable name
-    size_t entry_count; /**< Entry count (workaround for libhashtable
-                           enumeration bug) */
+    size_t entry_count; ///< Cached entry count: libhashtable exposes no
+                        ///< O(1) size query, so the wrapper tracks it on
+                        ///< insert/delete.
 };
 
 /**
@@ -311,6 +313,27 @@ size_t lle_strstr_hashtable_size(lle_strstr_hashtable_t *ht);
  * @brief Clear all entries
  */
 void lle_strstr_hashtable_clear(lle_strstr_hashtable_t *ht);
+
+/**
+ * @brief Visitor callback for lle_strstr_hashtable_foreach()
+ */
+typedef void (*lle_strstr_hashtable_visit_fn)(const char *key,
+                                              const char *value,
+                                              void *user_data);
+
+/**
+ * @brief Invoke @p cb for every key/value pair in the table.
+ *
+ * Walks the table via libhashtable's ht_strstr_enum API under the read
+ * lock (when thread-safe). The callback must not mutate the table.
+ *
+ * @param ht Hashtable (NULL is a no-op)
+ * @param cb Visitor invoked as cb(key, value, user_data)
+ * @param user_data Opaque pointer forwarded to the visitor
+ */
+void lle_strstr_hashtable_foreach(lle_strstr_hashtable_t *ht,
+                                  lle_strstr_hashtable_visit_fn cb,
+                                  void *user_data);
 
 /**
  * @brief Destroy hashtable

--- a/src/lle/core/hashtable.c
+++ b/src/lle/core/hashtable.c
@@ -906,6 +906,35 @@ void lle_strstr_hashtable_clear(lle_strstr_hashtable_t *ht) {
     }
 }
 
+void lle_strstr_hashtable_foreach(lle_strstr_hashtable_t *ht,
+                                  lle_strstr_hashtable_visit_fn cb,
+                                  void *user_data) {
+    if (!ht || !cb) {
+        return;
+    }
+
+    /// Read lock for the duration of the walk (Phase 2 thread-safety).
+    if (ht->is_concurrent && ht->lock) {
+        pthread_rwlock_rdlock(ht->lock);
+    }
+
+    /// libhashtable's ht_strstr_enum walks every live entry; the same
+    /// API backs lle_strstr_hashtable_clear() above and the associative-
+    /// array iteration in the executor, so it is exercised continuously.
+    ht_enum_t *enumerator = ht_strstr_enum_create(ht->ht);
+    if (enumerator) {
+        const char *key, *value;
+        while (ht_strstr_enum_next(enumerator, &key, &value)) {
+            cb(key, value, user_data);
+        }
+        ht_strstr_enum_destroy(enumerator);
+    }
+
+    if (ht->is_concurrent && ht->lock) {
+        pthread_rwlock_unlock(ht->lock);
+    }
+}
+
 /**
  * @brief Destroy a string-to-string hashtable and free all resources
  * @param ht Hashtable to destroy (may be NULL)

--- a/src/lle/keybinding/keybinding.c
+++ b/src/lle/keybinding/keybinding.c
@@ -1119,6 +1119,34 @@ lle_result_t lle_keybinding_manager_load_vi_insert_preset(
  * @param count_out Pointer to store the count of bindings
  * @return LLE_SUCCESS on success, error code on failure
  */
+/// Fill context for lle_keybinding_manager_list_bindings()'s enumeration.
+typedef struct {
+    lle_keybinding_info_t *bindings; ///< Caller-allocated output array
+    size_t capacity;                 ///< Number of slots in @c bindings
+    size_t index;                    ///< Next slot to write
+} list_bindings_fill_t;
+
+/// Visitor: each hashtable value is a "%p" pointer to the entry; copy its
+/// key sequence and action metadata into the next output slot.
+static void list_bindings_visit(const char *key, const char *value,
+                                void *user_data) {
+    list_bindings_fill_t *fill = (list_bindings_fill_t *)user_data;
+    if (fill->index >= fill->capacity) {
+        return;
+    }
+    lle_keybinding_entry_t *entry = NULL;
+    if (sscanf(value, "%p", (void **)&entry) != 1 || entry == NULL) {
+        return;
+    }
+    lle_keybinding_info_t *info = &fill->bindings[fill->index];
+    memset(info, 0, sizeof(*info));
+    snprintf(info->key_sequence, sizeof(info->key_sequence), "%s", key);
+    info->action = entry->action;
+    info->function_name = entry->function_name;
+    info->mode = entry->mode;
+    fill->index++;
+}
+
 lle_result_t
 lle_keybinding_manager_list_bindings(lle_keybinding_manager_t *manager,
                                      lle_keybinding_info_t **bindings_out,
@@ -1149,11 +1177,16 @@ lle_keybinding_manager_list_bindings(lle_keybinding_manager_t *manager,
         return LLE_ERROR_OUT_OF_MEMORY;
     }
 
-    /// Note: We would need to enumerate the hashtable here, but libhashtable's
-    /// enumeration is buggy according to the LLE wrapper. For now, return
-    /// empty.
+    /// Enumerate the bindings table and copy each entry into the output
+    /// array. ht_strstr_enum (via lle_strstr_hashtable_foreach) walks the
+    /// table reliably -- the same API backs the wrapper's clear() and the
+    /// executor's associative-array iteration.
+    list_bindings_fill_t fill = {
+        .bindings = bindings, .capacity = count, .index = 0};
+    lle_strstr_hashtable_foreach(manager->bindings, list_bindings_visit, &fill);
+
     *bindings_out = bindings;
-    *count_out = 0;
+    *count_out = fill.index;
 
     return LLE_SUCCESS;
 }

--- a/tests/lle/unit/test_keybinding.c
+++ b/tests/lle/unit/test_keybinding.c
@@ -264,6 +264,43 @@ TEST(bind_multiple_keys) {
     lle_keybinding_manager_destroy(manager);
 }
 
+TEST(list_bindings_enumerates) {
+    /// list_bindings must enumerate the bindings hashtable, not return an
+    /// empty set: ht_strstr_enum walks the table reliably.
+    lle_keybinding_manager_t *manager = NULL;
+    lle_result_t result = lle_keybinding_manager_create(&manager, NULL);
+    ASSERT(result == LLE_SUCCESS, "Create failed");
+
+    lle_keybinding_manager_bind(manager, "C-a", test_action,
+                                "beginning-of-line");
+    lle_keybinding_manager_bind(manager, "C-e", test_action, "end-of-line");
+    lle_keybinding_manager_bind(manager, "M-f", test_action, "forward-word");
+
+    lle_keybinding_info_t *bindings = NULL;
+    size_t count = 0;
+    result = lle_keybinding_manager_list_bindings(manager, &bindings, &count);
+    ASSERT(result == LLE_SUCCESS, "list_bindings failed");
+    ASSERT_EQ(count, 3, "list_bindings should return all three bindings");
+    ASSERT(bindings != NULL, "bindings array should be non-NULL");
+
+    bool seen_ca = false, seen_ce = false, seen_mf = false;
+    for (size_t i = 0; i < count; i++) {
+        if (strcmp(bindings[i].key_sequence, "C-a") == 0) {
+            seen_ca = true;
+        } else if (strcmp(bindings[i].key_sequence, "C-e") == 0) {
+            seen_ce = true;
+        } else if (strcmp(bindings[i].key_sequence, "M-f") == 0) {
+            seen_mf = true;
+        }
+    }
+    ASSERT(seen_ca && seen_ce && seen_mf,
+           "every bound sequence must appear in the list");
+
+    /// NULL pool -> list_bindings used malloc.
+    free(bindings);
+    lle_keybinding_manager_destroy(manager);
+}
+
 TEST(unbind_key) {
     lle_keybinding_manager_t *manager = NULL;
     lle_result_t result;
@@ -461,6 +498,7 @@ int main(void) {
     printf("\nKeybinding Operations Tests:\n");
     RUN_TEST(bind_and_lookup);
     RUN_TEST(bind_multiple_keys);
+    RUN_TEST(list_bindings_enumerates);
     RUN_TEST(unbind_key);
     RUN_TEST(lookup_nonexistent_key);
 


### PR DESCRIPTION
## Problem
`lle_keybinding_manager_list_bindings` allocated its output array, then returned an **empty** list with a comment claiming libhashtable's enumeration was buggy. It is not — `ht_strstr_enum` already backs the wrapper's own `lle_strstr_hashtable_clear()` and the executor's associative-array iteration. As a result the user-facing keybinding listing (`display lle keybinding`, `src/builtins/display/lle_keybindings.c`) rendered empty Navigation/Editing/History sections.

## Fix
- Add `lle_strstr_hashtable_foreach()` — a read-locked `ht_strstr_enum` walk mirroring the wrapper's existing `clear()` — and use it to populate `list_bindings` from the stored entries.
- Correct the false "enumeration bug" comments on the two wrapper structs: `entry_count` is a size cache because libhashtable exposes no O(1) size query, not an enumeration workaround.

## Notes
Swept `src/`, `include/`, `docs/` — no other false libhashtable-bug claims remain.

## Test plan
- [x] New `list_bindings_enumerates` test: bind three keys, list them, assert all three sequences come back (18/18 keybinding tests pass)
- [x] Full suite: 118/118 meson tests pass
- [x] 0 warnings (werror); clang-format clean; `///<` trailing-comment style