### PR TITLE
executor: slice the positional parameters with ${@:offset:length} (#147)

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -4554,6 +4554,7 @@ static char **ifs_field_split(const char *text, const char *ifs, int *count) {
  *   $@                       positional params
  *   $*                       positional params
  *   ${@}, ${*}               braced positional params
+ *   ${@:N}, ${@:N:M}         positional-param slice
  *   ${NAME[@]}, ${NAME[*]}   array all-elements
  *   ${!NAME[@]}              array keys (assoc) / indices (indexed)
  *   ${NAME[@]:N},  ${NAME[@]:N:M}, ${NAME[*]:N:M}  array slice
@@ -4566,6 +4567,47 @@ static char **ifs_field_split(const char *text, const char *ifs, int *count) {
  * @return true if the node was a vector form and out_vec/out_count were
  *         populated; false otherwise.
  */
+
+/// Parse an optional `:N` / `:N:M` slice suffix shared by the array and
+/// positional vector forms. @p p points just past the subscript (the `]`
+/// of NAME[@], or the `@`/`*` of a positional ref); @p end is just past
+/// the closing `}`. On a `:` slice sets *has_slice and the offset/length;
+/// with no suffix leaves them untouched. Returns false on malformed junk
+/// (anything other than end-of-content or a `:`-led numeric slice).
+static bool parse_vector_slice_suffix(const char *p, const char *end,
+                                      bool *has_slice, int *slice_offset,
+                                      int *slice_length) {
+    if (p == end) {
+        return true; /// no slice suffix
+    }
+    if (*p != ':') {
+        return false; /// junk between subscript/ref and `}`
+    }
+    p++;
+    if (p >= end) {
+        return false;
+    }
+    size_t spec_len = (size_t)(end - p);
+    char spec[64];
+    if (spec_len >= sizeof(spec)) {
+        return false;
+    }
+    memcpy(spec, p, spec_len);
+    spec[spec_len] = '\0';
+    char *endp = NULL;
+    *slice_offset = (int)strtol(spec, &endp, 10);
+    if (!endp) {
+        return false;
+    }
+    if (*endp == ':') {
+        *slice_length = (int)strtol(endp + 1, NULL, 10);
+    } else if (*endp != '\0') {
+        return false;
+    }
+    *has_slice = true;
+    return true;
+}
+
 static bool try_expand_vector_arg(executor_t *executor, node_t *node,
                                   char ***out_vec, int *out_count) {
     if (!node || !node->val.str) {
@@ -4824,10 +4866,15 @@ static bool try_expand_vector_arg(executor_t *executor, node_t *node,
         if (p == end) {
             return false;
         }
-        /// Special-cased ${@} / ${*}: positional, no subscript.
-        if (!keys_form && (end - p) == 1 && (*p == '@' || *p == '*')) {
+        /// ${@} / ${*}, optionally sliced: ${@:N} / ${@:N:M}.
+        if (!keys_form && (*p == '@' || *p == '*')) {
             is_positional = true;
             subscript = *p;
+            p++;
+            if (!parse_vector_slice_suffix(p, end, &has_slice, &slice_offset,
+                                           &slice_length)) {
+                return false;
+            }
         } else {
             /// Must be NAME[@] / NAME[*] optionally followed by :N or :N:M
             name_start = p;
@@ -4883,34 +4930,9 @@ static bool try_expand_vector_arg(executor_t *executor, node_t *node,
                 return false;
             }
             p++;
-            /// Optional slicing :N or :N:M.
-            if (p < end && *p == ':') {
-                has_slice = true;
-                p++;
-                if (p >= end) {
-                    return false;
-                }
-                char *endp = NULL;
-                /// end is past the trailing `}`; we need a NUL-terminated
-                /// span. Copy the slice spec into a scratch buffer.
-                size_t spec_len = (size_t)(end - p);
-                char spec[64];
-                if (spec_len >= sizeof(spec)) {
-                    return false;
-                }
-                memcpy(spec, p, spec_len);
-                spec[spec_len] = '\0';
-                slice_offset = (int)strtol(spec, &endp, 10);
-                if (!endp) {
-                    return false;
-                }
-                if (*endp == ':') {
-                    slice_length = (int)strtol(endp + 1, NULL, 10);
-                } else if (*endp != '\0') {
-                    return false;
-                }
-            } else if (p != end) {
-                /// Junk between `]` and `}`. Not a recognized vector form.
+            /// Optional slicing :N or :N:M (shared parser).
+            if (!parse_vector_slice_suffix(p, end, &has_slice, &slice_offset,
+                                           &slice_length)) {
                 return false;
             }
         }
@@ -4958,6 +4980,59 @@ braced_bare_array_ready:;
                     return false;
                 }
             }
+        }
+
+        /// Apply ${@:offset:length} slicing. bash slices the conceptual
+        /// sequence [$0, $1, ..., $N], so $0 sits at index 0; vec holds
+        /// $1..$N. A negative offset counts from the end; an omitted
+        /// length runs to the end.
+        if (has_slice) {
+            char *zero = symtable_get_var(executor->symtable, "0");
+            if (!zero) {
+                zero = strdup((shell_argv && shell_argc > 0 && shell_argv[0])
+                                  ? shell_argv[0]
+                                  : "");
+            }
+            int nelem = vcount + 1; /// includes $0
+            int start = slice_offset;
+            if (start < 0) {
+                start = nelem + start;
+            }
+            if (start < 0) {
+                start = 0;
+            }
+            int end_idx =
+                (slice_length >= 0) ? start + slice_length - 1 : nelem - 1;
+            if (end_idx >= nelem) {
+                end_idx = nelem - 1;
+            }
+            char **sliced = NULL;
+            int scount = 0, scap = 0;
+            bool oom = false;
+            for (int idx = start; idx <= end_idx && idx >= 0; idx++) {
+                const char *src = (idx == 0) ? zero : vec[idx - 1];
+                char *val = strdup(src ? src : "");
+                if (!add_to_argv_list(&sliced, &scount, &scap, val)) {
+                    free(val);
+                    oom = true;
+                    break;
+                }
+            }
+            free(zero);
+            for (int k = 0; k < vcount; k++) {
+                free(vec[k]);
+            }
+            free(vec);
+            if (oom) {
+                for (int k = 0; k < scount; k++) {
+                    free(sliced[k]);
+                }
+                free(sliced);
+                return false;
+            }
+            vec = sliced;
+            vcount = scount;
+            vcap = scap;
         }
     } else {
         /// Array name lookup. Need a NUL-terminated name.

--- a/tests/fuzz/differential/corpus/bash/237_bash_positional_slice.sh
+++ b/tests/fuzz/differential/corpus/bash/237_bash_positional_slice.sh
@@ -1,0 +1,7 @@
+# Bash positional-parameter slicing ${@:offset:length}, including a
+# negative offset, in whole-word (for-list) positions.
+set -- one two three four five
+for w in "${@:2}"; do echo "from2: $w"; done
+for w in "${@:2:2}"; do echo "slice: $w"; done
+for w in "${@: -1}"; do echo "last: $w"; done
+echo "count: $#"

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -1922,6 +1922,19 @@ TEST(param_substring_offset_length) {
                         "[]\n");
 }
 
+TEST(rt_positional_param_slice) {
+    /// ${@:offset:length} slices the positional parameters, counting $0
+    /// at index 0 like bash; a negative offset counts from the end (#147).
+    run_result_t r =
+        run_shell("set -- a b c d e\n"
+                  "for w in \"${@:2}\"; do echo \"f:$w\"; done\n"
+                  "for w in \"${@:2:2}\"; do echo \"s:$w\"; done\n"
+                  "for w in \"${@: -2}\"; do echo \"n:$w\"; done\n");
+    ASSERT_STDOUT_EQ(r, "f:b\nf:c\nf:d\nf:e\n"
+                        "s:b\ns:c\n"
+                        "n:d\nn:e\n");
+}
+
 TEST(rt_zsh_modifier_path_parts) {
     /// zsh :h/:t/:r/:e path modifiers (issue #132).
     run_result_t r = run_shell("mode zsh\n"
@@ -4353,6 +4366,7 @@ int main(void) {
     RUN_TEST(param_substring_removal_prefix);
     RUN_TEST(param_substring_removal_suffix);
     RUN_TEST(param_substring_offset_length);
+    RUN_TEST(rt_positional_param_slice);
     RUN_TEST(rt_zsh_modifier_path_parts);
     RUN_TEST(rt_zsh_modifier_case_and_quote);
     RUN_TEST(rt_zsh_modifier_substitute);


### PR DESCRIPTION
## Summary
- `${@:N}` / `${@:N:M}` / `${@: -N}` now slice the positional parameters. The braced positional parse only matched `${@}`/`${*}` as exactly one char, so `${@:2}` fell through to the array-name path and returned empty; the positional gather also ignored any slice.
- Extend the positional branch to parse the `:N:M` suffix via a new shared `parse_vector_slice_suffix` helper (the array path now uses it too, removing the duplicated inline parser), and apply the slice over the conceptual `[$0, $1, ..., $N]` sequence with bash semantics (`$0` at index 0, negative offset from the end, omitted length to the end).

## Verified vs bash
```
set -- a b c d e
"${@:2}"   -> b c d e
"${@:2:2}" -> b c
"${@: -2}" -> d e
"${arr[@]:1:2}" array slicing unchanged
```

## Test plan
- [x] Regression test (`${@:N}`, `${@:N:M}`, negative-offset `${@: -2}`)
- [x] Differential corpus seed `bash/237` agrees with bash
- [x] Full suite: 118/118; 0 warnings (werror); clang-format clean

Fixes #147