### PR TITLE
Differential corpus: +5 seeds (getopts, positional, arrays, regex, zsh split)

### DIFF
--- a/tests/fuzz/differential/corpus/bash/231_bash_array_keys_slice.sh
+++ b/tests/fuzz/differential/corpus/bash/231_bash_array_keys_slice.sh
@@ -1,0 +1,6 @@
+# Bash indexed-array keys, length, and slice (whole-word forms).
+arr=(zero one two three four)
+echo "keys:" "${!arr[@]}"
+echo "slice:" "${arr[@]:1:2}"
+echo "len: ${#arr[@]}"
+echo "elem-len: ${#arr[2]}"

--- a/tests/fuzz/differential/corpus/bash/233_bash_rematch.sh
+++ b/tests/fuzz/differential/corpus/bash/233_bash_rematch.sh
@@ -1,0 +1,6 @@
+# Bash [[ =~ ]] regex with BASH_REMATCH capture groups.
+s="2026-05-29"
+if [[ $s =~ ^([0-9]+)-([0-9]+)-([0-9]+)$ ]]; then
+  echo "y=${BASH_REMATCH[1]} m=${BASH_REMATCH[2]} d=${BASH_REMATCH[3]}"
+fi
+echo "full: ${BASH_REMATCH[0]}"

--- a/tests/fuzz/differential/corpus/posix/128_posix_getopts.sh
+++ b/tests/fuzz/differential/corpus/posix/128_posix_getopts.sh
@@ -1,0 +1,10 @@
+# POSIX getopts: option flags, an option with an argument, and OPTIND.
+set -- -a -b val -a rest1 rest2
+while getopts "ab:" opt; do
+  case "$opt" in
+    a) echo "flag-a" ;;
+    b) echo "opt-b=$OPTARG" ;;
+  esac
+done
+shift $((OPTIND - 1))
+echo "remaining: $*"

--- a/tests/fuzz/differential/corpus/posix/129_posix_positional_shift.sh
+++ b/tests/fuzz/differential/corpus/posix/129_posix_positional_shift.sh
@@ -1,0 +1,9 @@
+# POSIX positional parameters: count, access, shift by 1 and by N.
+set -- alpha beta gamma delta
+echo "count: $#"
+echo "first: $1"
+shift
+echo "after1: $1 count=$#"
+shift 2
+echo "after2: $1 count=$#"
+echo "all: $*"

--- a/tests/fuzz/differential/corpus/zsh/326_zsh_split_lines.sh
+++ b/tests/fuzz/differential/corpus/zsh/326_zsh_split_lines.sh
@@ -1,0 +1,6 @@
+# Zsh ${(f)var} splits a string on newlines into array elements.
+data=$'one\ntwo\nthree'
+lines=(${(f)data})
+echo "count: ${#lines}"
+echo "first: $lines[1]"
+echo "last: $lines[-1]"


### PR DESCRIPTION
## Summary
Grows the differential corpus 102 -> 107 with oracle-verified seeds:
- **posix**: `getopts` option/arg parsing + `OPTIND`; positional-parameter `shift` / `$#` / `$@` / `$*`
- **bash**: indexed-array keys (`${!arr[@]}`) / slice / length; `[[ =~ ]]` with `BASH_REMATCH` capture groups
- **zsh**: `${(f)var}` newline split into an array

All agree with the bash/zsh/dash oracles (`diff_oracle ... 0 unexpected divergences`).

## Bugs surfaced (filed, seeds held)
- #141 `printf -v VAR` does not assign to a variable
- #142 zsh `${(P)name}` indirect parameter flag not implemented

## Test plan
- [x] `diff_oracle` over the 5 new seeds: 0 unexpected divergences
- [x] Deterministic (no dates/PIDs/filesystem/locale-sensitive output)