### PR TITLE
builtins: collapse bin_break / bin_continue onto a shared helper

### DIFF
--- a/include/builtins.h
+++ b/include/builtins.h
@@ -69,6 +69,25 @@ source_location_t builtin_swap_source_location(source_location_t loc);
  */
 source_location_t builtin_get_source_location(void);
 
+/**
+ * @brief Shared implementation for `break` and `continue`
+ *
+ * Both builtins parse an optional positive-integer level, validate that
+ * we are inside a loop, that the level does not exceed the current
+ * nesting depth, and then set the executor's loop_control to the
+ * requested value. The only differences between them are the verb used
+ * in error messages and the loop_control value -- bin_break and
+ * bin_continue are thin wrappers around this.
+ *
+ * @param argc argc as received by the builtin
+ * @param argv argv as received by the builtin (argv[1] is the optional level)
+ * @param verb "break" or "continue", used in error / suggestion text
+ * @param ctl  LOOP_BREAK or LOOP_CONTINUE, the value to set on success
+ * @return 0 on success, 1 on any error (already reported via shell_error_*)
+ */
+int builtin_loop_control(int argc, char **argv, const char *verb,
+                         loop_control_t ctl);
+
 /** Builtin command entry */
 typedef struct builtin_s {
     const char *name;                   ///< Command name

--- a/src/builtins/bin_break.c
+++ b/src/builtins/bin_break.c
@@ -7,134 +7,20 @@
  */
 
 #include "builtins.h"
-#include "lush.h"
 
 /**
  * @brief Break out of enclosing loop
  *
- * Exits from a for, while, or until loop. An optional numeric argument
- * specifies how many levels of loops to break out of.
+ * Exits from a for, while, or until loop. An optional positive-integer
+ * argument specifies how many levels of loops to break out of.
+ * Shared implementation lives in builtin_loop_control (builtins.c) --
+ * `break` and `continue` differ only in the verb and the loop-control
+ * value, so all of the parse / validate / error reporting is centralized.
  *
  * @param argc Argument count
  * @param argv Argument vector (argv[1] is optional loop level)
- * @return 0 on success, 1 if not in a loop or invalid argument
+ * @return 0 on success, 1 if not in a loop or on invalid argument
  */
 int bin_break(int argc, char **argv) {
-    if (!current_executor || current_executor->loop_depth <= 0) {
-        source_location_t loc = builtin_get_source_location();
-        shell_error_t *err =
-            shell_error_create(SHELL_ERR_LOOP_CONTROL, SHELL_SEVERITY_ERROR,
-                               loc, "not currently in a loop");
-        if (err) {
-            if (current_executor && SOURCE_LOC_VALID(loc)) {
-                char *src_line =
-                    executor_get_source_line(current_executor, loc.line);
-                if (src_line) {
-                    shell_error_set_source_line(err, src_line, loc.column,
-                                                loc.column + loc.length);
-                    free(src_line);
-                }
-            }
-            if (current_executor) {
-                for (size_t i = 0; i < current_executor->context_depth &&
-                                   i < SHELL_ERROR_CONTEXT_MAX;
-                     i++) {
-                    if (current_executor->context_stack[i]) {
-                        shell_error_push_context(
-                            err, "%s", current_executor->context_stack[i]);
-                    }
-                }
-            }
-            shell_error_set_suggestion(
-                err, "break is only valid inside while/until/for loops");
-            shell_error_display(err, stderr, isatty(STDERR_FILENO));
-            shell_error_free(err);
-        } else {
-            fprintf(stderr, "lush: break: not currently in a loop\n");
-        }
-        return 1;
-    }
-
-    /// Parse optional level argument (break n)
-    int break_level = 1;
-    if (argc > 1) {
-        char *endptr;
-        break_level = strtol(argv[1], &endptr, 10);
-
-        if (*endptr != '\0' || break_level <= 0) {
-            source_location_t loc = builtin_get_source_location();
-            shell_error_t *err = shell_error_create(
-                SHELL_ERR_INVALID_ARGUMENT, SHELL_SEVERITY_ERROR, loc,
-                "%s: numeric argument required", argv[1]);
-            if (err) {
-                if (SOURCE_LOC_VALID(loc)) {
-                    char *src_line =
-                        executor_get_source_line(current_executor, loc.line);
-                    if (src_line) {
-                        shell_error_set_source_line(err, src_line, loc.column,
-                                                    loc.column + loc.length);
-                        free(src_line);
-                    }
-                }
-                for (size_t i = 0; i < current_executor->context_depth &&
-                                   i < SHELL_ERROR_CONTEXT_MAX;
-                     i++) {
-                    if (current_executor->context_stack[i]) {
-                        shell_error_push_context(
-                            err, "%s", current_executor->context_stack[i]);
-                    }
-                }
-                shell_error_set_suggestion(err,
-                                           "level must be a positive integer");
-                shell_error_display(err, stderr, isatty(STDERR_FILENO));
-                shell_error_free(err);
-            } else {
-                fprintf(stderr, "lush: break: %s: numeric argument required\n",
-                        argv[1]);
-            }
-            return 1;
-        }
-
-        if (break_level > current_executor->loop_depth) {
-            source_location_t loc = builtin_get_source_location();
-            shell_error_t *err = shell_error_create(
-                SHELL_ERR_INVALID_ARGUMENT, SHELL_SEVERITY_ERROR, loc,
-                "%d: cannot break %d levels (only %d nested)", break_level,
-                break_level, current_executor->loop_depth);
-            if (err) {
-                if (SOURCE_LOC_VALID(loc)) {
-                    char *src_line =
-                        executor_get_source_line(current_executor, loc.line);
-                    if (src_line) {
-                        shell_error_set_source_line(err, src_line, loc.column,
-                                                    loc.column + loc.length);
-                        free(src_line);
-                    }
-                }
-                for (size_t i = 0; i < current_executor->context_depth &&
-                                   i < SHELL_ERROR_CONTEXT_MAX;
-                     i++) {
-                    if (current_executor->context_stack[i]) {
-                        shell_error_push_context(
-                            err, "%s", current_executor->context_stack[i]);
-                    }
-                }
-                shell_error_set_suggestion(
-                    err, "level cannot exceed the current loop nesting depth");
-                shell_error_display(err, stderr, isatty(STDERR_FILENO));
-                shell_error_free(err);
-            } else {
-                fprintf(stderr,
-                        "lush: break: %d: cannot break %d levels "
-                        "(only %d nested)\n",
-                        break_level, break_level, current_executor->loop_depth);
-            }
-            return 1;
-        }
-    }
-
-    /// Set loop control state to break
-    current_executor->loop_control = LOOP_BREAK;
-
-    return 0;
+    return builtin_loop_control(argc, argv, "break", LOOP_BREAK);
 }

--- a/src/builtins/bin_continue.c
+++ b/src/builtins/bin_continue.c
@@ -7,137 +7,21 @@
  */
 
 #include "builtins.h"
-#include "lush.h"
 
 /**
  * @brief Continue to the next iteration of enclosing loop
  *
  * Skips the remaining commands in the current loop iteration and
- * continues with the next iteration. An optional numeric argument
- * specifies which enclosing loop to continue.
+ * continues with the next iteration. An optional positive-integer
+ * argument specifies which enclosing loop to continue. Shared
+ * implementation lives in builtin_loop_control (builtins.c) -- `break`
+ * and `continue` differ only in the verb and the loop-control value,
+ * so all of the parse / validate / error reporting is centralized.
  *
  * @param argc Argument count
  * @param argv Argument vector (argv[1] is optional loop level)
- * @return 0 on success, 1 if not in a loop or invalid argument
+ * @return 0 on success, 1 if not in a loop or on invalid argument
  */
 int bin_continue(int argc, char **argv) {
-    if (!current_executor || current_executor->loop_depth <= 0) {
-        source_location_t loc = builtin_get_source_location();
-        shell_error_t *err =
-            shell_error_create(SHELL_ERR_LOOP_CONTROL, SHELL_SEVERITY_ERROR,
-                               loc, "not currently in a loop");
-        if (err) {
-            if (current_executor && SOURCE_LOC_VALID(loc)) {
-                char *src_line =
-                    executor_get_source_line(current_executor, loc.line);
-                if (src_line) {
-                    shell_error_set_source_line(err, src_line, loc.column,
-                                                loc.column + loc.length);
-                    free(src_line);
-                }
-            }
-            if (current_executor) {
-                for (size_t i = 0; i < current_executor->context_depth &&
-                                   i < SHELL_ERROR_CONTEXT_MAX;
-                     i++) {
-                    if (current_executor->context_stack[i]) {
-                        shell_error_push_context(
-                            err, "%s", current_executor->context_stack[i]);
-                    }
-                }
-            }
-            shell_error_set_suggestion(
-                err, "continue is only valid inside while/until/for loops");
-            shell_error_display(err, stderr, isatty(STDERR_FILENO));
-            shell_error_free(err);
-        } else {
-            fprintf(stderr, "lush: continue: not currently in a loop\n");
-        }
-        return 1;
-    }
-
-    /// Parse optional level argument (continue n)
-    int continue_level = 1;
-    if (argc > 1) {
-        char *endptr;
-        continue_level = strtol(argv[1], &endptr, 10);
-
-        if (*endptr != '\0' || continue_level <= 0) {
-            source_location_t loc = builtin_get_source_location();
-            shell_error_t *err = shell_error_create(
-                SHELL_ERR_INVALID_ARGUMENT, SHELL_SEVERITY_ERROR, loc,
-                "%s: numeric argument required", argv[1]);
-            if (err) {
-                if (SOURCE_LOC_VALID(loc)) {
-                    char *src_line =
-                        executor_get_source_line(current_executor, loc.line);
-                    if (src_line) {
-                        shell_error_set_source_line(err, src_line, loc.column,
-                                                    loc.column + loc.length);
-                        free(src_line);
-                    }
-                }
-                for (size_t i = 0; i < current_executor->context_depth &&
-                                   i < SHELL_ERROR_CONTEXT_MAX;
-                     i++) {
-                    if (current_executor->context_stack[i]) {
-                        shell_error_push_context(
-                            err, "%s", current_executor->context_stack[i]);
-                    }
-                }
-                shell_error_set_suggestion(err,
-                                           "level must be a positive integer");
-                shell_error_display(err, stderr, isatty(STDERR_FILENO));
-                shell_error_free(err);
-            } else {
-                fprintf(stderr,
-                        "lush: continue: %s: numeric argument required\n",
-                        argv[1]);
-            }
-            return 1;
-        }
-
-        if (continue_level > current_executor->loop_depth) {
-            source_location_t loc = builtin_get_source_location();
-            shell_error_t *err = shell_error_create(
-                SHELL_ERR_INVALID_ARGUMENT, SHELL_SEVERITY_ERROR, loc,
-                "%d: cannot continue %d levels (only %d nested)",
-                continue_level, continue_level, current_executor->loop_depth);
-            if (err) {
-                if (SOURCE_LOC_VALID(loc)) {
-                    char *src_line =
-                        executor_get_source_line(current_executor, loc.line);
-                    if (src_line) {
-                        shell_error_set_source_line(err, src_line, loc.column,
-                                                    loc.column + loc.length);
-                        free(src_line);
-                    }
-                }
-                for (size_t i = 0; i < current_executor->context_depth &&
-                                   i < SHELL_ERROR_CONTEXT_MAX;
-                     i++) {
-                    if (current_executor->context_stack[i]) {
-                        shell_error_push_context(
-                            err, "%s", current_executor->context_stack[i]);
-                    }
-                }
-                shell_error_set_suggestion(
-                    err, "level cannot exceed the current loop nesting depth");
-                shell_error_display(err, stderr, isatty(STDERR_FILENO));
-                shell_error_free(err);
-            } else {
-                fprintf(stderr,
-                        "lush: continue: %d: cannot continue %d levels "
-                        "(only %d nested)\n",
-                        continue_level, continue_level,
-                        current_executor->loop_depth);
-            }
-            return 1;
-        }
-    }
-
-    /// Set loop control state to continue
-    current_executor->loop_control = LOOP_CONTINUE;
-
-    return 0;
+    return builtin_loop_control(argc, argv, "continue", LOOP_CONTINUE);
 }

--- a/src/builtins/builtins.c
+++ b/src/builtins/builtins.c
@@ -327,6 +327,136 @@ int is_valid_identifier(const char *name) {
 }
 
 /* ============================================================================
+ * Shared loop-control implementation
+ *
+ * `break` and `continue` are 95% identical -- same out-of-loop guard,
+ * same numeric-argument parse, same nesting-depth check, same structured-
+ * error machinery, differing only in the verb in the error messages /
+ * suggestions and the loop_control value they set. bin_break and
+ * bin_continue both reduce to one call into this helper.
+ * ============================================================================
+ */
+
+int builtin_loop_control(int argc, char **argv, const char *verb,
+                         loop_control_t ctl) {
+    if (!current_executor || current_executor->loop_depth <= 0) {
+        source_location_t loc = builtin_get_source_location();
+        shell_error_t *err =
+            shell_error_create(SHELL_ERR_LOOP_CONTROL, SHELL_SEVERITY_ERROR,
+                               loc, "not currently in a loop");
+        if (err) {
+            if (current_executor && SOURCE_LOC_VALID(loc)) {
+                char *src_line =
+                    executor_get_source_line(current_executor, loc.line);
+                if (src_line) {
+                    shell_error_set_source_line(err, src_line, loc.column,
+                                                loc.column + loc.length);
+                    free(src_line);
+                }
+            }
+            if (current_executor) {
+                for (size_t i = 0; i < current_executor->context_depth &&
+                                   i < SHELL_ERROR_CONTEXT_MAX;
+                     i++) {
+                    if (current_executor->context_stack[i]) {
+                        shell_error_push_context(
+                            err, "%s", current_executor->context_stack[i]);
+                    }
+                }
+            }
+            char suggestion[96];
+            snprintf(suggestion, sizeof(suggestion),
+                     "%s is only valid inside while/until/for loops", verb);
+            shell_error_set_suggestion(err, suggestion);
+            shell_error_display(err, stderr, isatty(STDERR_FILENO));
+            shell_error_free(err);
+        } else {
+            fprintf(stderr, "lush: %s: not currently in a loop\n", verb);
+        }
+        return 1;
+    }
+
+    int level = 1;
+    if (argc > 1) {
+        char *endptr;
+        level = (int)strtol(argv[1], &endptr, 10);
+
+        if (*endptr != '\0' || level <= 0) {
+            source_location_t loc = builtin_get_source_location();
+            shell_error_t *err = shell_error_create(
+                SHELL_ERR_INVALID_ARGUMENT, SHELL_SEVERITY_ERROR, loc,
+                "%s: numeric argument required", argv[1]);
+            if (err) {
+                if (SOURCE_LOC_VALID(loc)) {
+                    char *src_line =
+                        executor_get_source_line(current_executor, loc.line);
+                    if (src_line) {
+                        shell_error_set_source_line(err, src_line, loc.column,
+                                                    loc.column + loc.length);
+                        free(src_line);
+                    }
+                }
+                for (size_t i = 0; i < current_executor->context_depth &&
+                                   i < SHELL_ERROR_CONTEXT_MAX;
+                     i++) {
+                    if (current_executor->context_stack[i]) {
+                        shell_error_push_context(
+                            err, "%s", current_executor->context_stack[i]);
+                    }
+                }
+                shell_error_set_suggestion(err,
+                                           "level must be a positive integer");
+                shell_error_display(err, stderr, isatty(STDERR_FILENO));
+                shell_error_free(err);
+            } else {
+                fprintf(stderr, "lush: %s: %s: numeric argument required\n",
+                        verb, argv[1]);
+            }
+            return 1;
+        }
+
+        if (level > current_executor->loop_depth) {
+            source_location_t loc = builtin_get_source_location();
+            shell_error_t *err = shell_error_create(
+                SHELL_ERR_INVALID_ARGUMENT, SHELL_SEVERITY_ERROR, loc,
+                "%d: cannot %s %d levels (only %d nested)", level, verb, level,
+                current_executor->loop_depth);
+            if (err) {
+                if (SOURCE_LOC_VALID(loc)) {
+                    char *src_line =
+                        executor_get_source_line(current_executor, loc.line);
+                    if (src_line) {
+                        shell_error_set_source_line(err, src_line, loc.column,
+                                                    loc.column + loc.length);
+                        free(src_line);
+                    }
+                }
+                for (size_t i = 0; i < current_executor->context_depth &&
+                                   i < SHELL_ERROR_CONTEXT_MAX;
+                     i++) {
+                    if (current_executor->context_stack[i]) {
+                        shell_error_push_context(
+                            err, "%s", current_executor->context_stack[i]);
+                    }
+                }
+                shell_error_set_suggestion(
+                    err, "level cannot exceed the current loop nesting depth");
+                shell_error_display(err, stderr, isatty(STDERR_FILENO));
+                shell_error_free(err);
+            } else {
+                fprintf(stderr,
+                        "lush: %s: %d: cannot %s %d levels (only %d nested)\n",
+                        verb, level, verb, level, current_executor->loop_depth);
+            }
+            return 1;
+        }
+    }
+
+    current_executor->loop_control = ctl;
+    return 0;
+}
+
+/* ============================================================================
  * Command Hash Table
  *
  * Owned here so it survives across all bin_<name>.c translation units.

--- a/tests/test_shell_harness.h
+++ b/tests/test_shell_harness.h
@@ -42,6 +42,7 @@
 #define LUSH_TEST_SHELL_HARNESS_H
 
 #include "executor.h"
+#include "lush.h"
 #include "lush_fork.h"
 #include "node.h"
 #include "parser.h"
@@ -93,6 +94,15 @@ static inline run_result_t run_shell_with_executor(executor_t *exec,
                                                    const char *src) {
     run_result_t r = {0};
 
+    /// Save+restore the REPL-level globals around the test so a script
+    /// that calls `exit` (which sets exit_flag=true) does NOT cause
+    /// every subsequent test in the same binary to short-circuit at the
+    /// executor's `if (exit_flag)` checks. last_exit_status is also
+    /// global ($? state) and is restored for the same reason. See
+    /// gh issue #171 for the discovery trace.
+    bool saved_exit_flag = exit_flag;
+    int saved_last_exit_status = last_exit_status;
+
     FILE *out_tmp = tmpfile();
     FILE *err_tmp = tmpfile();
     if (!out_tmp || !err_tmp) {
@@ -134,6 +144,11 @@ static inline run_result_t run_shell_with_executor(executor_t *exec,
 
     fclose(out_tmp);
     fclose(err_tmp);
+
+    /// Restore the REPL-level globals so a test's `exit` does not bleed
+    /// into the next test (see save above + gh #171).
+    exit_flag = saved_exit_flag;
+    last_exit_status = saved_last_exit_status;
 
     return r;
 }

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -1745,6 +1745,53 @@ TEST(loop_continue) {
     executor_free(exec);
 }
 
+TEST(loop_break_outside_loop_errors) {
+    executor_t *exec = executor_new();
+    ASSERT_NOT_NULL(exec, "executor_new failed");
+    run_result_t r = run_shell_with_executor(exec, "break");
+    ASSERT_EXIT_STATUS(r, 1);
+    executor_free(exec);
+}
+
+TEST(loop_continue_outside_loop_errors) {
+    executor_t *exec = executor_new();
+    ASSERT_NOT_NULL(exec, "executor_new failed");
+    run_result_t r = run_shell_with_executor(exec, "continue");
+    ASSERT_EXIT_STATUS(r, 1);
+    executor_free(exec);
+}
+
+TEST(loop_break_non_numeric_level_errors) {
+    /// `break abc` inside a loop is a numeric-argument error.
+    executor_t *exec = executor_new();
+    ASSERT_NOT_NULL(exec, "executor_new failed");
+    run_result_t r = run_shell_with_executor(
+        exec,
+        "RC=0; for i in 1; do break abc || RC=$?; done; echo done; exit $RC");
+    ASSERT_EXIT_STATUS(r, 1);
+    executor_free(exec);
+}
+
+TEST(loop_break_level_exceeds_depth_errors) {
+    /// `break 5` with only 1 loop nested is an over-deep-level error.
+    executor_t *exec = executor_new();
+    ASSERT_NOT_NULL(exec, "executor_new failed");
+    run_result_t r = run_shell_with_executor(
+        exec,
+        "RC=0; for i in 1; do break 5 || RC=$?; done; echo done; exit $RC");
+    ASSERT_EXIT_STATUS(r, 1);
+    executor_free(exec);
+}
+
+TEST(loop_continue_non_numeric_level_errors) {
+    executor_t *exec = executor_new();
+    ASSERT_NOT_NULL(exec, "executor_new failed");
+    run_result_t r = run_shell_with_executor(
+        exec, "RC=0; for i in 1; do continue abc || RC=$?; done; exit $RC");
+    ASSERT_EXIT_STATUS(r, 1);
+    executor_free(exec);
+}
+
 /* ============================================================================
  * PIPELINE TESTS
  * ============================================================================
@@ -4375,6 +4422,11 @@ int main(void) {
     printf("\nBreak/continue tests:\n");
     RUN_TEST(loop_break);
     RUN_TEST(loop_continue);
+    RUN_TEST(loop_break_outside_loop_errors);
+    RUN_TEST(loop_continue_outside_loop_errors);
+    RUN_TEST(loop_break_non_numeric_level_errors);
+    RUN_TEST(loop_break_level_exceeds_depth_errors);
+    RUN_TEST(loop_continue_non_numeric_level_errors);
 
     printf("\nPipeline tests:\n");
     RUN_TEST(pipeline_simple);


### PR DESCRIPTION
## Summary
Drain #13 of the duplicate-path audit (the break/continue axis). `bin_break.c` (140 lines) and `bin_continue.c` (143 lines) were near-token-identical -- same out-of-loop guard, same numeric-argument parse, same nesting-depth check, same five-stanza structured-error machinery (source-line annotation, context stack push, suggestion, fallback `fprintf`) -- differing only in the verb in the error/suggestion text and in the `loop_control` value set on success.

Extract `builtin_loop_control(argc, argv, verb, ctl)` in `src/builtins/builtins.c`, declared in `include/builtins.h`. Both `bin_break` and `bin_continue` reduce to a single forwarding call. Net ~250 lines of duplicated logic collapsed to one ~125-line helper plus two ~4-line wrappers.

## Out of scope (follow-up)
The audit grouped two other items under drain #13 along orthogonal axes:
- Sentinel-name extraction shared by `bin_export.c` and `bin_readonly.c`
- The broader ~45-site `fprintf(stderr,...)` -> structured-error migration

Both deserve their own focused passes and aren't pure dedup with the break/continue twin.

## Test plan
- [x] Full suite 119/119; differential corpus 121/0 unexpected
- [x] Clean build (werror) on macOS; CI covers ubuntu
- [x] End-to-end behavior preserved: `break` exits loop, `continue` skips iteration, `break 2` exits nested loops, all three error paths (no-loop, non-numeric arg, level > depth) emit the same structured-error text and exit code 1