### PR TITLE
bin_local: route identifier check through canonical is_valid_identifier

### DIFF
--- a/src/builtins/bin_local.c
+++ b/src/builtins/bin_local.c
@@ -145,23 +145,16 @@ int bin_local(int argc, char **argv) {
             strncpy(name, arg, name_len);
             name[name_len] = '\0';
 
-            /// Validate variable name
-            if (!name[0] || (!isalpha(name[0]) && name[0] != '_')) {
-                executor_error_report(
-                    current_executor, SHELL_ERR_INVALID_ARGUMENT,
-                    builtin_get_source_location(), "invalid variable name");
+            /// Validate variable name via the canonical, Unicode-aware
+            /// is_valid_identifier (matches the bin_declare/export/readonly
+            /// pattern; honors FEATURE_UNICODE_IDENTIFIERS).
+            if (!is_valid_identifier(name)) {
+                executor_error_report(current_executor,
+                                      SHELL_ERR_INVALID_ARGUMENT,
+                                      builtin_get_source_location(),
+                                      "invalid variable name: %s", name);
                 free(name);
                 return 1;
-            }
-
-            for (size_t j = 1; j < name_len; j++) {
-                if (!isalnum(name[j]) && name[j] != '_') {
-                    executor_error_report(
-                        current_executor, SHELL_ERR_INVALID_ARGUMENT,
-                        builtin_get_source_location(), "invalid variable name");
-                    free(name);
-                    return 1;
-                }
             }
 
             char *value = eq + 1;
@@ -258,21 +251,15 @@ int bin_local(int argc, char **argv) {
             free(name);
         } else {
             /// Declaration only: local var
-            /// Validate variable name
-            if (!arg[0] || (!isalpha(arg[0]) && arg[0] != '_')) {
-                executor_error_report(
-                    current_executor, SHELL_ERR_INVALID_ARGUMENT,
-                    builtin_get_source_location(), "invalid variable name");
+            /// Validate variable name via the canonical, Unicode-aware
+            /// is_valid_identifier (matches the bin_declare/export/readonly
+            /// pattern; honors FEATURE_UNICODE_IDENTIFIERS).
+            if (!is_valid_identifier(arg)) {
+                executor_error_report(current_executor,
+                                      SHELL_ERR_INVALID_ARGUMENT,
+                                      builtin_get_source_location(),
+                                      "invalid variable name: %s", arg);
                 return 1;
-            }
-
-            for (size_t j = 1; arg[j]; j++) {
-                if (!isalnum(arg[j]) && arg[j] != '_') {
-                    executor_error_report(
-                        current_executor, SHELL_ERR_INVALID_ARGUMENT,
-                        builtin_get_source_location(), "invalid variable name");
-                    return 1;
-                }
             }
 
             if (opt_nameref) {


### PR DESCRIPTION
## Summary
Drain #8 of the duplicate-path audit. `bin_local` validated variable names with inline `isalpha`/`isalnum` byte loops -- the lone outlier among the attribute-setting builtins. Replace both validation sites with the canonical `is_valid_identifier` (declared in `builtins.h`, a thin wrapper around `lush_is_valid_identifier` in `src/identifier.c`), matching the pattern already used by `bin_declare`, `bin_export`, and `bin_readonly`.

`local` now honors `FEATURE_UNICODE_IDENTIFIERS` and NFC-normalizes the candidate name through the same path the other attribute-setting builtins do, so a non-ASCII identifier that `declare`/`export` accept is no longer rejected by `local`. The error message also gains the offending name (matching the bin_export style).

## Test plan
- [x] Full suite 119/119; differential corpus 121/0 unexpected
- [x] Clean build (werror) on macOS; CI covers ubuntu
- [x] End-to-end: `local x=42` works in a function; invalid `local 123bad=foo` rejected with `E1204: invalid variable name: 123bad`
- Net change: 12 inline-loop lines replaced with one canonical-helper call per site