### PR TITLE
Differential corpus: +4 seeds (param-error, array replace, zsh assoc/split)

### DIFF
--- a/tests/fuzz/differential/corpus/bash/238_bash_array_replace.sh
+++ b/tests/fuzz/differential/corpus/bash/238_bash_array_replace.sh
@@ -1,0 +1,4 @@
+# Bash per-element pattern replacement over an array.
+arr=(foo.txt bar.txt baz.log)
+echo "first:" "${arr[@]/.txt/.md}"
+echo "allo:" "${arr[@]//o/0}"

--- a/tests/fuzz/differential/corpus/posix/132_posix_param_error.sh
+++ b/tests/fuzz/differential/corpus/posix/132_posix_param_error.sh
@@ -1,0 +1,5 @@
+# POSIX ${var:?word}: print word to stderr and exit non-zero when unset.
+echo "before"
+unset missing
+: "${missing:?is required}"
+echo "after (should not print)"

--- a/tests/fuzz/differential/corpus/zsh/328_zsh_assoc_keys_sorted.sh
+++ b/tests/fuzz/differential/corpus/zsh/328_zsh_assoc_keys_sorted.sh
@@ -1,0 +1,8 @@
+# Zsh associative-array sorted keys/values via (ko)/(vo) ordering.
+typeset -A m
+m[banana]=3
+m[apple]=1
+m[cherry]=2
+echo "keys: ${(ko)m}"
+echo "count: ${#m}"
+echo "apple: $m[apple]"

--- a/tests/fuzz/differential/corpus/zsh/329_zsh_split_custom_delim.sh
+++ b/tests/fuzz/differential/corpus/zsh/329_zsh_split_custom_delim.sh
@@ -1,0 +1,7 @@
+# Zsh ${(s/:/)str} split on a custom delimiter into array elements.
+path="a:bb:ccc:d"
+parts=(${(s/:/)path})
+echo "count: ${#parts}"
+echo "first: $parts[1]"
+echo "third: $parts[3]"
+echo "joined: ${(j/-/)parts}"


### PR DESCRIPTION
## Summary
Grows the differential corpus 115 -> 119 with oracle-verified seeds:
- **posix**: `${var:?word}` error-and-exit on unset
- **bash**: per-element array pattern replacement `${arr[@]/old/new}` and `//`
- **zsh**: `(ko)` sorted associative keys; `(s/:/)` split on a custom delimiter

All agree with the bash/zsh/dash oracles.

## Bugs surfaced (filed, seeds held)
- #147 `${@:offset:length}` positional-parameter slicing not implemented
- #148 extended glob `@(...) +(...)` etc. not matched (extglob)

## Test plan
- [x] `diff_oracle` over the 4 new seeds: 0 unexpected divergences
- [x] Deterministic output