### PR TITLE
printf: implement -v VAR to assign formatted output (#141)

### DIFF
--- a/src/builtins/bin_printf.c
+++ b/src/builtins/bin_printf.c
@@ -7,10 +7,15 @@
  */
 
 #include "builtins.h"
+#include "symtable.h"
 
 #include <ctype.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 /**
  * @brief Process escape sequences in a string
@@ -101,7 +106,21 @@ char *process_escape_sequences(const char *str) {
  * @return 0 on success, 1 on usage error
  */
 int bin_printf(int argc, char **argv) {
-    if (argc < 2) {
+    /// `printf -v VAR FMT ARGS` assigns the formatted output to VAR
+    /// instead of writing it to stdout.
+    const char *assign_var = NULL;
+    int base = 1;
+    if (argc >= 2 && strcmp(argv[1], "-v") == 0) {
+        if (argc < 3) {
+            fprintf(stderr, "lush: printf: -v: option requires a variable "
+                            "name\n");
+            return 1;
+        }
+        assign_var = argv[2];
+        base = 3;
+    }
+
+    if (argc < base + 1) {
         source_location_t loc = builtin_get_source_location();
         shell_error_t *err =
             shell_error_create(SHELL_ERR_MISSING_ARGUMENT, SHELL_SEVERITY_ERROR,
@@ -137,8 +156,30 @@ int bin_printf(int argc, char **argv) {
         return 1;
     }
 
-    const char *format = argv[1];
-    int arg_index = 2;
+    const char *format = argv[base];
+    int arg_index = base + 1;
+
+    /// For `-v`, redirect stdout to a temp file for the duration so the
+    /// existing per-conversion output code is unchanged; the captured
+    /// bytes are read back and assigned after the format loop.
+    int printf_saved_fd = -1;
+    FILE *printf_capture = NULL;
+    if (assign_var) {
+        fflush(stdout);
+        printf_capture = tmpfile();
+        if (printf_capture) {
+            printf_saved_fd = dup(STDOUT_FILENO);
+            if (printf_saved_fd < 0 ||
+                dup2(fileno(printf_capture), STDOUT_FILENO) < 0) {
+                if (printf_saved_fd >= 0) {
+                    close(printf_saved_fd);
+                }
+                fclose(printf_capture);
+                printf_capture = NULL;
+                printf_saved_fd = -1;
+            }
+        }
+    }
 
     /// POSIX: The format string is reused as often as necessary to satisfy
     /// the remaining arguments. If the format string contains no conversion
@@ -400,6 +441,33 @@ int bin_printf(int argc, char **argv) {
         }
 
     } while (arg_index < argc);
+
+    if (assign_var) {
+        fflush(stdout);
+        if (printf_capture) {
+            if (printf_saved_fd >= 0) {
+                dup2(printf_saved_fd, STDOUT_FILENO);
+                close(printf_saved_fd);
+            }
+            long n = ftell(printf_capture);
+            if (n < 0) {
+                n = 0;
+            }
+            rewind(printf_capture);
+            char *buf = malloc((size_t)n + 1);
+            if (buf) {
+                size_t got = fread(buf, 1, (size_t)n, printf_capture);
+                buf[got] = '\0';
+                symtable_set_global(assign_var, buf);
+                free(buf);
+            }
+            fclose(printf_capture);
+        } else {
+            /// Capture setup failed; clear the target rather than leave a
+            /// stale value.
+            symtable_set_global(assign_var, "");
+        }
+    }
 
     return 0;
 }

--- a/tests/fuzz/differential/corpus/bash/232_bash_printf_v.sh
+++ b/tests/fuzz/differential/corpus/bash/232_bash_printf_v.sh
@@ -1,0 +1,6 @@
+# Bash printf -v assigns formatted output to a variable (no stdout).
+printf -v out "%05d-%s" 42 hello
+echo "out: $out"
+printf -v hex "%x" 255
+echo "hex: $hex"
+printf "direct %s\n" still-prints

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -1579,6 +1579,20 @@ TEST(rt_read_non_whitespace_ifs_not_trimmed) {
     ASSERT_STDOUT_EQ(r, "[:a:b:]\n");
 }
 
+TEST(rt_printf_v_assigns_variable) {
+    /// printf -v VAR assigns the formatted output to VAR and prints
+    /// nothing to stdout; the value is visible to a later command (#141).
+    run_result_t r = run_shell("printf -v out '%05d-%s' 42 hello\n"
+                               "echo \"[$out]\"\n");
+    ASSERT_STDOUT_EQ(r, "[00042-hello]\n");
+}
+
+TEST(rt_printf_without_v_still_prints) {
+    /// Regression guard: plain printf (no -v) still writes to stdout.
+    run_result_t r = run_shell("printf '%s-%d\\n' hi 7\n");
+    ASSERT_STDOUT_EQ(r, "hi-7\n");
+}
+
 TEST(builtin_eval) {
     executor_t *exec = executor_new();
     ASSERT_NOT_NULL(exec, "executor_new failed");
@@ -4295,6 +4309,8 @@ int main(void) {
     RUN_TEST(rt_read_strips_leading_trailing_ifs_whitespace);
     RUN_TEST(rt_read_multi_var_trims_trailing_ws);
     RUN_TEST(rt_read_non_whitespace_ifs_not_trimmed);
+    RUN_TEST(rt_printf_v_assigns_variable);
+    RUN_TEST(rt_printf_without_v_still_prints);
     RUN_TEST(builtin_eval);
     RUN_TEST(builtin_shift);
     RUN_TEST(builtin_set_positional);


### PR DESCRIPTION
## Summary
- `printf -v VAR FMT ARGS` now assigns the formatted result to `VAR` instead of writing it to stdout, matching bash/zsh.
- The per-conversion output loop is unchanged: for `-v`, stdout is redirected to a temp file for the duration, then the captured bytes are read back and stored via `symtable_set_global`. Plain `printf` (no `-v`) still writes to stdout.

## Verified vs bash
```
printf -v out "%05d-%s" 42 hello; echo "out: $out"   -> out: 00042-hello
printf -v hex "%x" 255;          echo "hex: $hex"    -> hex: ff
printf -v multi "%s\n" a b c                          -> multi spans 3 lines (format reuse)
printf "direct %s\n" x                                -> still prints to stdout
```

## Test plan
- [x] 2 regression tests (`-v` assigns + prints nothing; plain printf still prints)
- [x] Differential corpus seed `bash/232` agrees with bash
- [x] Full suite: 118/118; 0 warnings (werror); clang-format clean

Fixes #141