### PR TITLE
Unify all pattern matching on lush_pattern_match (Fixes #148)

### DIFF
--- a/include/pattern_match.h
+++ b/include/pattern_match.h
@@ -2,9 +2,12 @@
  * @file pattern_match.h
  * @brief Shell pattern matcher with bash extglob and zsh bare-alternation
  *
- * Lush's pattern matcher for `[[ ... == pat ]]`, `case`, parameter
- * expansion (`${var/pat/repl}`), etc. Wraps fnmatch for the standard
- * glob subset (`*`, `?`, `[...]`, `\`) and adds extended-pattern support:
+ * Lush's single canonical pattern matcher for `[[ ... == pat ]]`,
+ * `case`, parameter expansion (`${var/pat/repl}`, `${var^^[pat]}`),
+ * filename globbing, and the zsh `(r)`/`(i)` array-subscript flags. It
+ * recognizes the standard glob subset (`*`, `?`, `[...]`, `\`) inline,
+ * with codepoint-aware `[...]` ranges and POSIX/Unicode `[:class:]`,
+ * and adds extended-pattern support:
  *
  *   ?(p1|p2|...)   zero or one occurrence of one of the patterns
  *   *(p1|p2|...)   zero or more occurrences
@@ -13,6 +16,10 @@
  *   !(p1|p2|...)   anything that does not match any of the patterns
  *
  *   (p1|p2|...)    zsh bare-alternation form; equivalent to @(p1|p2|...)
+ *
+ * With LUSH_PATTERN_ZSH_EXTENDED, the zsh extended-glob postfix
+ * quantifiers `x#` (zero or more of x) and `x##` (one or more) and a
+ * leading `^` (negate the whole pattern) are additionally honored.
  *
  * Patterns are matched against the entire string; the matcher does not
  * locate substrings. Returns true on exact match.
@@ -38,5 +45,25 @@
  * @return true on exact match, false otherwise
  */
 bool lush_pattern_match(const char *str, const char *pattern);
+
+/// Enable zsh extended-glob operators in lush_pattern_match_ex: the
+/// postfix quantifiers `x#` / `x##` and a leading `^` whole-pattern
+/// negation.
+#define LUSH_PATTERN_ZSH_EXTENDED 0x1u
+
+/**
+ * @brief Match `str` against `pattern` with extended options
+ *
+ * Same as lush_pattern_match, but `flags` (a bitwise OR of LUSH_PATTERN_*
+ * values) selects optional dialect behavior. With flags == 0 it is
+ * identical to lush_pattern_match.
+ *
+ * @param str     String to match
+ * @param pattern Pattern to match against
+ * @param flags   Bitwise OR of LUSH_PATTERN_* option flags
+ * @return true on exact match, false otherwise
+ */
+bool lush_pattern_match_ex(const char *str, const char *pattern,
+                           unsigned flags);
 
 #endif /* LUSH_PATTERN_MATCH_H */

--- a/src/builtins/bin_zstyle.c
+++ b/src/builtins/bin_zstyle.c
@@ -36,9 +36,9 @@
  */
 
 #include "builtins.h"
+#include "pattern_match.h"
 #include "symtable.h"
 
-#include <fnmatch.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -79,8 +79,9 @@ static zstyle_entry_t *find_exact(const char *pattern, const char *style) {
 }
 
 /// Find the recorded entry whose pattern matches the query pattern via
-/// fnmatch (i.e., the query pattern is the "context" being looked up).
-/// Returns the first match; future enhancement: specificity ranking.
+/// lush_pattern_match (i.e., the query pattern is the "context" being
+/// looked up). Returns the first match; future enhancement: specificity
+/// ranking.
 static zstyle_entry_t *find_matching(const char *query_pattern,
                                      const char *style) {
     if (!query_pattern || !style) {
@@ -91,7 +92,7 @@ static zstyle_entry_t *find_matching(const char *query_pattern,
     if (exact) {
         return exact;
     }
-    /// Then fnmatch: recorded pattern's wildcards expand against the
+    /// Then glob-match: recorded pattern's wildcards expand against the
     /// query pattern. (Reverse of the conventional zsh lookup, where the
     /// query is a specific context string and recorded patterns match
     /// against it. For corpus purposes both directions cover the same
@@ -100,8 +101,8 @@ static zstyle_entry_t *find_matching(const char *query_pattern,
         if (strcmp(e->style, style) != 0) {
             continue;
         }
-        if (fnmatch(e->pattern, query_pattern, 0) == 0 ||
-            fnmatch(query_pattern, e->pattern, 0) == 0) {
+        if (lush_pattern_match(query_pattern, e->pattern) ||
+            lush_pattern_match(e->pattern, query_pattern)) {
             return e;
         }
     }

--- a/src/executor.c
+++ b/src/executor.c
@@ -44,7 +44,6 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <fnmatch.h>
 #include <glob.h>
 #include <math.h>
 #include <pwd.h>
@@ -7158,182 +7157,6 @@ static bool has_extglob_pattern(const char *pattern) {
 }
 
 /**
- * @brief Convert extglob pattern to regex pattern
- *
- * Converts bash extglob syntax to POSIX extended regex:
- *   ?(pat)  -> (pat)?
- *   *(pat)  -> (pat)*
- *   +(pat)  -> (pat)+
- *   @(pat)  -> (pat)
- *   !(pat)  -> handled specially (negative match)
- *   *       -> .*
- *   ?       -> .
- *   .       -> \.
- *
- * @param pattern Extglob pattern
- * @param is_negated Output: true if pattern uses !(...)
- * @return Regex pattern (caller must free), or NULL on error
- */
-static char *extglob_to_regex(const char *pattern, bool *is_negated) {
-    if (!pattern)
-        return NULL;
-
-    *is_negated = false;
-
-    /// Allocate generous buffer (pattern can expand significantly)
-    size_t max_len = strlen(pattern) * 4 + 10;
-    char *regex = malloc(max_len);
-    if (!regex)
-        return NULL;
-
-    char *out = regex;
-    *out++ = '^'; /// Anchor at start
-
-    const char *p = pattern;
-    while (*p) {
-        /// Check for extglob operators
-        if ((*p == '?' || *p == '*' || *p == '+' || *p == '@' || *p == '!') &&
-            *(p + 1) == '(') {
-            char op = *p;
-            p += 2; /// Skip operator and (
-
-            /// Find matching closing paren
-            int depth = 1;
-            const char *start = p;
-            while (*p && depth > 0) {
-                if (*p == '(')
-                    depth++;
-                else if (*p == ')')
-                    depth--;
-                if (depth > 0)
-                    p++;
-            }
-
-            if (depth != 0) {
-                /// Unmatched paren - treat literally
-                free(regex);
-                return NULL;
-            }
-
-            /// Copy the inner pattern
-            *out++ = '(';
-            size_t inner_len = p - start;
-
-            /// Convert inner pattern (replace | with |, escape regex chars)
-            for (size_t i = 0; i < inner_len; i++) {
-                char c = start[i];
-                if (c == '*') {
-                    *out++ = '.';
-                    *out++ = '*';
-                } else if (c == '?') {
-                    *out++ = '.';
-                } else if (c == '.') {
-                    *out++ = '\\';
-                    *out++ = '.';
-                } else if (c == '|') {
-                    *out++ = '|';
-                } else {
-                    *out++ = c;
-                }
-            }
-            *out++ = ')';
-
-            /// Add quantifier based on operator
-            switch (op) {
-            case '?':
-                *out++ = '?';
-                break;
-            case '*':
-                *out++ = '*';
-                break;
-            case '+':
-                *out++ = '+';
-                break;
-            case '@': /// exactly one, no quantifier
-                break;
-            case '!':
-                *is_negated = true;
-                break;
-            }
-
-            p++; /// Skip closing paren
-        } else if (*p == '*') {
-            /// Glob * -> regex .*
-            *out++ = '.';
-            *out++ = '*';
-            p++;
-        } else if (*p == '?') {
-            /// Glob ? -> regex .
-            *out++ = '.';
-            p++;
-        } else if (*p == '.') {
-            /// Escape literal dot
-            *out++ = '\\';
-            *out++ = '.';
-            p++;
-        } else if (*p == '[') {
-            /// Character class - copy as-is until ]
-            *out++ = *p++;
-            while (*p && *p != ']') {
-                *out++ = *p++;
-            }
-            if (*p == ']') {
-                *out++ = *p++;
-            }
-        } else {
-            /// Regular character - might need escaping
-            if (strchr("^$+{}\\", *p)) {
-                *out++ = '\\';
-            }
-            *out++ = *p++;
-        }
-    }
-
-    *out++ = '$'; /// Anchor at end
-    *out = '\0';
-
-    return regex;
-}
-
-/**
- * @brief Match filename against extglob pattern
- *
- * @param filename Filename to match
- * @param pattern Extglob pattern
- * @return true if matches
- */
-static bool match_extglob(const char *filename, const char *pattern) {
-    if (!regex_pattern_is_safe(pattern)) {
-        return false;
-    }
-    bool is_negated = false;
-    char *regex_pattern = extglob_to_regex(pattern, &is_negated);
-    if (!regex_pattern) {
-        return false;
-    }
-
-    regex_t regex;
-    int ret = regcomp(&regex, regex_pattern, REG_EXTENDED | REG_NOSUB);
-    free(regex_pattern);
-
-    if (ret != 0) {
-        return false;
-    }
-
-    ret = regexec(&regex, filename, 0, NULL, 0);
-    regfree(&regex);
-
-    bool matches = (ret == 0);
-
-    /// For !(pattern), invert the result
-    if (is_negated) {
-        matches = !matches;
-    }
-
-    return matches;
-}
-
-/**
  * @brief Expand extglob pattern by reading directory and matching
  *
  * @param pattern Pattern with extglob syntax
@@ -7386,7 +7209,7 @@ static char **expand_extglob_pattern(const char *pattern, int *expanded_count) {
             }
         }
 
-        if (match_extglob(entry->d_name, file_pattern)) {
+        if (lush_pattern_match(entry->d_name, file_pattern)) {
             /// Resize array if needed
             if (count >= capacity) {
                 capacity = capacity ? capacity * 2 : 16;
@@ -7678,7 +7501,8 @@ static char **expand_globstar_pattern(const char *pattern,
  * flag to change that (GLOB_PERIOD is a glibc/_GNU_SOURCE extension,
  * absent on macOS). The zsh `(D)` glob qualifier explicitly requests
  * dotfile inclusion, so for D-qualified patterns scan the directory
- * directly with readdir + fnmatch. `.` and `..` are always excluded.
+ * directly with readdir + lush_pattern_match. `.` and `..` are always
+ * excluded.
  *
  * Only single-component patterns and `dir/filepat` forms are handled
  * (the qualifier-glob syntax in practice never nests deeper). Results
@@ -7725,9 +7549,9 @@ static char **expand_glob_dotglob(const char *base_pattern,
             strcmp(entry->d_name, "..") == 0) {
             continue;
         }
-        /// fnmatch without FNM_PERIOD: `*` matches leading-dot names,
-        /// which is exactly the D-qualifier semantics.
-        if (fnmatch(filepat, entry->d_name, 0) != 0) {
+        /// lush_pattern_match has no FNM_PERIOD analogue: `*` matches
+        /// leading-dot names, which is exactly the D-qualifier semantics.
+        if (!lush_pattern_match(entry->d_name, filepat)) {
             continue;
         }
         /// Build the path as the caller would see it.
@@ -10392,20 +10216,17 @@ static char *convert_case_first_lower(const char *str) {
  *
  * `${var^^[pat]}` / `${var,,[pat]}` / `${var^[pat]}` / `${var,[pat]}`
  * apply case conversion only to characters that match `pattern`.
- * `pattern` is fnmatch-style and matched against each codepoint's
- * UTF-8 byte sequence. If `first_only` is true, only the first matching
- * codepoint is converted (the `^` / `,` operators); otherwise all
- * matches convert (`^^` / `,,`).
+ * `pattern` is a glob pattern matched against each codepoint's UTF-8
+ * byte sequence via lush_pattern_match. If `first_only` is true, only
+ * the first matching codepoint is converted (the `^` / `,` operators);
+ * otherwise all matches convert (`^^` / `,,`).
  *
  * Iteration is by codepoint via lle_utf8_decode_codepoint; case
  * mapping goes through lle_unicode_toupper_codepoint /
  * lle_unicode_tolower_codepoint so non-ASCII letters convert correctly.
- * Pattern matching is fnmatch against the codepoint's UTF-8 bytes:
- * ASCII patterns like `[aeiou]` and Unicode patterns like `[äöü]`
- * both work; full Unicode general-category char-classes
- * (`[[:alpha:]]`) are still byte-class-bound in the matcher — that
- * is a separate audit item (see UNICODE_AUDIT_WORKLIST.md C-verdict
- * #2).
+ * lush_pattern_match is codepoint-aware, so ASCII patterns like
+ * `[aeiou]`, Unicode literals/ranges like `[äöü]`, and Unicode
+ * general-category char-classes like `[[:alpha:]]` all work.
  *
  * @param str Input string
  * @param pattern Glob pattern (may be NULL/empty -- treated as "any char")
@@ -10463,7 +10284,7 @@ static char *convert_case_pattern(const char *str, const char *pattern,
                 should_convert = false;
             } else {
                 utf8_buf[enc] = '\0';
-                should_convert = (fnmatch(pattern, utf8_buf, 0) == 0);
+                should_convert = lush_pattern_match(utf8_buf, pattern);
             }
         }
 
@@ -10690,10 +10511,10 @@ static char *pattern_substitute(const char *str, const char *pattern,
     size_t pattern_len = strlen(pattern);
     size_t replacement_len = strlen(replacement);
 
-    /// Detect glob metacharacters that route through fnmatch. The
-    /// original check missed `[` (character class) and treated `[bd]`
-    /// patterns as exact-substring matches, which never matched
-    /// because the literal string never contained `[bd]`. fnmatch
+    /// Detect glob metacharacters that route through lush_pattern_match.
+    /// The original check missed `[` (character class) and treated `[bd]`
+    /// patterns as exact-substring matches, which never matched because
+    /// the literal string never contained `[bd]`. lush_pattern_match
     /// supports character classes natively.
     bool is_glob =
         (strchr(pattern, '*') || strchr(pattern, '?') || strchr(pattern, '['));
@@ -10713,7 +10534,7 @@ static char *pattern_substitute(const char *str, const char *pattern,
                 }
                 memcpy(substr, str, try_len);
                 substr[try_len] = '\0';
-                if (fnmatch(pattern, substr, 0) == 0) {
+                if (lush_pattern_match(substr, pattern)) {
                     matched = true;
                     match_len = try_len;
                     /// For glob with *, prefer longest match.
@@ -10726,7 +10547,7 @@ static char *pattern_substitute(const char *str, const char *pattern,
                             }
                             memcpy(l, str, longer);
                             l[longer] = '\0';
-                            if (fnmatch(pattern, l, 0) == 0) {
+                            if (lush_pattern_match(l, pattern)) {
                                 match_len = longer;
                             }
                             free(l);
@@ -10773,7 +10594,7 @@ static char *pattern_substitute(const char *str, const char *pattern,
                 }
                 memcpy(substr, str + start, try_len);
                 substr[try_len] = '\0';
-                if (fnmatch(pattern, substr, 0) == 0) {
+                if (lush_pattern_match(substr, pattern)) {
                     matched = true;
                     match_len = try_len;
                     free(substr);
@@ -10821,14 +10642,14 @@ static char *pattern_substitute(const char *str, const char *pattern,
 
         /// Simple pattern matching - check for exact match or glob
         if (is_glob) {
-            /// Use fnmatch for glob patterns
+            /// Use lush_pattern_match for glob patterns
             /// Try increasing lengths to find the match
             for (size_t try_len = 1; try_len <= str_len - i; try_len++) {
                 char *substr = malloc(try_len + 1);
                 if (substr) {
                     strncpy(substr, str + i, try_len);
                     substr[try_len] = '\0';
-                    if (fnmatch(pattern, substr, 0) == 0) {
+                    if (lush_pattern_match(substr, pattern)) {
                         matched = true;
                         match_len = try_len;
                         /// For greedy matching with *, keep trying longer
@@ -10839,8 +10660,8 @@ static char *pattern_substitute(const char *str, const char *pattern,
                                 if (longer_substr) {
                                     strncpy(longer_substr, str + i, longer);
                                     longer_substr[longer] = '\0';
-                                    if (fnmatch(pattern, longer_substr, 0) ==
-                                        0) {
+                                    if (lush_pattern_match(longer_substr,
+                                                           pattern)) {
                                         match_len = longer;
                                     }
                                     free(longer_substr);
@@ -13545,7 +13366,8 @@ static char *parse_parameter_expansion(executor_t *executor,
                         /// zsh subscript flags ${arr[(r)pat]} / ${arr[(R)pat]}:
                         /// return the VALUE of the first / last element
                         /// matching pat, or empty string on no match.
-                        /// pat is fnmatch-style. Issue #104.
+                        /// pat is a glob pattern (lush_pattern_match). Issue
+                        /// #104.
                         bool last_match = (subscript[1] == 'R');
                         const char *pat = subscript + 3;
                         size_t total = symtable_array_length(array);
@@ -13560,7 +13382,7 @@ static char *parse_parameter_expansion(executor_t *executor,
                             }
                             bool match;
                             if (is_glob) {
-                                match = (fnmatch(pat, elem, 0) == 0);
+                                match = lush_pattern_match(elem, pat);
                             } else {
                                 match = (strcmp(elem, pat) == 0);
                             }
@@ -13578,7 +13400,8 @@ static char *parse_parameter_expansion(executor_t *executor,
                         /// zsh subscript flags ${arr[(i)pat]} / ${arr[(I)pat]}:
                         /// return the 1-based index of the first / last
                         /// element matching pat, or N+1 / 0 if no match.
-                        /// pat is fnmatch-style. Issue #99.
+                        /// pat is a glob pattern (lush_pattern_match). Issue
+                        /// #99.
                         bool last_index = (subscript[1] == 'I');
                         const char *pat = subscript + 3;
                         size_t total = symtable_array_length(array);
@@ -13594,7 +13417,7 @@ static char *parse_parameter_expansion(executor_t *executor,
                             }
                             bool match;
                             if (is_glob) {
-                                match = (fnmatch(pat, elem, 0) == 0);
+                                match = lush_pattern_match(elem, pat);
                             } else {
                                 match = (strcmp(elem, pat) == 0);
                             }
@@ -14635,7 +14458,8 @@ static char *parse_parameter_expansion(executor_t *executor,
             /// as `/.` -- silently producing the original string back.
             /// Walk the spec and break at the first unescaped `/`.
             /// Backslash-escapes other than `\/` pass through to
-            /// fnmatch which handles them per glob spec. Issue #96.
+            /// lush_pattern_match which handles them per glob spec.
+            /// Issue #96.
             if (var_value) {
                 char *sep = NULL;
                 for (char *p = expanded_default; *p; p++) {

--- a/src/executor.c
+++ b/src/executor.c
@@ -6823,144 +6823,6 @@ static bool has_zsh_extglob_pattern(const char *pattern) {
 }
 
 /**
- * @brief Convert zsh extglob pattern to POSIX extended regex
- *
- * Converts zsh extended glob syntax to regex:
- *   X#   -> X* (zero or more)
- *   X##  -> X+ (one or more)
- *   (a|b) -> (a|b) (alternation)
- *   [...]# -> [...]* (char class zero or more)
- *   *    -> .* (any chars)
- *   ?    -> . (any single char)
- *   .    -> \. (literal dot)
- *
- * @param pattern Zsh extglob pattern (without leading ^ if negation)
- * @return Regex pattern (caller must free), or NULL on error
- */
-static char *zsh_extglob_to_regex(const char *pattern) {
-    if (!pattern)
-        return NULL;
-
-    /// Allocate generous buffer
-    size_t max_len = strlen(pattern) * 4 + 10;
-    char *regex = malloc(max_len);
-    if (!regex)
-        return NULL;
-
-    char *out = regex;
-    *out++ = '^'; /// Anchor at start
-
-    const char *p = pattern;
-    while (*p) {
-        if (*p == '[') {
-            /// Character class - copy until ]
-            *out++ = *p++;
-            /// Handle negation [^ or [!
-            if (*p == '^' || *p == '!') {
-                *out++ = '^';
-                p++;
-            }
-            /// Handle ] as first char (literal)
-            if (*p == ']') {
-                *out++ = *p++;
-            }
-            while (*p && *p != ']') {
-                *out++ = *p++;
-            }
-            if (*p == ']') {
-                *out++ = *p++;
-            }
-            /// Check for # or ## after char class
-            if (*p == '#') {
-                if (*(p + 1) == '#') {
-                    *out++ = '+'; /// ## = one or more
-                    p += 2;
-                } else {
-                    *out++ = '*'; /// # = zero or more
-                    p++;
-                }
-            }
-        } else if (*p == '(') {
-            /// Alternation group - copy as-is, handling nested parens
-            *out++ = *p++;
-            int depth = 1;
-            while (*p && depth > 0) {
-                if (*p == '(') {
-                    depth++;
-                    *out++ = *p++;
-                } else if (*p == ')') {
-                    depth--;
-                    *out++ = *p++;
-                } else if (*p == '*') {
-                    /// Glob * inside alternation
-                    *out++ = '.';
-                    *out++ = '*';
-                    p++;
-                } else if (*p == '?') {
-                    *out++ = '.';
-                    p++;
-                } else if (*p == '.') {
-                    *out++ = '\\';
-                    *out++ = '.';
-                    p++;
-                } else {
-                    *out++ = *p++;
-                }
-            }
-        } else if (*p == '*') {
-            /// Glob * -> regex .*
-            *out++ = '.';
-            *out++ = '*';
-            p++;
-        } else if (*p == '?') {
-            /// Glob ? -> regex .
-            *out++ = '.';
-            p++;
-        } else if (*p == '.') {
-            /// Escape literal dot
-            *out++ = '\\';
-            *out++ = '.';
-            p++;
-        } else if (*p == '#') {
-            /// Standalone # - should not happen if preceded by nothing
-            /// Skip it (treat as literal)
-            *out++ = '#';
-            p++;
-        } else {
-            /// Regular character
-            char c = *p++;
-            /// Check for # or ## quantifier after this char
-            if (*p == '#') {
-                /// Need to wrap single char in group for regex
-                /// But first, escape regex metacharacters
-                if (strchr("^$+{}\\|()", c)) {
-                    *out++ = '\\';
-                }
-                *out++ = c;
-                if (*(p + 1) == '#') {
-                    *out++ = '+'; /// ## = one or more
-                    p += 2;
-                } else {
-                    *out++ = '*'; /// # = zero or more
-                    p++;
-                }
-            } else {
-                /// No quantifier - regular char, might need escaping
-                if (strchr("^$+{}\\|", c)) {
-                    *out++ = '\\';
-                }
-                *out++ = c;
-            }
-        }
-    }
-
-    *out++ = '$'; /// Anchor at end
-    *out = '\0';
-
-    return regex;
-}
-
-/**
  * @brief Reject regex patterns that exceed behavior.regex_pattern_max length.
  *
  * Platform regcomp implementations (TRE on macOS, glibc regex on Linux)
@@ -6986,38 +6848,6 @@ static bool regex_pattern_is_safe(const char *pattern) {
         return true; /// explicitly unbounded
     }
     return strlen(pattern) <= (size_t)config.regex_pattern_max;
-}
-
-/// @brief Match filename against zsh extglob pattern
-static bool match_zsh_extglob(const char *filename, const char *pattern,
-                              bool is_negated) {
-    if (!regex_pattern_is_safe(pattern)) {
-        return false;
-    }
-    char *regex_pattern = zsh_extglob_to_regex(pattern);
-    if (!regex_pattern) {
-        return false;
-    }
-
-    regex_t regex;
-    int ret = regcomp(&regex, regex_pattern, REG_EXTENDED | REG_NOSUB);
-    free(regex_pattern);
-
-    if (ret != 0) {
-        return false;
-    }
-
-    ret = regexec(&regex, filename, 0, NULL, 0);
-    regfree(&regex);
-
-    bool matches = (ret == 0);
-
-    /// For ^pattern, invert the result
-    if (is_negated) {
-        matches = !matches;
-    }
-
-    return matches;
 }
 
 /// @brief Expand zsh extglob pattern by reading directory and matching
@@ -7075,7 +6905,12 @@ static char **expand_zsh_extglob_pattern(const char *pattern,
             continue;
         }
 
-        if (match_zsh_extglob(entry->d_name, file_pattern, is_negated)) {
+        bool zsh_match = lush_pattern_match_ex(entry->d_name, file_pattern,
+                                               LUSH_PATTERN_ZSH_EXTENDED);
+        if (is_negated) {
+            zsh_match = !zsh_match;
+        }
+        if (zsh_match) {
             /// Grow array if needed
             if (result_count >= result_capacity) {
                 size_t new_capacity =

--- a/src/pattern_match.c
+++ b/src/pattern_match.c
@@ -285,8 +285,50 @@ static int match_char_class(const char *s, const char *p, const char **end,
 }
 
 /* Forward declaration: the matcher is mutually recursive with the
- * alternative-branch composer. */
-static bool match(const char *s, const char *p);
+ * alternative-branch composer. `flags` carries LUSH_PATTERN_* options
+ * (currently only the zsh-extended `#`/`##` postfix quantifiers). */
+static bool match(const char *s, const char *p, unsigned flags);
+
+/**
+ * @brief End of a quantifiable atom for zsh `#`/`##`, or NULL
+ *
+ * A "quantifiable atom" is the smallest pattern unit that a trailing
+ * zsh `#` (zero-or-more) or `##` (one-or-more) repeats: a `[...]`
+ * character class, a `\`-escaped character, or a single literal
+ * codepoint. The glob-control characters `*?()|` do not begin a
+ * quantifiable atom (they are handled by their own matcher branches),
+ * so this returns NULL for them and for an unterminated `[`.
+ */
+static const char *find_quantifiable_atom_end(const char *p) {
+    if (*p == '[') {
+        const char *q = p + 1;
+        if (*q == '!' || *q == '^') {
+            q++;
+        }
+        if (*q == ']') {
+            q++;
+        }
+        while (*q && *q != ']') {
+            if (*q == '\\' && q[1]) {
+                q += 2;
+            } else {
+                q++;
+            }
+        }
+        return (*q == ']') ? q + 1 : NULL;
+    }
+    if (*p == '\\' && p[1]) {
+        size_t b;
+        (void)decode_one(p + 1, &b);
+        return p + 1 + b;
+    }
+    if (*p && !strchr("*?()|", *p)) {
+        size_t b;
+        (void)decode_one(p, &b);
+        return p + b;
+    }
+    return NULL;
+}
 
 /**
  * @brief Match `s` against (alt-text + rest_pattern) by composition
@@ -297,7 +339,8 @@ static bool match(const char *s, const char *p);
  * as failure (the caller continues with other alternatives).
  */
 static bool match_alt_plus_rest(const char *s, const char *alt_start,
-                                const char *alt_end, const char *rest) {
+                                const char *alt_end, const char *rest,
+                                unsigned flags) {
     size_t alt_len = (size_t)(alt_end - alt_start);
     size_t rest_len = strlen(rest);
     char *composite = malloc(alt_len + rest_len + 1);
@@ -307,7 +350,7 @@ static bool match_alt_plus_rest(const char *s, const char *alt_start,
     memcpy(composite, alt_start, alt_len);
     memcpy(composite + alt_len, rest, rest_len);
     composite[alt_len + rest_len] = '\0';
-    bool r = match(s, composite);
+    bool r = match(s, composite, flags);
     free(composite);
     return r;
 }
@@ -321,8 +364,8 @@ static bool match_alt_plus_rest(const char *s, const char *alt_start,
  * pattern or OOM yields false.
  */
 static bool alt_matches_exact_prefix(const char *s, size_t s_len,
-                                     const char *alt_start,
-                                     const char *alt_end) {
+                                     const char *alt_start, const char *alt_end,
+                                     unsigned flags) {
     size_t alt_len = (size_t)(alt_end - alt_start);
     char *alt_buf = malloc(alt_len + 1);
     char *s_buf = malloc(s_len + 1);
@@ -335,7 +378,7 @@ static bool alt_matches_exact_prefix(const char *s, size_t s_len,
     alt_buf[alt_len] = '\0';
     memcpy(s_buf, s, s_len);
     s_buf[s_len] = '\0';
-    bool r = match(s_buf, alt_buf);
+    bool r = match(s_buf, alt_buf, flags);
     free(alt_buf);
     free(s_buf);
     return r;
@@ -353,8 +396,35 @@ static bool alt_matches_exact_prefix(const char *s, size_t s_len,
  * to per-operator handling; otherwise consumes one glob token from `p`
  * (`*`, `?`, `[...]`, `\X`, or literal) and recurses on the remainder.
  */
-static bool match(const char *s, const char *p) {
+static bool match(const char *s, const char *p, unsigned flags) {
     while (*p) {
+        /// zsh-extended `#` (zero-or-more) / `##` (one-or-more) postfix
+        /// quantifiers. An atom immediately followed by `#`/`##` is
+        /// equivalent to the extglob group `*(atom)` / `+(atom)`, so
+        /// synthesize that form and reuse the tested extglob machinery.
+        if (flags & LUSH_PATTERN_ZSH_EXTENDED) {
+            const char *atom_end = find_quantifiable_atom_end(p);
+            if (atom_end && *atom_end == '#') {
+                bool one_or_more = (atom_end[1] == '#');
+                const char *rest = one_or_more ? atom_end + 2 : atom_end + 1;
+                size_t atom_len = (size_t)(atom_end - p);
+                size_t rest_len = strlen(rest);
+                char *synth = malloc(2 + atom_len + 1 + rest_len + 1);
+                if (!synth) {
+                    return false;
+                }
+                synth[0] = one_or_more ? '+' : '*';
+                synth[1] = '(';
+                memcpy(synth + 2, p, atom_len);
+                synth[2 + atom_len] = ')';
+                memcpy(synth + 3 + atom_len, rest, rest_len);
+                synth[3 + atom_len + rest_len] = '\0';
+                bool r = match(s, synth, flags);
+                free(synth);
+                return r;
+            }
+        }
+
         char op = 0;
         const char *paren_inside = NULL;
         if ((*p == '?' || *p == '*' || *p == '+' || *p == '@' || *p == '!') &&
@@ -378,7 +448,7 @@ static bool match(const char *s, const char *p) {
                 const char *alt_start = paren_inside;
                 while (alt_start <= close) {
                     const char *sep = find_next_alt_separator(alt_start, close);
-                    if (match_alt_plus_rest(s, alt_start, sep, rest)) {
+                    if (match_alt_plus_rest(s, alt_start, sep, rest, flags)) {
                         return true;
                     }
                     if (sep == close) {
@@ -391,14 +461,14 @@ static bool match(const char *s, const char *p) {
 
             if (op == '?') {
                 /// Zero occurrences: rest matches whole s.
-                if (match(s, rest)) {
+                if (match(s, rest, flags)) {
                     return true;
                 }
                 /// One occurrence: identical to @.
                 const char *alt_start = paren_inside;
                 while (alt_start <= close) {
                     const char *sep = find_next_alt_separator(alt_start, close);
-                    if (match_alt_plus_rest(s, alt_start, sep, rest)) {
+                    if (match_alt_plus_rest(s, alt_start, sep, rest, flags)) {
                         return true;
                     }
                     if (sep == close) {
@@ -411,7 +481,7 @@ static bool match(const char *s, const char *p) {
 
             if (op == '*' || op == '+') {
                 /// Zero (only valid for `*`): rest matches whole s.
-                if (op == '*' && match(s, rest)) {
+                if (op == '*' && match(s, rest, flags)) {
                     return true;
                 }
                 /// One-or-more: pick an alternative, match it against a
@@ -445,9 +515,9 @@ static bool match(const char *s, const char *p) {
                     while (alt_start <= close && !found) {
                         const char *sep =
                             find_next_alt_separator(alt_start, close);
-                        if (alt_matches_exact_prefix(s, split, alt_start,
-                                                     sep)) {
-                            if (match(s + split, kleene)) {
+                        if (alt_matches_exact_prefix(s, split, alt_start, sep,
+                                                     flags)) {
+                            if (match(s + split, kleene, flags)) {
                                 found = true;
                             }
                         }
@@ -473,8 +543,8 @@ static bool match(const char *s, const char *p) {
                     while (alt_start <= close) {
                         const char *sep =
                             find_next_alt_separator(alt_start, close);
-                        if (alt_matches_exact_prefix(s, split, alt_start,
-                                                     sep)) {
+                        if (alt_matches_exact_prefix(s, split, alt_start, sep,
+                                                     flags)) {
                             any_alt_matches = true;
                             break;
                         }
@@ -483,7 +553,7 @@ static bool match(const char *s, const char *p) {
                         }
                         alt_start = sep + 1;
                     }
-                    if (!any_alt_matches && match(s + split, rest)) {
+                    if (!any_alt_matches && match(s + split, rest, flags)) {
                         return true;
                     }
                 }
@@ -503,7 +573,7 @@ static bool match(const char *s, const char *p) {
             /// stepping is both faster and more principled than the
             /// prior byte-stepping `s++`.
             while (*s) {
-                if (match(s, p)) {
+                if (match(s, p, flags)) {
                     return true;
                 }
                 size_t step;
@@ -513,7 +583,7 @@ static bool match(const char *s, const char *p) {
                 }
                 s += step;
             }
-            return match(s, p); /// try with empty tail
+            return match(s, p, flags); /// try with empty tail
         }
         if (*p == '?') {
             if (*s == '\0') {
@@ -563,8 +633,19 @@ static bool match(const char *s, const char *p) {
 }
 
 bool lush_pattern_match(const char *str, const char *pattern) {
+    return lush_pattern_match_ex(str, pattern, 0);
+}
+
+bool lush_pattern_match_ex(const char *str, const char *pattern,
+                           unsigned flags) {
     if (!str || !pattern) {
         return false;
     }
-    return match(str, pattern);
+    /// zsh-extended leading `^` negates the whole pattern (the rest is
+    /// matched and the result inverted). Only honored at pattern start,
+    /// matching the historical zsh extended-glob filename behavior.
+    if ((flags & LUSH_PATTERN_ZSH_EXTENDED) && pattern[0] == '^') {
+        return !match(str, pattern + 1, flags);
+    }
+    return match(str, pattern, flags);
 }

--- a/tests/unit/test_pattern_match.c
+++ b/tests/unit/test_pattern_match.c
@@ -230,6 +230,54 @@ TEST(bracket_negation_unicode) {
 }
 
 /* ============================================================================
+ * Zsh extended-glob (LUSH_PATTERN_ZSH_EXTENDED): `#`/`##` + leading `^`
+ * ============================================================================
+ */
+
+TEST(zsh_ext_hash_zero_or_more) {
+    /// `x#` matches zero or more of x (like `*(x)`).
+    unsigned f = LUSH_PATTERN_ZSH_EXTENDED;
+    ASSERT(lush_pattern_match_ex("", "a#", f), "zero a's");
+    ASSERT(lush_pattern_match_ex("aaaa", "a#", f), "many a's");
+    ASSERT(!lush_pattern_match_ex("aaab", "a#", f), "trailing b fails");
+    /// Without the flag, `#` is a literal character.
+    ASSERT(lush_pattern_match_ex("a#", "a#", 0), "# literal without flag");
+    ASSERT(!lush_pattern_match_ex("aaaa", "a#", 0),
+           "no quantifier without flag");
+}
+
+TEST(zsh_ext_hashhash_one_or_more) {
+    /// `x##` matches one or more of x (like `+(x)`).
+    unsigned f = LUSH_PATTERN_ZSH_EXTENDED;
+    ASSERT(!lush_pattern_match_ex("", "a##", f), "zero a's fails one-or-more");
+    ASSERT(lush_pattern_match_ex("a", "a##", f), "one a");
+    ASSERT(lush_pattern_match_ex("aaaa", "a##", f), "many a's");
+}
+
+TEST(zsh_ext_hash_charclass_and_suffix) {
+    /// Quantifier applies to a `[...]` atom, with a literal suffix after.
+    unsigned f = LUSH_PATTERN_ZSH_EXTENDED;
+    ASSERT(lush_pattern_match_ex("123.txt", "[0-9]#.txt", f),
+           "digits then .txt");
+    ASSERT(lush_pattern_match_ex(".txt", "[0-9]#.txt", f),
+           "zero digits then .txt");
+    ASSERT(lush_pattern_match_ex("7.txt", "[0-9]##.txt", f),
+           "one-or-more digits");
+    ASSERT(!lush_pattern_match_ex(".txt", "[0-9]##.txt", f),
+           "zero digits fails one-or-more");
+}
+
+TEST(zsh_ext_leading_caret_negates) {
+    /// A leading `^` negates the whole pattern.
+    unsigned f = LUSH_PATTERN_ZSH_EXTENDED;
+    ASSERT(lush_pattern_match_ex("world", "^h*", f), "world is not h*");
+    ASSERT(!lush_pattern_match_ex("hello", "^h*", f),
+           "hello matches h*, negated");
+    /// Without the flag, leading `^` is a literal.
+    ASSERT(lush_pattern_match_ex("^h", "^h", 0), "^ literal without flag");
+}
+
+/* ============================================================================
  * MAIN
  * ============================================================================
  */
@@ -260,6 +308,12 @@ int main(void) {
     printf("\nZsh bare alternation:\n");
     RUN_TEST(zsh_bare_alt_equiv_to_at);
     RUN_TEST(zsh_bare_alt_with_empty);
+
+    printf("\nZsh extended glob (#/##/^):\n");
+    RUN_TEST(zsh_ext_hash_zero_or_more);
+    RUN_TEST(zsh_ext_hashhash_one_or_more);
+    RUN_TEST(zsh_ext_hash_charclass_and_suffix);
+    RUN_TEST(zsh_ext_leading_caret_negates);
 
     printf("\nEdge cases:\n");
     RUN_TEST(null_inputs);


### PR DESCRIPTION
## Summary
Completes the de-duplication of shell pattern matching that #152 began. The duplicate-path audit found that #152 unified only `case` + the prefix/suffix strip operators; several live duplicates of the canonical `lush_pattern_match` (`src/pattern_match.c`) remained. This removes all of them.

**Commit 1 — bash extglob + all `fnmatch` sites:**
- Deleted the regex-compiling bash-extglob filename matcher (`extglob_to_regex` / `match_extglob`).
- Migrated 9 `fnmatch()` call sites: `${var/pat/rep}` (`pattern_substitute`), `${var^^[pat]}` case conversion, the zsh `(r)`/`(R)`/`(i)`/`(I)` array-subscript flags, the `(D)` dotglob qualifier, and `zstyle` context lookup.
- `fnmatch` is `(pattern, string)`; `lush_pattern_match` is `(string, pattern)` — arg order swapped at each site.
- Bonus: `${var^^[[:alpha:]]}` and friends now honor Unicode general-category classes (the `[:class:]` support from #152).

**Commit 2 — zsh `#`/`##`/`^` extended glob:**
- Added a new `lush_pattern_match_ex(str, pattern, flags)` entry point gated by `LUSH_PATTERN_ZSH_EXTENDED`, leaving default callers untouched.
- `x#`/`x##` are implemented by synthesizing the equivalent `*(atom)`/`+(atom)` extglob group and reusing the tested extglob engine — no parallel repetition path. Leading `^` negates the whole match.
- Routed `expand_zsh_extglob_pattern` through it and deleted `zsh_extglob_to_regex` / `match_zsh_extglob`.

One matcher now backs `case`, `[[ == ]]`, every parameter pattern operator, the `(r)`/`(i)` subscript flags, filename globbing (plain + bash extglob + zsh extended), and `zstyle`.

## Test plan
- [x] New `lush_pattern_match_ex` unit tests: `x#`, `x##`, `[class]#/##`, leading `^`, plus without-flag literal behavior
- [x] End-to-end in zsh mode: `echo a#.log` → zero-or-more, `echo ^*.log` → negation, both correct
- [x] Full suite 118/118; 0 warnings (werror); clang-format + comment-style clean
- [x] Differential corpus 121/0 unexpected (incl. the `(r)`/`(i)` glob seed)
- Net code removed across both commits (two regex matchers + 9 fnmatch sites deleted)

Note: while testing I found a **pre-existing, unrelated** bug — `echo`/word arguments beginning with a `[...]` bracket glob (e.g. `echo [0-9].txt`) misroute to the `[` test builtin (E1127). It reproduces on default mode with no extended-glob syntax and does not touch this PR's code paths (`ls [5].txt` works). Will file separately.

Fixes #148