### PR TITLE
executor: implement zsh ${(P)name} indirect parameter flag (#142)

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -12520,6 +12520,19 @@ static char *parse_parameter_expansion(executor_t *executor,
                 char *new_result = NULL;
 
                 switch (*p) {
+                case 'P':
+                    /// Indirect: treat the current value as the NAME of a
+                    /// parameter and expand that parameter. ${(P)ref} yields
+                    /// the value of the variable named by $ref, comparable to
+                    /// bash ${!ref}.
+                    new_result = symtable_get_var(executor->symtable, result);
+                    if (result != inner_result) {
+                        free(result);
+                    }
+                    result = new_result ? new_result : strdup("");
+                    p++;
+                    break;
+
                 case 'U':
                     /// Uppercase all
                     new_result = convert_case_all_upper(result);

--- a/tests/fuzz/differential/corpus/zsh/325_zsh_indirect_P.sh
+++ b/tests/fuzz/differential/corpus/zsh/325_zsh_indirect_P.sh
@@ -1,0 +1,6 @@
+# Zsh ${(P)name} indirect expansion: value of the named variable, and
+# composing with another flag.
+target=hello
+ref=target
+echo "indirect: ${(P)ref}"
+echo "indirect-upper: ${(PU)ref}"

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -1964,6 +1964,17 @@ TEST(rt_zsh_modifier_numeric_arg_still_substring) {
     ASSERT_STDOUT_EQ(r, "cdef|bcd\n");
 }
 
+TEST(rt_zsh_param_indirect_P) {
+    /// ${(P)ref} expands the variable NAMED by $ref (indirect), and
+    /// composes with other flags, e.g. ${(PU)ref}. Issue #142.
+    run_result_t r = run_shell("mode zsh\n"
+                               "target=hello\n"
+                               "ref=target\n"
+                               "echo \"${(P)ref}|${(PU)ref}\"\n");
+    run_shell("mode lush\n");
+    ASSERT_STDOUT_EQ(r, "hello|HELLO\n");
+}
+
 TEST(param_pattern_substitution) {
     executor_t *exec = executor_new();
     ASSERT_NOT_NULL(exec, "executor_new failed");
@@ -4332,6 +4343,7 @@ int main(void) {
     RUN_TEST(rt_zsh_modifier_chain_and_nest);
     RUN_TEST(rt_zsh_modifier_off_in_bash_is_substring);
     RUN_TEST(rt_zsh_modifier_numeric_arg_still_substring);
+    RUN_TEST(rt_zsh_param_indirect_P);
     RUN_TEST(param_pattern_substitution);
     RUN_TEST(param_global_substitution);
 


### PR DESCRIPTION
## Summary
- The zsh `(P)` parameter flag expands the variable *named* by the parameter's value: `${(P)ref}` yields the value of the variable whose name is `$ref` (comparable to bash `${!ref}`). It was unhandled, so lush returned the ref's literal value.
- Add a `P` case to the parameter-flag loop that looks up the current value as a variable name. It composes with other flags left-to-right, e.g. `${(PU)ref}` indirects then uppercases.

## Verified vs zsh
```
target=hello; ref=target
${(P)ref}  -> hello
${(PU)ref} -> HELLO
```

## Test plan
- [x] Regression test (`${(P)ref}` and `${(PU)ref}`)
- [x] Differential corpus seed `zsh/325` agrees with the zsh oracle
- [x] Full suite: 118/118; 0 warnings (werror); clang-format clean

Fixes #142