### PR TITLE
Implement zsh parameter modifiers ${var:h:t:r:e...} (#132)

### DIFF
--- a/include/shell_mode.h
+++ b/include/shell_mode.h
@@ -186,6 +186,17 @@ typedef enum {
                                 ///< across modes. Toggleable per-script via
                                 ///< setopt/unsetopt.
 
+    FEATURE_ZSH_PARAM_MODIFIERS, ///< zsh `${var:h}` history-style modifier
+                                 ///< family (:h head, :t tail, :r root,
+                                 ///< :e ext, :l/:u case, :q quote,
+                                 ///< :s/old/new/ and :gs/old/new/), with
+                                 ///< chaining (${var:t:r}). On in zsh and
+                                 ///< lush modes; OFF in bash and posix,
+                                 ///< where ${var:x} is substring-offset
+                                 ///< expansion and a leading letter would
+                                 ///< otherwise change meaning. setopt name
+                                 ///< `zsh_param_modifiers`.
+
     /// Sentinel - must be last
     FEATURE_COUNT ///< Number of features (for array sizing)
 } shell_feature_t;

--- a/src/executor.c
+++ b/src/executor.c
@@ -11931,12 +11931,228 @@ static const char *find_op_outside_brackets(const char *haystack,
             }
             continue;
         }
+        if (p[0] == '$' && p[1] == '{') {
+            /// Skip a nested ${...} so an operator inside it is not
+            /// mistaken for this expansion's operator -- the inner ':'
+            /// of ${${p:t}:r} must not hide the outer ':r'.
+            int depth = 1;
+            p += 2;
+            while (*p && depth > 0) {
+                if (*p == '{') {
+                    depth++;
+                } else if (*p == '}') {
+                    depth--;
+                }
+                p++;
+            }
+            continue;
+        }
         if (strncmp(p, needle, needle_len) == 0) {
             return p;
         }
         p++;
     }
     return NULL;
+}
+
+/// zsh `:h` (head / dirname): everything up to the last '/'. No slash
+/// yields "." (a relative name has no directory part).
+static char *zsh_mod_head(const char *v) {
+    const char *slash = strrchr(v, '/');
+    if (!slash) {
+        return strdup(".");
+    }
+    if (slash == v) {
+        return strdup("/"); /// "/foo" -> "/"
+    }
+    size_t n = (size_t)(slash - v);
+    char *r = malloc(n + 1);
+    if (r) {
+        memcpy(r, v, n);
+        r[n] = '\0';
+    }
+    return r;
+}
+
+/// zsh `:t` (tail / basename): everything after the last '/'.
+static char *zsh_mod_tail(const char *v) {
+    const char *slash = strrchr(v, '/');
+    return strdup(slash ? slash + 1 : v);
+}
+
+/// Locate the extension dot in the tail component: the last '.' that is
+/// after the last '/' and not the leading character of the tail (so a
+/// dotfile like ".bashrc" has no extension). Returns NULL when none.
+static const char *zsh_ext_dot(const char *v) {
+    const char *slash = strrchr(v, '/');
+    const char *base = slash ? slash + 1 : v;
+    const char *dot = strrchr(base, '.');
+    if (!dot || dot == base) {
+        return NULL;
+    }
+    return dot;
+}
+
+/// zsh `:r` (root): strip the last extension (".gz" off "x.tar.gz").
+static char *zsh_mod_root(const char *v) {
+    const char *dot = zsh_ext_dot(v);
+    if (!dot) {
+        return strdup(v);
+    }
+    size_t n = (size_t)(dot - v);
+    char *r = malloc(n + 1);
+    if (r) {
+        memcpy(r, v, n);
+        r[n] = '\0';
+    }
+    return r;
+}
+
+/// zsh `:e` (extension): the text after the last extension dot, or "".
+static char *zsh_mod_ext(const char *v) {
+    const char *dot = zsh_ext_dot(v);
+    return strdup(dot ? dot + 1 : "");
+}
+
+/// zsh `:q` (quote): backslash-escape characters that are not safe bare,
+/// so the result re-evaluates to the original (zsh emits "Hello\ World",
+/// not the single-quoted form bash's @Q uses). UTF-8 continuation bytes
+/// (>= 0x80) are left intact so multibyte characters are not mangled.
+static char *zsh_mod_quote(const char *v) {
+    size_t len = strlen(v);
+    char *r = malloc(len * 2 + 1);
+    if (!r) {
+        return NULL;
+    }
+    size_t j = 0;
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)v[i];
+        bool safe = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                    (c >= '0' && c <= '9') || c == '/' || c == '.' ||
+                    c == '_' || c == '-' || c == '+' || c == ',' || c >= 0x80;
+        if (!safe) {
+            r[j++] = '\\';
+        }
+        r[j++] = (char)c;
+    }
+    r[j] = '\0';
+    return r;
+}
+
+/// Apply a zsh modifier chain (the argument after the first ':' in
+/// ${var:...}) to @p value. Supports h/t/r/e (path), l/u (case),
+/// q (quote), and s/old/new/ plus gs/old/new/ (substitute, optional g
+/// for global), separated or run together (e.g. "t:r" or "h:h").
+/// Returns a newly malloc'd string; the caller frees. Unknown modifier
+/// letters are skipped (zsh would error; we degrade gracefully).
+static char *apply_zsh_modifiers(executor_t *executor, const char *value,
+                                 const char *chain) {
+    (void)executor;
+    char *cur = strdup(value ? value : "");
+    if (!cur) {
+        return NULL;
+    }
+    const char *p = chain;
+    while (p && *p) {
+        if (*p == ':') {
+            p++;
+            continue;
+        }
+        char m = *p;
+        char *next = NULL;
+        if (m == 'h') {
+            next = zsh_mod_head(cur);
+            p++;
+        } else if (m == 't') {
+            next = zsh_mod_tail(cur);
+            p++;
+        } else if (m == 'r') {
+            next = zsh_mod_root(cur);
+            p++;
+        } else if (m == 'e') {
+            next = zsh_mod_ext(cur);
+            p++;
+        } else if (m == 'l') {
+            next = convert_case_all_lower(cur);
+            p++;
+        } else if (m == 'u') {
+            next = convert_case_all_upper(cur);
+            p++;
+        } else if (m == 'q') {
+            next = zsh_mod_quote(cur);
+            p++;
+        } else if (m == 's' || (m == 'g' && p[1] == 's')) {
+            bool global = (m == 'g');
+            if (global) {
+                p++; /// past 'g'
+            }
+            p++; /// past 's'
+            if (!*p) {
+                break; /// malformed: no delimiter
+            }
+            char delim = *p++;
+            const char *old_start = p;
+            while (*p && *p != delim) {
+                p++;
+            }
+            if (*p != delim) {
+                break; /// malformed: unterminated old
+            }
+            size_t old_len = (size_t)(p - old_start);
+            p++; /// past middle delim
+            const char *new_start = p;
+            while (*p && *p != delim) {
+                p++;
+            }
+            size_t new_len = (size_t)(p - new_start);
+            if (*p == delim) {
+                p++; /// optional trailing delim
+            }
+            char *oldp = malloc(old_len + 1);
+            char *newp = malloc(new_len + 1);
+            if (oldp && newp) {
+                memcpy(oldp, old_start, old_len);
+                oldp[old_len] = '\0';
+                memcpy(newp, new_start, new_len);
+                newp[new_len] = '\0';
+                next = pattern_substitute(cur, oldp, newp, global);
+            }
+            free(oldp);
+            free(newp);
+        } else {
+            /// Unknown modifier letter: skip it.
+            p++;
+            continue;
+        }
+        if (next) {
+            free(cur);
+            cur = next;
+        }
+    }
+    return cur;
+}
+
+/// True if the argument after ':' in ${var:...} is a zsh modifier chain
+/// (leads with a modifier letter) rather than a substring offset (which
+/// begins with a digit, sign, space, or arithmetic paren).
+static bool looks_like_zsh_modifier(const char *arg) {
+    if (!arg) {
+        return false;
+    }
+    switch (arg[0]) {
+    case 'h':
+    case 't':
+    case 'r':
+    case 'e':
+    case 'l':
+    case 'u':
+    case 'q':
+    case 's':
+    case 'g':
+        return true;
+    default:
+        return false;
+    }
 }
 
 static char *parse_parameter_expansion(executor_t *executor,
@@ -14003,8 +14219,15 @@ static char *parse_parameter_expansion(executor_t *executor,
             }
         }
 
-        /// Get variable value
-        char *var_value = symtable_get_var(executor->symtable, var_name);
+        /// Get variable value. A nested expansion in the name position
+        /// (${${inner}:op}) is expanded first so the outer operator or
+        /// modifier applies to the inner result, e.g. ${${p:t}:r}.
+        char *var_value;
+        if (var_name[0] == '$' && var_name[1] == '{') {
+            var_value = expand_variable(executor, var_name);
+        } else {
+            var_value = symtable_get_var(executor->symtable, var_name);
+        }
         const char *default_value = op_pos + strlen(operators[op_type]);
 
         /// Expand variables in default value
@@ -14469,8 +14692,15 @@ static char *parse_parameter_expansion(executor_t *executor,
             }
             break;
 
-        case 14: /// ${var:offset:length} - substring expansion
-            if (var_value) {
+        case 14: /// ${var:offset:length} substring, or ${var:h...} modifiers
+            if (var_value && shell_mode_allows(FEATURE_ZSH_PARAM_MODIFIERS) &&
+                looks_like_zsh_modifier(expanded_default)) {
+                /// zsh modifier chain (:h, :t, :r, :e, :l, :u, :q, :s///,
+                /// :gs///). The leading char is a modifier letter, which is
+                /// never a valid substring offset (those are numeric).
+                result =
+                    apply_zsh_modifiers(executor, var_value, expanded_default);
+            } else if (var_value) {
                 /// Parse offset and optional length (with variable expansion)
                 char *expanded_offset_str =
                     expand_variables_in_string(executor, expanded_default);

--- a/src/shell_mode.c
+++ b/src/shell_mode.c
@@ -100,6 +100,8 @@ static const bool feature_matrix[SHELL_MODE_COUNT][FEATURE_COUNT] = {
                 false, /// POSIX permits failing loop bodies; do not deviate
             [FEATURE_ASSIGN_ERROR_EXITS] =
                 true, /// POSIX 2.8.1: assignment error exits non-interactive sh
+            [FEATURE_ZSH_PARAM_MODIFIERS] =
+                false,                 /// ${var:x} is substring-offset in POSIX
             [FEATURE_XPG_ECHO] = true, /// POSIX XSI mandates escape interp
 
             /// History Behavior
@@ -189,6 +191,8 @@ static const bool feature_matrix[SHELL_MODE_COUNT][FEATURE_COUNT] = {
             [FEATURE_ASSIGN_ERROR_EXITS] =
                 false, /// bash continues after a readonly assignment error,
                        /// aborting only the current AND-OR list
+            [FEATURE_ZSH_PARAM_MODIFIERS] =
+                false,                  /// ${var:x} is substring-offset in bash
             [FEATURE_XPG_ECHO] = false, /// shopt xpg_echo, off by default
 
             /// History Behavior
@@ -281,6 +285,7 @@ static const bool feature_matrix[SHELL_MODE_COUNT][FEATURE_COUNT] = {
             [FEATURE_ASSIGN_ERROR_EXITS] =
                 true, /// zsh exits a non-interactive shell on a readonly
                       /// assignment error, like dash; match it in zsh mode
+            [FEATURE_ZSH_PARAM_MODIFIERS] = true, /// native zsh modifiers
             [FEATURE_XPG_ECHO] = true, /* zsh: BSD_ECHO off → escapes interp'd
                             by default in zsh's echo builtin */
 
@@ -384,6 +389,11 @@ static const bool feature_matrix[SHELL_MODE_COUNT][FEATURE_COUNT] = {
                             stops the dangerous `||` fallthrough. Opt into the
                             strict posix/zsh behavior with
                             `setopt assign_error_exits`. */
+            [FEATURE_ZSH_PARAM_MODIFIERS] =
+                true, /* Curated: the zsh ${var:h/t/r/e/...} modifiers are a
+                            genuinely useful, terse path/string toolkit, and a
+                            leading modifier letter never collides with a valid
+                            substring offset (which is numeric). On in lush. */
             [FEATURE_XPG_ECHO] =
                 true, /* Curated zsh-style: echo interprets escapes by
                             default. More predictable and modern than bash's
@@ -496,6 +506,7 @@ static const char *feature_names[FEATURE_COUNT] = {
     [FEATURE_CDABLE_VARS] = "cdable_vars",
     [FEATURE_ERREXIT_IN_LOOPS] = "errexit_in_loops",
     [FEATURE_ASSIGN_ERROR_EXITS] = "assign_error_exits",
+    [FEATURE_ZSH_PARAM_MODIFIERS] = "zsh_param_modifiers",
     [FEATURE_XPG_ECHO] = "xpg_echo",
 
     /// History Behavior

--- a/tests/fuzz/differential/corpus/zsh/324_zsh_modifiers.sh
+++ b/tests/fuzz/differential/corpus/zsh/324_zsh_modifiers.sh
@@ -1,0 +1,14 @@
+# Zsh history-style parameter modifiers: head/tail/root/ext, case,
+# quote, substitute, and chained/nested composition.
+p=/usr/local/bin/script.tar.gz
+echo "h: ${p:h}"
+echo "t: ${p:t}"
+echo "r: ${p:r}"
+echo "e: ${p:e}"
+echo "chain: ${p:t:r}"
+echo "nest: ${${p:t}:r}"
+s="Hello World"
+echo "l: ${s:l}"
+echo "u: ${s:u}"
+echo "subst: ${p:s/local/LOCAL/}"
+echo "gsubst: ${p:gs/o/0/}"

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -1908,6 +1908,62 @@ TEST(param_substring_offset_length) {
                         "[]\n");
 }
 
+TEST(rt_zsh_modifier_path_parts) {
+    /// zsh :h/:t/:r/:e path modifiers (issue #132).
+    run_result_t r = run_shell("mode zsh\n"
+                               "p=/usr/local/bin/script.tar.gz\n"
+                               "echo \"${p:h}|${p:t}|${p:r}|${p:e}\"\n");
+    run_shell("mode lush\n");
+    ASSERT_STDOUT_EQ(
+        r, "/usr/local/bin|script.tar.gz|/usr/local/bin/script.tar|gz\n");
+}
+
+TEST(rt_zsh_modifier_case_and_quote) {
+    /// :l/:u case modifiers and :q (backslash quoting, zsh style).
+    run_result_t r = run_shell("mode zsh\n"
+                               "s=\"Hello World\"\n"
+                               "echo \"${s:l}|${s:u}|${s:q}\"\n");
+    run_shell("mode lush\n");
+    ASSERT_STDOUT_EQ(r, "hello world|HELLO WORLD|Hello\\ World\n");
+}
+
+TEST(rt_zsh_modifier_substitute) {
+    /// :s/old/new/ (first) and :gs/old/new/ (global).
+    run_result_t r = run_shell("mode zsh\n"
+                               "p=/usr/local/bin\n"
+                               "echo \"${p:s/local/LOCAL/}|${p:gs/o/0/}\"\n");
+    run_shell("mode lush\n");
+    ASSERT_STDOUT_EQ(r, "/usr/LOCAL/bin|/usr/l0cal/bin\n");
+}
+
+TEST(rt_zsh_modifier_chain_and_nest) {
+    /// Chained (:t:r) and nested (${${p:t}:r}) modifiers compose.
+    run_result_t r = run_shell("mode zsh\n"
+                               "p=/usr/local/bin/script.tar.gz\n"
+                               "echo \"${p:t:r}|${${p:t}:r}|${${p:h}:t}\"\n");
+    run_shell("mode lush\n");
+    ASSERT_STDOUT_EQ(r, "script.tar|script.tar|bin\n");
+}
+
+TEST(rt_zsh_modifier_off_in_bash_is_substring) {
+    /// In bash mode ${var:h} is substring-offset (h parses as 0), not a
+    /// modifier, so the whole value is returned -- matching bash.
+    run_result_t r = run_shell("mode bash\n"
+                               "p=/usr/local/bin\n"
+                               "echo \"${p:h}\"\n");
+    run_shell("mode lush\n");
+    ASSERT_STDOUT_EQ(r, "/usr/local/bin\n");
+}
+
+TEST(rt_zsh_modifier_numeric_arg_still_substring) {
+    /// Even in zsh mode a numeric argument is substring, not a modifier.
+    run_result_t r = run_shell("mode zsh\n"
+                               "s=abcdef\n"
+                               "echo \"${s:2}|${s:1:3}\"\n");
+    run_shell("mode lush\n");
+    ASSERT_STDOUT_EQ(r, "cdef|bcd\n");
+}
+
 TEST(param_pattern_substitution) {
     executor_t *exec = executor_new();
     ASSERT_NOT_NULL(exec, "executor_new failed");
@@ -4270,6 +4326,12 @@ int main(void) {
     RUN_TEST(param_substring_removal_prefix);
     RUN_TEST(param_substring_removal_suffix);
     RUN_TEST(param_substring_offset_length);
+    RUN_TEST(rt_zsh_modifier_path_parts);
+    RUN_TEST(rt_zsh_modifier_case_and_quote);
+    RUN_TEST(rt_zsh_modifier_substitute);
+    RUN_TEST(rt_zsh_modifier_chain_and_nest);
+    RUN_TEST(rt_zsh_modifier_off_in_bash_is_substring);
+    RUN_TEST(rt_zsh_modifier_numeric_arg_still_substring);
     RUN_TEST(param_pattern_substitution);
     RUN_TEST(param_global_substitution);
 


### PR DESCRIPTION
## Summary
Adds the zsh history-style parameter modifier family to the expansion engine:
- `:h` head/dirname, `:t` tail/basename, `:r` root (strip last extension), `:e` extension
- `:l`/`:u` case, `:q` backslash-quote (zsh form, e.g. `Hello\ World`)
- `:s/old/new/` (first) and `:gs/old/new/` (global) substitution
- **chaining** `${p:t:r}` and **nesting** `${${p:t}:r}`

## How
- The `:` operator (op_type 14) now disambiguates on its argument: a leading modifier letter → modifier chain; a numeric offset → substring (unchanged).
- Nested expansion in the name position works by skipping `${...}` in `find_op_outside_brackets` (so the *outer* operator is found, not the inner one) and expanding a `${...}`-shaped name before applying the operator.
- Gated by **`FEATURE_ZSH_PARAM_MODIFIERS`**: on in zsh + lush, off in bash + posix (where `${var:x}` is substring-offset and a leading letter would change meaning). `setopt zsh_param_modifiers`.

## Verified vs zsh
```
p=/usr/local/bin/script.tar.gz
${p:h}=/usr/local/bin  ${p:t}=script.tar.gz  ${p:r}=/usr/local/bin/script.tar  ${p:e}=gz
${p:t:r}=script.tar    ${${p:t}:r}=script.tar    ${${p:h}:t}=bin
${s:l}/${s:u}/${s:q}, ${p:s/local/LOCAL/}, ${p:gs/o/0/}  — all match zsh
bash mode: ${p:h} -> whole value (substring offset), matches bash
```

## Scope note
`:a`/`:A` (absolute-path / symlink resolution) are a distinct filesystem- and cwd-dependent subfamily (non-deterministic for differential testing) and are intentionally not part of this change.

## Test plan
- [x] 6 unit tests (path parts, case+quote, substitute, chain+nest, bash-mode substring gating, numeric-arg-still-substring)
- [x] differential corpus seed `zsh/324` agrees with the zsh oracle
- [x] Full suite: 118/118 meson tests pass; 0 warnings (werror); clang-format clean
- [x] No regression on nested defaults (`${u:-${d}}`) from the `find_op` brace-skip

Fixes #132