### PR TITLE
display: delete dead screen_buffer_render_menu/calculate_menu_width

### DIFF
--- a/include/display/screen_buffer.h
+++ b/include/display/screen_buffer.h
@@ -396,28 +396,6 @@ bool screen_buffer_render_multiline_with_prefixes(const screen_buffer_t *buffer,
 size_t screen_buffer_calculate_visual_width(const char *text, size_t start_col);
 
 /**
- * Render completion menu through screen buffer virtual layout
- *
- * Properly handles ANSI codes and calculates actual line count.
- * Separate from main render function to avoid breaking existing code.
- *
- * @param buffer Screen buffer to use for layout calculation
- * @param menu_text The rendered menu text with ANSI codes
- * @param terminal_width Current terminal width
- * @return Number of lines the menu occupies
- */
-int screen_buffer_render_menu(screen_buffer_t *buffer, const char *menu_text,
-                              int terminal_width);
-
-/**
- * Calculate visual width of menu without rendering
- *
- * @param menu_text The menu text to measure
- * @return Maximum line width in the menu
- */
-int screen_buffer_calculate_menu_width(const char *menu_text);
-
-/**
  * Add plain text rows to screen buffer (for menu, hints, etc.)
  *
  * Parses text line-by-line and adds each line as a new row starting

--- a/src/display/screen_buffer_menu.c
+++ b/src/display/screen_buffer_menu.c
@@ -1,15 +1,26 @@
 /**
  * @file screen_buffer_menu.c
- * @brief Completion Menu Rendering Through Screen Buffer
+ * @brief Below-cursor row management for the virtual screen buffer
  *
- * Provides screen_buffer_render_menu() for completion menu rendering
- * through the virtual layout system.
+ * The canonical pattern for completion menus, notifications, hints, and
+ * the debug command-list display is to **append** their content as
+ * additional rows below the prompt+command in the same virtual screen
+ * buffer (rather than render in a parallel pass), then query the row
+ * count below the cursor for the cursor-up math after redraw. This file
+ * holds the helpers that implement that pattern:
  *
- * Features:
- * - Proper ANSI code handling (menu has syntax highlighting)
- * - Correct column width calculations (no shifting)
- * - Terminal width awareness
- * - UTF-8 and wide character support
+ *   - screen_buffer_add_text_rows: extend the virtual screen with
+ *     plain-text rows starting at the given row index.
+ *   - screen_buffer_get_rows_below_cursor: report how many rows of the
+ *     virtual screen lie below the cursor row (used by the
+ *     display_controller cursor-positioning math).
+ *   - screen_buffer_get_total_display_rows: total row count, including
+ *     any added below-cursor content.
+ *
+ * The older parallel-render path (screen_buffer_render_menu /
+ * screen_buffer_calculate_menu_width) was deleted; this row-append
+ * approach is the canonical one and is referenced from
+ * display_controller.c's menu/notification rendering.
  *
  * @author Michael Berry <trismegustis@gmail.com>
  * @copyright Copyright (C) 2021-2026 Michael Berry
@@ -19,169 +30,6 @@
 #include "lle/utf8_support.h"
 #include <stdlib.h>
 #include <string.h>
-
-/**
- * @brief Render completion menu through screen buffer virtual layout
- *
- * Unlike direct terminal writes, this:
- * 1. Parses ANSI codes properly
- * 2. Calculates actual visual width
- * 3. Handles line wrapping correctly
- * 4. Returns proper line count
- *
- * @param buffer Screen buffer to use for layout calculation
- * @param menu_text The rendered menu text with ANSI codes
- * @param terminal_width Current terminal width
- * @return Number of lines the menu occupies
- */
-int screen_buffer_render_menu(screen_buffer_t *buffer, const char *menu_text,
-                              int terminal_width) {
-    if (!buffer || !menu_text || !*menu_text) {
-        return 0;
-    }
-
-    /// Save current screen buffer state
-    int saved_row = buffer->cursor_row;
-    int saved_col = buffer->cursor_col;
-    int saved_num_rows = buffer->num_rows;
-
-    /// Start menu on a new line after current content
-    buffer->cursor_row = buffer->num_rows;
-    buffer->cursor_col = 0;
-
-    /// Use screen buffer's virtual layout to process menu text
-    /// This handles:
-    /// - ANSI escape sequences (colors, bold, etc)
-    /// - UTF-8 characters
-    /// - Wide characters (emoji, CJK)
-    /// - Line wrapping at terminal width
-    const char *p = menu_text;
-    int menu_start_row = buffer->cursor_row;
-
-    while (*p) {
-        if (*p == '\033' && p[1] == '[') {
-            /// ANSI escape sequence - let screen buffer handle it
-            const char *seq_end = strchr(p, 'm');
-            if (seq_end) {
-                /// Screen buffer would normally process this for colors
-                /// For now, skip it in position calculations
-                p = seq_end + 1;
-                continue;
-            }
-        }
-
-        if (*p == '\n') {
-            /// Newline - move to next row
-            buffer->cursor_row++;
-            buffer->cursor_col = 0;
-            if (buffer->cursor_row >= buffer->num_rows) {
-                buffer->num_rows = buffer->cursor_row + 1;
-            }
-            p++;
-            continue;
-        }
-
-        /// Regular character - account for width
-        if ((*p & 0x80) == 0) {
-            /// ASCII character - 1 column
-            buffer->cursor_col++;
-        } else {
-            /// UTF-8 character - could be 1 or 2 columns wide
-            /// Simple approximation for now
-            buffer->cursor_col++;
-        }
-
-        /// Handle line wrapping
-        if (buffer->cursor_col >= terminal_width) {
-            buffer->cursor_row++;
-            buffer->cursor_col = 0;
-            if (buffer->cursor_row >= buffer->num_rows) {
-                buffer->num_rows = buffer->cursor_row + 1;
-            }
-        }
-
-        p++;
-    }
-
-    /// Calculate menu height
-    int menu_lines = buffer->cursor_row - menu_start_row + 1;
-
-    /// Restore original cursor position (menu doesn't move cursor)
-    buffer->cursor_row = saved_row;
-    buffer->cursor_col = saved_col;
-
-    /// CRITICAL: Don't permanently modify num_rows!
-    /// The menu is temporary and shouldn't affect buffer state
-    buffer->num_rows = saved_num_rows;
-
-    return menu_lines;
-}
-
-/**
- * @brief Calculate visual width of menu without rendering
- *
- * Useful for determining if menu needs multiple columns.
- *
- * @param menu_text The menu text with ANSI codes
- * @return Maximum visual width of any line in the menu
- */
-int screen_buffer_calculate_menu_width(const char *menu_text) {
-    if (!menu_text || !*menu_text) {
-        return 0;
-    }
-
-    int max_width = 0;
-    int current_width = 0;
-    const char *p = menu_text;
-
-    while (*p) {
-        if (*p == '\033' && p[1] == '[') {
-            /// Skip ANSI sequence
-            const char *seq_end = strchr(p, 'm');
-            if (seq_end) {
-                p = seq_end + 1;
-                continue;
-            }
-        }
-
-        if (*p == '\n') {
-            /// End of line - check if this line was wider
-            if (current_width > max_width) {
-                max_width = current_width;
-            }
-            current_width = 0;
-            p++;
-            continue;
-        }
-
-        /// Count visual width
-        if ((*p & 0x80) == 0) {
-            /// ASCII
-            current_width++;
-        } else if ((*p & 0xE0) == 0xC0) {
-            /// 2-byte UTF-8
-            current_width++;
-            p++; /// Skip second byte
-        } else if ((*p & 0xF0) == 0xE0) {
-            /// 3-byte UTF-8 (often CJK - 2 columns)
-            current_width += 2;
-            p += 2; /// Skip next 2 bytes
-        } else if ((*p & 0xF8) == 0xF0) {
-            /// 4-byte UTF-8 (emoji - usually 2 columns)
-            current_width += 2;
-            p += 3; /// Skip next 3 bytes
-        }
-
-        p++;
-    }
-
-    /// Check last line
-    if (current_width > max_width) {
-        max_width = current_width;
-    }
-
-    return max_width;
-}
 
 /**
  * @brief Add plain text rows to screen buffer for menu, hints, etc.


### PR DESCRIPTION
## Summary
Drain #6 of the duplicate-path audit, scoped down to its safe part. Two functions in `src/display/screen_buffer_menu.c` -- `screen_buffer_render_menu` and `screen_buffer_calculate_menu_width` -- are the older parallel-render-pass approach to completion-menu display. They have **zero callers** in src/ or tests/. The live canonical path renders menus, notifications, hints, and the debug command-list display by extending the *same* virtual screen buffer the prompt+command live in, via `screen_buffer_add_text_rows` + `screen_buffer_get_rows_below_cursor`, orchestrated from `display_controller.c`. That pattern was hard-won; the dead functions are the abandoned earlier attempt.

Deletes the two dead functions (139 lines), their two declarations in `include/display/screen_buffer.h`, and reframes the file-header doc-block to describe what the file actually does now (below-cursor row management for the virtual screen buffer).

## Out of scope (deliberately)
- **Render entry-point merge:** `screen_buffer_render` and `screen_buffer_render_with_continuation` overlap but differ in line-prefix-clearing behavior. Collapsing them is a semantics decision, not pure dedup; folded into #157.
- **ANSI-escape skip extraction:** the remaining inline skip-loops live inside the three divergent visual-width functions, which are tied to the rendering-policy unification tracked in #157. Folding them in here would churn code that #157 will consolidate.

## Test plan
- [x] Full suite 119/119; differential corpus 121/0 unexpected
- [x] Clean build (werror) on macOS; CI covers ubuntu
- [x] Verified `screen_buffer_add_text_rows`, `screen_buffer_get_rows_below_cursor`, `screen_buffer_get_total_display_rows` are the live functions (3 + 1 + 2 = 6 callers across display_controller.c and debug_view.c) and remain
- Net -174 lines

Refs #157