### PR TITLE
Unify on the canonical pattern matcher; delete the duplicate (Refs #148)

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -26,7 +26,6 @@
 #include "lle/lle_shell_event_hub.h"
 #include "lle/lle_shell_integration.h"
 #include "lle/unicode_case.h"
-#include "lle/unicode_class.h"
 #include "lle/unicode_compare.h"
 #include "lle/unicode_grapheme.h"
 #include "lle/utf8_support.h"
@@ -220,7 +219,6 @@ static char *expand_ansi_c_string(const char *str, size_t len);
 static bool is_assignment(const char *text);
 static int execute_assignment(executor_t *executor, const char *assignment,
                               source_location_t loc);
-static bool match_pattern(const char *str, const char *pattern);
 
 /**
  * @brief Check if command is allowed in privileged mode
@@ -9344,6 +9342,39 @@ static int execute_assignment(executor_t *executor, const char *assignment,
  * @param node Case statement node
  * @return Exit status of executed commands, or 0 if no match
  */
+
+/// Find the next case-alternative `|` separator at the top level: a `|`
+/// that is not inside an extglob group `(...)` or a `[...]` bracket, and
+/// not backslash-escaped. Without this an extglob pattern like
+/// `@(cat|dog)` would be wrongly split at its inner `|`. Returns NULL
+/// when the remaining patterns hold no further top-level separator.
+static const char *find_case_alt_separator(const char *p) {
+    int paren = 0;
+    int bracket = 0;
+    for (; *p; p++) {
+        if (*p == '\\' && p[1]) {
+            p++; /// skip the escaped char
+            continue;
+        }
+        if (*p == '[') {
+            bracket++;
+        } else if (*p == ']') {
+            if (bracket > 0) {
+                bracket--;
+            }
+        } else if (*p == '(') {
+            paren++;
+        } else if (*p == ')') {
+            if (paren > 0) {
+                paren--;
+            }
+        } else if (*p == '|' && paren == 0 && bracket == 0) {
+            return p;
+        }
+    }
+    return NULL;
+}
+
 static int execute_case(executor_t *executor, node_t *node) {
     if (!executor || !node || node->type != NODE_CASE) {
         return 1;
@@ -9412,7 +9443,7 @@ static int execute_case(executor_t *executor, node_t *node) {
             /// Use strchr-based splitting that emits empty tokens.
             const char *p = patterns;
             while (p && !matched) {
-                const char *bar = strchr(p, '|');
+                const char *bar = find_case_alt_separator(p);
                 size_t plen = bar ? (size_t)(bar - p) : strlen(p);
                 char *pattern = malloc(plen + 1);
                 if (!pattern) {
@@ -9424,7 +9455,7 @@ static int execute_case(executor_t *executor, node_t *node) {
 
                 char *expanded_pattern = expand_if_needed(executor, pattern);
                 if (expanded_pattern) {
-                    if (match_pattern(test_word, expanded_pattern)) {
+                    if (lush_pattern_match(test_word, expanded_pattern)) {
                         matched = true;
                     }
                     free(expanded_pattern);
@@ -10204,222 +10235,6 @@ static char *extract_substring(const char *str, int offset, int length,
 }
 
 /**
- * @brief Match string against glob pattern
- *
- * Supports *, ?, and [...] character classes including ranges
- * and negation [!...] or [^...]. Used for case patterns and
- * parameter expansion pattern matching.
- *
- * @param str String to match
- * @param pattern Glob pattern
- * @return true if string matches pattern
- */
-static bool match_pattern(const char *str, const char *pattern) {
-    if (!str || !pattern) {
-        return false;
-    }
-
-    const char *s = str;
-    const char *p = pattern;
-
-    while (*p) {
-        if (*p == '*') {
-            /// Handle wildcard
-            p++; /// Skip the *
-
-            /// If * is at the end, it matches everything remaining
-            if (*p == '\0') {
-                return true;
-            }
-
-            /// Try to match the rest of the pattern at each position in the
-            /// string
-            while (*s) {
-                if (match_pattern(s, p)) {
-                    return true;
-                }
-                s++;
-            }
-
-            /// Try matching the pattern with empty string (for cases like
-            /// "*suffix")
-            return match_pattern(s, p);
-        } else if (*p == '?') {
-            /// Wildcard matches any single character
-            if (*s == '\0') {
-                return false; /// ? can't match empty
-            }
-            s++;
-            p++;
-        } else if (*p == '[') {
-            /// Character class pattern [abc] or [a-z]
-            if (*s == '\0') {
-                return false; /// Character class can't match empty
-            }
-
-            p++; /// Skip opening [
-            bool matched = false;
-            bool negated = false;
-
-            /// Decode the input codepoint once for the whole bracket.
-            /// All match-arms (class / range / literal) test against
-            /// this single codepoint, and the post-bracket `s` advance
-            /// uses its UTF-8 byte length so multi-byte input never
-            /// gets left mid-codepoint. Malformed UTF-8 degrades to a
-            /// byte-as-codepoint so ASCII patterns continue to work.
-            uint32_t input_cp = (uint32_t)(unsigned char)*s;
-            size_t s_consumed = 1;
-            if (*s) {
-                uint32_t decoded = 0;
-                int consumed =
-                    lle_utf8_decode_codepoint(s, strlen(s), &decoded);
-                if (consumed > 0) {
-                    input_cp = decoded;
-                    s_consumed = (size_t)consumed;
-                }
-            }
-
-            /// Check for negation [!abc] or [^abc]
-            if (*p == '!' || *p == '^') {
-                negated = true;
-                p++;
-            }
-
-            while (*p && *p != ']') {
-                /// POSIX character class [:CLASS:] (e.g. [:space:],
-                /// [:alpha:], [:digit:]). Used heavily by real-world
-                /// trim/parse idioms - `${s%%[![:space:]]*}` was
-                /// silently treating [:space:] as the literal
-                /// character set { '[', ':', 's', 'p', 'a', 'c', 'e' }
-                /// because the class form was never parsed
-                /// (real_world/bash/201 trim function). Scan for `:]`
-                /// to delimit the class name, then dispatch through
-                /// the Unicode general-category predicates.
-                if (p[0] == '[' && p[1] == ':') {
-                    const char *class_start = p + 2;
-                    const char *class_end = strstr(class_start, ":]");
-                    if (class_end) {
-                        size_t cl = (size_t)(class_end - class_start);
-                        bool cls_match = false;
-                        if (cl == 5 && memcmp(class_start, "space", 5) == 0) {
-                            cls_match = lle_unicode_is_space(input_cp);
-                        } else if (cl == 5 &&
-                                   memcmp(class_start, "alpha", 5) == 0) {
-                            cls_match = lle_unicode_is_alpha(input_cp);
-                        } else if (cl == 5 &&
-                                   memcmp(class_start, "digit", 5) == 0) {
-                            cls_match = lle_unicode_is_digit(input_cp);
-                        } else if (cl == 5 &&
-                                   memcmp(class_start, "alnum", 5) == 0) {
-                            cls_match = lle_unicode_is_alnum(input_cp);
-                        } else if (cl == 5 &&
-                                   memcmp(class_start, "upper", 5) == 0) {
-                            cls_match = lle_unicode_is_upper(input_cp);
-                        } else if (cl == 5 &&
-                                   memcmp(class_start, "lower", 5) == 0) {
-                            cls_match = lle_unicode_is_lower(input_cp);
-                        } else if (cl == 5 &&
-                                   memcmp(class_start, "punct", 5) == 0) {
-                            cls_match = lle_unicode_is_punct(input_cp);
-                        } else if (cl == 5 &&
-                                   memcmp(class_start, "print", 5) == 0) {
-                            cls_match = lle_unicode_is_print(input_cp);
-                        } else if (cl == 5 &&
-                                   memcmp(class_start, "graph", 5) == 0) {
-                            cls_match = lle_unicode_is_graph(input_cp);
-                        } else if (cl == 5 &&
-                                   memcmp(class_start, "blank", 5) == 0) {
-                            cls_match = lle_unicode_is_blank(input_cp);
-                        } else if (cl == 5 &&
-                                   memcmp(class_start, "cntrl", 5) == 0) {
-                            cls_match = lle_unicode_is_cntrl(input_cp);
-                        } else if (cl == 6 &&
-                                   memcmp(class_start, "xdigit", 6) == 0) {
-                            cls_match = lle_unicode_is_xdigit(input_cp);
-                        }
-                        if (cls_match) {
-                            matched = true;
-                        }
-                        p = class_end + 2; /// past `:]`
-                        continue;
-                    }
-                }
-
-                /// Decode the pattern codepoint at p. UTF-8 multi-byte
-                /// characters in patterns are now first-class: `[α-ω]`
-                /// is one codepoint, one `-`, one codepoint, not five
-                /// independent bytes. Malformed UTF-8 falls back to a
-                /// single byte so ASCII patterns are untouched.
-                uint32_t pat_first = (uint32_t)(unsigned char)*p;
-                size_t pat_first_bytes = 1;
-                {
-                    uint32_t decoded = 0;
-                    int consumed =
-                        lle_utf8_decode_codepoint(p, strlen(p), &decoded);
-                    if (consumed > 0) {
-                        pat_first = decoded;
-                        pat_first_bytes = (size_t)consumed;
-                    }
-                }
-                const char *after_first = p + pat_first_bytes;
-                if (*after_first == '-' && after_first[1] != ']' &&
-                    after_first[1] != '\0') {
-                    /// Range pattern X-Y. Decode the end codepoint.
-                    const char *range_end = after_first + 1;
-                    uint32_t pat_end = (uint32_t)(unsigned char)*range_end;
-                    size_t pat_end_bytes = 1;
-                    {
-                        uint32_t decoded = 0;
-                        int consumed = lle_utf8_decode_codepoint(
-                            range_end, strlen(range_end), &decoded);
-                        if (consumed > 0) {
-                            pat_end = decoded;
-                            pat_end_bytes = (size_t)consumed;
-                        }
-                    }
-                    if (input_cp >= pat_first && input_cp <= pat_end) {
-                        matched = true;
-                    }
-                    p = range_end + pat_end_bytes;
-                } else {
-                    /// Single codepoint
-                    if (input_cp == pat_first) {
-                        matched = true;
-                    }
-                    p += pat_first_bytes;
-                }
-            }
-
-            if (*p == ']') {
-                p++; /// Skip closing ]
-            }
-
-            /// Apply negation if needed
-            if (negated) {
-                matched = !matched;
-            }
-
-            if (!matched) {
-                return false;
-            }
-
-            s += s_consumed;
-        } else {
-            /// Literal character match (including special chars like : @ /
-            /// etc.)
-            if (*s != *p) {
-                return false;
-            }
-            s++;
-            p++;
-        }
-    }
-
-    /// Pattern is exhausted, string should be too for a complete match
-    return *s == '\0';
-}
-
-/**
  * @brief Find prefix match length for # and ## operators
  *
  * Finds how many characters from the beginning of str match pattern.
@@ -10448,7 +10263,7 @@ static int find_prefix_match(const char *str, const char *pattern,
         strncpy(substr, str, i);
         substr[i] = '\0';
 
-        if (match_pattern(substr, pattern)) {
+        if (lush_pattern_match(substr, pattern)) {
             match_len = i;
             if (!longest) {
                 free(substr);
@@ -10483,7 +10298,7 @@ static int find_suffix_match(const char *str, const char *pattern,
 
     for (int i = 0; i <= str_len; i++) {
         const char *suffix = str + str_len - i;
-        if (match_pattern(suffix, pattern)) {
+        if (lush_pattern_match(suffix, pattern)) {
             match_len = i;
             if (!longest) {
                 break; /// Return first (shortest) match

--- a/src/pattern_match.c
+++ b/src/pattern_match.c
@@ -17,6 +17,8 @@
 
 #include "pattern_match.h"
 
+#include "lle/unicode_case.h"
+#include "lle/unicode_class.h"
 #include "lle/utf8_support.h"
 
 #include <ctype.h>
@@ -205,6 +207,48 @@ static int match_char_class(const char *s, const char *p, const char **end,
     bool first = true;
     while (*p && (first || *p != ']')) {
         first = false;
+
+        /// POSIX / Unicode character class [:CLASS:] inside the bracket.
+        /// Matched against the same decoded input codepoint, via the
+        /// project's Unicode general-category predicates.
+        if (p[0] == '[' && p[1] == ':') {
+            const char *class_start = p + 2;
+            const char *class_end = strstr(class_start, ":]");
+            if (class_end) {
+                size_t cl = (size_t)(class_end - class_start);
+                bool cls = false;
+                if (cl == 5 && memcmp(class_start, "space", 5) == 0) {
+                    cls = lle_unicode_is_space(input_cp);
+                } else if (cl == 5 && memcmp(class_start, "alpha", 5) == 0) {
+                    cls = lle_unicode_is_alpha(input_cp);
+                } else if (cl == 5 && memcmp(class_start, "digit", 5) == 0) {
+                    cls = lle_unicode_is_digit(input_cp);
+                } else if (cl == 5 && memcmp(class_start, "alnum", 5) == 0) {
+                    cls = lle_unicode_is_alnum(input_cp);
+                } else if (cl == 5 && memcmp(class_start, "upper", 5) == 0) {
+                    cls = lle_unicode_is_upper(input_cp);
+                } else if (cl == 5 && memcmp(class_start, "lower", 5) == 0) {
+                    cls = lle_unicode_is_lower(input_cp);
+                } else if (cl == 5 && memcmp(class_start, "punct", 5) == 0) {
+                    cls = lle_unicode_is_punct(input_cp);
+                } else if (cl == 5 && memcmp(class_start, "print", 5) == 0) {
+                    cls = lle_unicode_is_print(input_cp);
+                } else if (cl == 5 && memcmp(class_start, "graph", 5) == 0) {
+                    cls = lle_unicode_is_graph(input_cp);
+                } else if (cl == 5 && memcmp(class_start, "blank", 5) == 0) {
+                    cls = lle_unicode_is_blank(input_cp);
+                } else if (cl == 5 && memcmp(class_start, "cntrl", 5) == 0) {
+                    cls = lle_unicode_is_cntrl(input_cp);
+                } else if (cl == 6 && memcmp(class_start, "xdigit", 6) == 0) {
+                    cls = lle_unicode_is_xdigit(input_cp);
+                }
+                if (cls) {
+                    matched = true;
+                }
+                p = class_end + 2; /// past `:]`
+                continue;
+            }
+        }
 
         /// Decode the low codepoint (may be `\`-escaped).
         uint32_t lo;

--- a/tests/fuzz/differential/corpus/lush/416_lush_extglob_case.sh
+++ b/tests/fuzz/differential/corpus/lush/416_lush_extglob_case.sh
@@ -1,0 +1,10 @@
+# Extended glob in case patterns through lush's canonical matcher
+# (lush_pattern_match): @(...) exact-one, +(...) one-or-more, and the
+# zsh bare-alternation (a|b) form. extglob is on by default in lush mode.
+for w in cat dog bird 42; do
+  case "$w" in
+    @(cat|dog)) echo "pet: $w" ;;
+    +([a-z])) echo "word: $w" ;;
+    *) echo "other: $w" ;;
+  esac
+done

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -555,6 +555,34 @@ TEST(case_posix_character_class) {
     executor_free(exec);
 }
 
+TEST(rt_case_extglob_alternation) {
+    /// Extended-glob @(a|b) in a case pattern: the inner `|` is part of
+    /// the extglob group, not a case-alternative separator, and the
+    /// canonical matcher (lush_pattern_match) matches it. The duplicate
+    /// hand-rolled matcher that lacked extglob was retired here (#148).
+    /// zsh mode has extglob on at parse time; the bash-mode parse-time
+    /// `shopt -s extglob` enablement is a separate, deeper issue.
+    run_result_t r = run_shell("mode zsh\n"
+                               "for w in cat dog bird; do\n"
+                               "  case \"$w\" in\n"
+                               "    @(cat|dog)) echo \"pet:$w\" ;;\n"
+                               "    +([a-z])) echo \"word:$w\" ;;\n"
+                               "  esac\n"
+                               "done\n");
+    run_shell("mode lush\n");
+    ASSERT_STDOUT_EQ(r, "pet:cat\npet:dog\nword:bird\n");
+}
+
+TEST(rt_case_plain_alternation_unregressed) {
+    /// The paren/bracket-aware separator must still split ordinary
+    /// top-level `|` alternation, including an empty alternative.
+    run_result_t r =
+        run_shell("case b in a|b|c) echo abc;; *) echo no;; esac\n"
+                  "x=''\n"
+                  "case \"$x\" in ''|z) echo empty-or-z;; *) echo no;; esac\n");
+    ASSERT_STDOUT_EQ(r, "abc\nempty-or-z\n");
+}
+
 /* ============================================================================
  * SEMANTICS section 3.4/3.9 conformance: ${arr[@]} in scalar context
  *
@@ -4246,6 +4274,8 @@ int main(void) {
     RUN_TEST(case_statement);
     RUN_TEST(case_wildcard);
     RUN_TEST(case_posix_character_class);
+    RUN_TEST(rt_case_extglob_alternation);
+    RUN_TEST(rt_case_plain_alternation_unregressed);
     RUN_TEST(trap_err_fires_on_nonzero_exit);
     RUN_TEST(trap_err_silent_on_zero_exit);
     RUN_TEST(trap_err_not_inherited_in_function_by_default);


### PR DESCRIPTION
## Summary
`case` and `${var#pat}`/`${var%pat}` used a hand-rolled `match_pattern()` in executor.c that had POSIX/Unicode `[:class:]` support but **no extglob**, while the canonical `lush_pattern_match()` (`src/pattern_match.c`) had extglob + zsh bare-alternation but **no `[:class:]`**. Two drifting matchers, neither a superset — the duplicate-path hazard that sent us down the wrong road on #148.

This unifies on one matcher:
- Port the 12 `[:class:]` forms into `pattern_match.c`'s `match_char_class`, making it a true superset.
- Route `execute_case` and `find_prefix_match`/`find_suffix_match` through `lush_pattern_match`.
- **Delete `match_pattern` entirely** (net −101 lines). One matcher now backs `case`, `[[ == ]]`, and the parameter pattern operators.
- Fix case-alternative splitting with a paren/bracket-aware `find_case_alt_separator` (replaces `strchr(p,'|')`) so the inner `|` of `@(cat|dog)` isn't mistaken for a case-arm separator.

## Result
extglob in `case` now parses and matches in zsh/lush mode (extglob on at parse time). The bash-mode whole-file `shopt -s extglob` *parse-time* enablement is a separate, deeper tokenizer issue → **#151**.

## Test plan
- [x] New tests: `@(a|b)`/`+(...)` extglob in case; plain + empty-alt case unregressed; `[:class:]` in case unchanged (`case_posix_character_class` still passes through the unified matcher)
- [x] Full differential corpus: 121 seeds, 0 unexpected divergences (case + pattern-strip seeds unregressed)
- [x] Full suite: 118/118; 0 warnings (werror); clang-format clean
- [x] Corpus seed `lush/416` exercises extglob-in-case through the engine

Refs #148, #151