### PR TITLE
LLE: collapse pool_strdup statics onto a single inline lle_pool_strdup

### DIFF
--- a/include/lle/memory_management.h
+++ b/include/lle/memory_management.h
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 #include <time.h>
 
 /// Include LLE error handling
@@ -403,6 +404,32 @@ void *lle_pool_alloc(size_t size);
  * @param ptr Pointer returned by lle_pool_alloc (may be NULL)
  */
 void lle_pool_free(void *ptr);
+/**
+ * @brief Duplicate a NUL-terminated string into pool-allocated memory
+ *
+ * Pool-allocator analogue of `strdup`: returns a freshly allocated copy
+ * of `str` (including the trailing NUL) owned by the global pool. NULL
+ * input maps to NULL output; allocation failure also returns NULL. The
+ * result must be freed with `lle_pool_free`.
+ *
+ * Defined inline so unit tests that link a mock `lle_pool_alloc` still
+ * get a consistent strdup wrapper without pulling in the real pool
+ * allocator definition.
+ *
+ * @param str Source string (may be NULL)
+ * @return Pool-allocated copy on success, NULL on NULL input or OOM.
+ */
+static inline char *lle_pool_strdup(const char *str) {
+    if (!str) {
+        return NULL;
+    }
+    size_t bytes = strlen(str) + 1;
+    char *dup = (char *)lle_pool_alloc(bytes);
+    if (dup) {
+        memcpy(dup, str, bytes);
+    }
+    return dup;
+}
 /**
  * @brief Allocate memory from a specific base memory pool
  *

--- a/src/lle/completion/word_context.c
+++ b/src/lle/completion/word_context.c
@@ -45,6 +45,7 @@
  */
 
 #include "lle/completion/word_context.h"
+#include "lle/memory_management.h"
 
 #include "executor.h"
 #include "identifier.h"
@@ -1264,17 +1265,6 @@ static char *pool_substring(const char *buffer, size_t start, size_t end) {
 }
 
 /// Allocate a pool-owned copy of a NUL-terminated string.
-static char *pool_strdup(const char *s) {
-    if (!s)
-        return NULL;
-    size_t len = strlen(s);
-    char *out = lle_pool_alloc(len + 1);
-    if (!out)
-        return NULL;
-    memcpy(out, s, len + 1);
-    return out;
-}
-
 /* True if the path-prefix bytes contain a comma-separated brace list
  * suitable for expand_brace_pattern. We accept either a list (`{a,b}`)
  * or a range (`{1..5}`); both are handled by the existing expander. */
@@ -1456,7 +1446,7 @@ static char *resolve_single_path_prefix(const char *path_prefix,
     if (current_executor) {
         char *expanded = expand_if_needed(current_executor, path_prefix);
         if (expanded && expanded[0]) {
-            char *result = pool_strdup(expanded);
+            char *result = lle_pool_strdup(expanded);
             free(expanded);
             return result;
         }
@@ -1468,7 +1458,7 @@ static char *resolve_single_path_prefix(const char *path_prefix,
     /// uniformly.
     if (path_prefix[0] != '$' && path_prefix[0] != '`' &&
         path_prefix[0] != '~') {
-        return pool_strdup(path_prefix);
+        return lle_pool_strdup(path_prefix);
     }
 
     /// Path begins with an expansion marker we couldn't resolve (e.g.,

--- a/src/lle/history/history_expansion.c
+++ b/src/lle/history/history_expansion.c
@@ -95,27 +95,6 @@ static lle_expansion_context_t g_expansion_ctx = {
  */
 
 /**
- * @brief Duplicate string using memory pool
- *
- * Allocates memory from the LLE memory pool and copies the input string.
- *
- * @param str String to duplicate (may be NULL)
- * @return Pointer to duplicated string, or NULL if str is NULL or allocation
- * fails
- */
-static char *pool_strdup(const char *str) {
-    if (!str)
-        return NULL;
-
-    size_t len = strlen(str) + 1;
-    char *dup = lle_pool_alloc(len);
-    if (dup) {
-        memcpy(dup, str, len);
-    }
-    return dup;
-}
-
-/**
  * @brief Find the next history expansion marker in a string
  *
  * Searches for unescaped '!' characters or '^' at position 0.
@@ -362,7 +341,7 @@ static lle_result_t expand_single_reference(const char *expansion_str,
             return LLE_ERROR_NOT_FOUND;
         }
 
-        result->expanded_command = pool_strdup(entry->command);
+        result->expanded_command = lle_pool_strdup(entry->command);
         if (!result->expanded_command) {
             return LLE_ERROR_OUT_OF_MEMORY;
         }
@@ -410,7 +389,7 @@ static lle_result_t expand_single_reference(const char *expansion_str,
             return LLE_ERROR_NOT_FOUND;
         }
 
-        result->expanded_command = pool_strdup(entry->command);
+        result->expanded_command = lle_pool_strdup(entry->command);
         if (!result->expanded_command) {
             return LLE_ERROR_OUT_OF_MEMORY;
         }
@@ -451,7 +430,7 @@ static lle_result_t expand_single_reference(const char *expansion_str,
 
         const lle_search_result_t *first_result =
             lle_history_search_results_get(search_results, 0);
-        result->expanded_command = pool_strdup(first_result->command);
+        result->expanded_command = lle_pool_strdup(first_result->command);
 
         lle_history_search_results_destroy(search_results);
 
@@ -493,7 +472,7 @@ static lle_result_t expand_single_reference(const char *expansion_str,
 
     const lle_search_result_t *first_result =
         lle_history_search_results_get(search_results, 0);
-    result->expanded_command = pool_strdup(first_result->command);
+    result->expanded_command = lle_pool_strdup(first_result->command);
 
     lle_history_search_results_destroy(search_results);
 
@@ -609,7 +588,7 @@ lle_result_t lle_history_expand_line(const char *command, char **expanded) {
 
     /// Check if expansion is needed
     if (!lle_history_expansion_needed(command)) {
-        *expanded = pool_strdup(command);
+        *expanded = lle_pool_strdup(command);
         return *expanded ? LLE_SUCCESS : LLE_ERROR_OUT_OF_MEMORY;
     }
 
@@ -657,7 +636,7 @@ lle_result_t lle_history_expand_line(const char *command, char **expanded) {
             return LLE_ERROR_INVALID_PARAMETER;
         }
 
-        *expanded = pool_strdup(result);
+        *expanded = lle_pool_strdup(result);
         return *expanded ? LLE_SUCCESS : LLE_ERROR_OUT_OF_MEMORY;
     }
 
@@ -721,7 +700,7 @@ lle_result_t lle_history_expand_line(const char *command, char **expanded) {
     result[result_pos] = '\0';
     g_expansion_ctx.recursion_depth--;
 
-    *expanded = pool_strdup(result);
+    *expanded = lle_pool_strdup(result);
     return *expanded ? LLE_SUCCESS : LLE_ERROR_OUT_OF_MEMORY;
 }
 

--- a/src/lle/history/history_forensics.c
+++ b/src/lle/history/history_forensics.c
@@ -79,27 +79,6 @@ static bool get_terminal_name(char *buffer, size_t size) {
     return false;
 }
 
-/**
- * @brief Duplicate string using memory pool
- *
- * Allocates memory from the LLE memory pool and copies the input string.
- *
- * @param str String to duplicate (may be NULL)
- * @return Pointer to duplicated string, or NULL if str is NULL or allocation
- * fails
- */
-static char *pool_strdup(const char *str) {
-    if (!str)
-        return NULL;
-
-    size_t len = strlen(str) + 1;
-    char *dup = lle_pool_alloc(len);
-    if (dup) {
-        memcpy(dup, str, len);
-    }
-    return dup;
-}
-
 /* ============================================================================
  * PUBLIC API - FORENSIC CONTEXT
  * ============================================================================
@@ -152,7 +131,7 @@ lle_result_t lle_forensic_capture_context(lle_forensic_context_t *context) {
     /// Capture terminal name
     char tty_buffer[256];
     if (get_terminal_name(tty_buffer, sizeof(tty_buffer))) {
-        context->terminal_name = pool_strdup(tty_buffer);
+        context->terminal_name = lle_pool_strdup(tty_buffer);
     } else {
         context->terminal_name = NULL;
     }
@@ -160,7 +139,7 @@ lle_result_t lle_forensic_capture_context(lle_forensic_context_t *context) {
     /// Capture working directory
     char cwd_buffer[4096];
     if (getcwd(cwd_buffer, sizeof(cwd_buffer)) != NULL) {
-        context->working_directory = pool_strdup(cwd_buffer);
+        context->working_directory = lle_pool_strdup(cwd_buffer);
     } else {
         context->working_directory = NULL;
     }
@@ -198,12 +177,12 @@ lle_forensic_apply_to_entry(lle_history_entry_t *entry,
 
     /// Apply terminal name
     if (context->terminal_name) {
-        entry->terminal_name = pool_strdup(context->terminal_name);
+        entry->terminal_name = lle_pool_strdup(context->terminal_name);
     }
 
     /// Apply working directory (if not already set)
     if (!entry->working_directory && context->working_directory) {
-        entry->working_directory = pool_strdup(context->working_directory);
+        entry->working_directory = lle_pool_strdup(context->working_directory);
     }
 
     /// Initialize timing fields

--- a/src/lle/history/history_interactive_search.c
+++ b/src/lle/history/history_interactive_search.c
@@ -24,6 +24,7 @@
 
 #include "lle/error_handling.h"
 #include "lle/history.h"
+#include "lle/memory_management.h"
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -42,26 +43,6 @@
  * HELPER FUNCTIONS
  * ============================================================================
  */
-
-/**
- * @brief Duplicate a string using pool allocation
- *
- * Allocates memory from the LLE memory pool and copies the input string.
- *
- * @param str String to duplicate (may be NULL)
- * @return Pointer to duplicated string, or NULL if str is NULL or allocation
- * fails
- */
-static char *pool_strdup(const char *str) {
-    if (!str)
-        return NULL;
-    size_t len = strlen(str);
-    char *dup = lle_pool_alloc(len + 1);
-    if (dup) {
-        memcpy(dup, str, len + 1);
-    }
-    return dup;
-}
 
 /* ============================================================================
  * TYPE DEFINITIONS
@@ -288,7 +269,8 @@ lle_history_interactive_search_init(lle_history_core_t *history_core,
     if (session->original_line) {
         lle_pool_free(session->original_line);
     }
-    session->original_line = current_line ? pool_strdup(current_line) : NULL;
+    session->original_line =
+        current_line ? lle_pool_strdup(current_line) : NULL;
     session->original_cursor_pos = cursor_pos;
 
     /// Update prompt

--- a/src/lle/history/history_multiline.c
+++ b/src/lle/history/history_multiline.c
@@ -119,28 +119,6 @@ static lle_result_t flatten_command(const char *original, char *flattened,
     return LLE_SUCCESS;
 }
 
-/**
- * @brief Duplicate a string using memory pool
- *
- * Allocates memory from the LLE memory pool and copies the input string.
- *
- * @param str String to duplicate (may be NULL)
- * @return Pointer to duplicated string, or NULL if str is NULL or allocation
- * fails
- */
-static char *pool_strdup(const char *str) {
-    if (!str) {
-        return NULL;
-    }
-
-    size_t len = strlen(str) + 1;
-    char *dup = lle_pool_alloc(len);
-    if (dup) {
-        memcpy(dup, str, len);
-    }
-    return dup;
-}
-
 /* ============================================================================
  * PUBLIC API
  * ============================================================================
@@ -266,7 +244,7 @@ lle_result_t lle_history_preserve_multiline(lle_history_entry_t *entry,
     }
 
     /// Store original multiline format
-    entry->original_multiline = pool_strdup(original_multiline);
+    entry->original_multiline = lle_pool_strdup(original_multiline);
     if (!entry->original_multiline) {
         return LLE_ERROR_OUT_OF_MEMORY;
     }
@@ -286,7 +264,7 @@ lle_result_t lle_history_preserve_multiline(lle_history_entry_t *entry,
         lle_pool_free(entry->command);
     }
 
-    entry->command = pool_strdup(flattened);
+    entry->command = lle_pool_strdup(flattened);
     if (!entry->command) {
         lle_pool_free(entry->original_multiline);
         entry->original_multiline = NULL;

--- a/src/lle/history/history_search.c
+++ b/src/lle/history/history_search.c
@@ -27,6 +27,7 @@
 #include "fuzzy_match.h"
 #include "lle/error_handling.h"
 #include "lle/history.h"
+#include "lle/memory_management.h"
 #include "lle/performance.h"
 #include "lle/unicode_case.h"
 #include "lle/unicode_compare.h"
@@ -83,26 +84,6 @@ struct lle_history_search_results {
  * PRIVATE HELPER FUNCTIONS
  * ============================================================================
  */
-
-/**
- * @brief Duplicate a string using pool allocation
- *
- * Allocates memory from the LLE memory pool and copies the input string.
- *
- * @param str String to duplicate (may be NULL)
- * @return Pointer to duplicated string, or NULL if str is NULL or allocation
- * fails
- */
-static char *pool_strdup(const char *str) {
-    if (!str)
-        return NULL;
-    size_t len = strlen(str);
-    char *dup = lle_pool_alloc(len + 1);
-    if (dup) {
-        memcpy(dup, str, len + 1);
-    }
-    return dup;
-}
 
 /// Note: Levenshtein distance now provided by libfuzzy (fuzzy_match.h)
 
@@ -472,7 +453,7 @@ lle_history_search_exact(lle_history_core_t *history_core, const char *query,
     }
 
     /// Store query
-    results->query = pool_strdup(query);
+    results->query = lle_pool_strdup(query);
     results->search_type = LLE_SEARCH_TYPE_EXACT;
 
     /// Get total entry count
@@ -556,7 +537,7 @@ lle_history_search_prefix(lle_history_core_t *history_core, const char *prefix,
     }
 
     /// Store query
-    results->query = pool_strdup(prefix);
+    results->query = lle_pool_strdup(prefix);
     results->search_type = LLE_SEARCH_TYPE_PREFIX;
 
     /// Get total entry count
@@ -637,7 +618,7 @@ lle_history_search_substring(lle_history_core_t *history_core,
     }
 
     /// Store query
-    results->query = pool_strdup(substring);
+    results->query = lle_pool_strdup(substring);
     results->search_type = LLE_SEARCH_TYPE_SUBSTRING;
 
     /// Get total entry count
@@ -722,7 +703,7 @@ lle_history_search_fuzzy(lle_history_core_t *history_core, const char *query,
     }
 
     /// Store query
-    results->query = pool_strdup(query);
+    results->query = lle_pool_strdup(query);
     results->search_type = LLE_SEARCH_TYPE_FUZZY;
 
     /// Get total entry count


### PR DESCRIPTION
## Summary
Drain #5 of the duplicate-path audit. Six file-private `static char *pool_strdup(const char *)` copies (in history_interactive_search, history_forensics, history_multiline, history_expansion, history_search, **and** completion/word_context -- the audit missed that last one) all implemented the same `lle_pool_alloc + memcpy` strdup. Replace them with one canonical `lle_pool_strdup` declared in `lle/memory_management.h` and defined `static inline` there.

## Why inline rather than a real symbol
A real `lle_pool_strdup` symbol in `memory_management.c` would conflict with `tests/lle/functional/test_memory_mock.c`, which supplies a mock `lle_pool_alloc`/`lle_pool_free` that several history-test binaries link against. Inline definition has no linker symbol of its own and naturally picks up whichever `lle_pool_alloc` is linked -- production code gets the real allocator; mocked tests get the mock.

## Intentional non-target
`src/lle/widget/widget_system.c` also has a `pool_strdup`, but its signature takes an explicit `lle_memory_pool_t *` pool argument -- a different concern (allocating from a specific pool rather than the global one). Left alone.

## Test plan
- [x] Full suite 119/119; differential corpus 121/0 unexpected
- [x] Clean build (werror) on macOS; CI covers ubuntu
- [x] Per-file damage audit on the 6 touched files (no collateral deletions beyond the deleted static and its doc comment)
- [x] LLE pre-commit compile check + prefix
- Net -84 lines across 7 files

Lesson from #4 applied: precise per-file Edits for the block deletions, not heuristic awk (see memory `feedback-no-brittle-awk-for-refactors`).