### PR TITLE
Fold hand-rolled UTF-8 encoders onto the canonical lle_utf8_encode_codepoint

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2400,7 +2400,8 @@ if fs.exists('tests/unit/test_escape.c')
   test_escape = executable('test_escape',
                            'tests/unit/test_escape.c',
                            'src/escape.c',
-                           include_directories: [inc, include_directories('tests')])
+                           include_directories: [inc, include_directories('tests')],
+                           dependencies: [lle_dep])
   test('Escape Engine', test_escape,
        suite: 'unit',
        timeout: 30)

--- a/src/escape.c
+++ b/src/escape.c
@@ -8,6 +8,8 @@
 
 #include "escape.h"
 
+#include "lle/utf8_support.h"
+
 #include <ctype.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -38,33 +40,6 @@ int lush_escape_basic_char(char c) {
     default:
         return -1;
     }
-}
-
-/// Encode `cp` as UTF-8 into `out` (must hold >= 4 bytes); return byte count.
-static size_t encode_utf8(uint32_t cp, char *out) {
-    if (cp < 0x80) {
-        out[0] = (char)cp;
-        return 1;
-    }
-    if (cp < 0x800) {
-        out[0] = (char)(0xC0 | (cp >> 6));
-        out[1] = (char)(0x80 | (cp & 0x3F));
-        return 2;
-    }
-    if (cp < 0x10000) {
-        out[0] = (char)(0xE0 | (cp >> 12));
-        out[1] = (char)(0x80 | ((cp >> 6) & 0x3F));
-        out[2] = (char)(0x80 | (cp & 0x3F));
-        return 3;
-    }
-    if (cp <= 0x10FFFF) {
-        out[0] = (char)(0xF0 | (cp >> 18));
-        out[1] = (char)(0x80 | ((cp >> 12) & 0x3F));
-        out[2] = (char)(0x80 | ((cp >> 6) & 0x3F));
-        out[3] = (char)(0x80 | (cp & 0x3F));
-        return 4;
-    }
-    return 0;
 }
 
 char *lush_expand_escapes(const char *str, size_t len,
@@ -139,7 +114,10 @@ char *lush_expand_escapes(const char *str, size_t len,
                     }
                     if (n == want) {
                         uint32_t cp = (uint32_t)strtoul(hex, NULL, 16);
-                        pos += encode_utf8(cp, out + pos);
+                        int enc = lle_utf8_encode_codepoint(cp, out + pos);
+                        if (enc > 0) {
+                            pos += (size_t)enc;
+                        }
                         i += 2 + (size_t)n;
                     } else {
                         out[pos++] = str[i++];

--- a/src/lle/keybinding/keybinding_actions.c
+++ b/src/lle/keybinding/keybinding_actions.c
@@ -2968,29 +2968,14 @@ lle_result_t lle_self_insert(lle_editor_t *editor, uint32_t codepoint) {
         clear_completion_menu(editor);
     }
 
-    /// Convert codepoint to UTF-8 bytes
+    /// Convert codepoint to UTF-8 bytes via the canonical encoder.
     char utf8_bytes[4];
-    size_t byte_count = 0;
-
-    if (codepoint < 0x80) {
-        utf8_bytes[0] = (char)codepoint;
-        byte_count = 1;
-    } else if (codepoint < 0x800) {
-        utf8_bytes[0] = (char)(0xC0 | (codepoint >> 6));
-        utf8_bytes[1] = (char)(0x80 | (codepoint & 0x3F));
-        byte_count = 2;
-    } else if (codepoint < 0x10000) {
-        utf8_bytes[0] = (char)(0xE0 | (codepoint >> 12));
-        utf8_bytes[1] = (char)(0x80 | ((codepoint >> 6) & 0x3F));
-        utf8_bytes[2] = (char)(0x80 | (codepoint & 0x3F));
-        byte_count = 3;
-    } else {
-        utf8_bytes[0] = (char)(0xF0 | (codepoint >> 18));
-        utf8_bytes[1] = (char)(0x80 | ((codepoint >> 12) & 0x3F));
-        utf8_bytes[2] = (char)(0x80 | ((codepoint >> 6) & 0x3F));
-        utf8_bytes[3] = (char)(0x80 | (codepoint & 0x3F));
-        byte_count = 4;
+    int encoded = lle_utf8_encode_codepoint(codepoint, utf8_bytes);
+    if (encoded <= 0) {
+        /// Invalid codepoint (surrogate or out of range): nothing to insert.
+        return LLE_ERROR_INVALID_PARAMETER;
     }
+    size_t byte_count = (size_t)encoded;
 
     /// Insert at cursor
     return lle_buffer_insert_text(editor->buffer,


### PR DESCRIPTION
## Summary
Drain #3 (encode half) of the duplicate-path audit. Two sites byte-composed UTF-8 by hand instead of using the canonical `lle_utf8_encode_codepoint`:
- `escape.c`'s static `encode_utf8` (the `$'...'` `\u`/`\U` path)
- `lle_self_insert` in `keybinding/keybinding_actions.c` (inserting a typed codepoint)

Both deleted in favor of the canonical encoder, which additionally **validates** the codepoint (rejects surrogates `U+D800..U+DFFF` and values above `U+10FFFF`) rather than emitting malformed bytes. `lle_self_insert` now returns `LLE_ERROR_INVALID_PARAMETER` for an unencodable codepoint. `escape.c` gains a liblle dependency, so the standalone `test_escape` target links `lle_dep`.

## Scope note (the other two-thirds of drain #3, deliberately split)
- **Width tables** (`lle_codepoint_width` vs `lle_utf8_codepoint_width`) are a rendering-policy decision (East Asian Ambiguous width is host-dependent) → tracked as **#157** with the agreed plan (char_width.c canonical + TR11 ambiguous classifier + `display.ambiguous_width` config knob).
- **Decode** (`decode_utf8` in `terminal_unix_interface.c`) is a streaming reader on the live keyboard-input path, not a true duplicate → folded into the modifier-key input work (**#155**).

## Test plan
- [x] Full suite 119/119; differential corpus 121/0 unexpected
- [x] `test_escape` green incl. the 4-byte astral `\U0001F600` case
- [x] Clean build (werror) on macOS; CI covers ubuntu
- [x] LLE pre-commit compile check + prefix

Refs #157, #155