### PR TITLE
Differential corpus: +6 seeds (arith ops, cmdsub, case, indirect, C-for, zsh capitalize)

### DIFF
--- a/tests/fuzz/differential/corpus/bash/234_bash_case_modify_pattern.sh
+++ b/tests/fuzz/differential/corpus/bash/234_bash_case_modify_pattern.sh
@@ -1,0 +1,6 @@
+# Bash case modification with an optional pattern selecting which chars.
+s="hello world"
+echo "up-all: ${s^^}"
+echo "up-l: ${s^^l}"
+echo "low-first: ${s,}"
+echo "up-vowels: ${s^^[aeiou]}"

--- a/tests/fuzz/differential/corpus/bash/235_bash_indirect_ref.sh
+++ b/tests/fuzz/differential/corpus/bash/235_bash_indirect_ref.sh
@@ -1,0 +1,6 @@
+# Bash indirect expansion ${!ref}.
+val=treasure
+ref=val
+echo "indirect: ${!ref}"
+levels=ref
+echo "single-level: ${!levels}"

--- a/tests/fuzz/differential/corpus/bash/236_bash_cstyle_for.sh
+++ b/tests/fuzz/differential/corpus/bash/236_bash_cstyle_for.sh
@@ -1,0 +1,10 @@
+# Bash C-style arithmetic for loop.
+sum=0
+for ((i = 1; i <= 5; i++)); do
+  sum=$((sum + i))
+done
+echo "sum: $sum"
+for ((j = 3; j > 0; j--)); do
+  printf '%s ' "$j"
+done
+echo ""

--- a/tests/fuzz/differential/corpus/posix/130_posix_arith_assign_ops.sh
+++ b/tests/fuzz/differential/corpus/posix/130_posix_arith_assign_ops.sh
@@ -1,0 +1,8 @@
+# POSIX arithmetic compound assignment operators inside $(( )).
+n=10
+echo "plus: $((n += 5))"
+echo "minus: $((n -= 3))"
+echo "times: $((n *= 2))"
+echo "div: $((n /= 4))"
+echo "mod: $((n %= 4))"
+echo "final: $n"

--- a/tests/fuzz/differential/corpus/posix/131_posix_nested_cmdsub.sh
+++ b/tests/fuzz/differential/corpus/posix/131_posix_nested_cmdsub.sh
@@ -1,0 +1,5 @@
+# POSIX nested command substitution and arithmetic over it.
+echo "outer: $(echo $(echo inner))"
+n=$(echo $(( $(echo 3) + $(echo 4) )))
+echo "n: $n"
+echo "chain: $(printf '%s' "$(echo a)$(echo b)")"

--- a/tests/fuzz/differential/corpus/zsh/327_zsh_capitalize.sh
+++ b/tests/fuzz/differential/corpus/zsh/327_zsh_capitalize.sh
@@ -1,0 +1,5 @@
+# Zsh (C) capitalize-words parameter flag.
+s="hello world foo"
+echo "cap: ${(C)s}"
+t="MIXED case HERE"
+echo "cap2: ${(C)t}"


### PR DESCRIPTION
## Summary
Grows the differential corpus 109 -> 115 with oracle-verified seeds:
- **posix**: arithmetic compound assignment (`+= -= *= /= %=`); nested command substitution
- **bash**: case modification with a char-class pattern (`${s^^[aeiou]}`); `${!ref}` indirect expansion; C-style `for ((;;))` loop
- **zsh**: `(C)` capitalize-words parameter flag

All agree with the bash/zsh/dash oracles (`diff_oracle ... 0 unexpected divergences`). No new bugs surfaced this batch.

## Test plan
- [x] `diff_oracle` over the 6 new seeds: 0 unexpected divergences
- [x] Deterministic output (no dates/PIDs/filesystem/locale-sensitive constructs)