### PR TITLE
Fix #154: leading-[ words glob instead of mis-routing to [ test builtin

### DIFF
--- a/include/tokenizer.h
+++ b/include/tokenizer.h
@@ -295,6 +295,40 @@ bool token_is_operator(token_type_t type);
  */
 bool token_is_word_like(token_type_t type);
 
+/**
+ * @brief Check if a token type is acceptable inside a command-argument word.
+ *
+ * Returns true for every token type the parser may pull into a
+ * concatenated argument word via `collect_word_argument` adjacency.
+ * In particular, this includes TOK_LBRACKET and TOK_RBRACKET so a
+ * bracket-glob like `[5].txt` at the start of an argument word does
+ * not get mis-parsed as an invocation of the `[` test builtin (#154).
+ */
+bool token_is_argument_word_token(token_type_t type);
+
+/**
+ * @brief Check if a token type is acceptable as part of an assignment value.
+ *
+ * Used by `parse_scalar_assignment_string` to decide what counts as a
+ * continuation of `x=...` adjacency. Differs from
+ * `token_is_argument_word_token` because TOK_PLUS_ASSIGN is accepted
+ * here (POSIX ASSIGNMENT_WORD only delimits at the FIRST `=`, so a
+ * subsequent `+=` inside the value is literal text), and TOK_STRING /
+ * keywords / TOK_GLOB / TOK_QUESTION / TOK_NOT_EQUAL are not.
+ */
+bool token_is_assignment_value_token(token_type_t type);
+
+/**
+ * @brief Check if a token type is acceptable as a for/select word-list item.
+ *
+ * Used by `for NAME in WORDS;` and `select NAME in WORDS;` parsers
+ * (and the zsh `for NAME (WORDS)` form). Includes TOK_LBRACKET /
+ * TOK_RBRACKET so a bracket-glob like `for f in [5].txt; ...` is
+ * collected as a word instead of mis-routing to the `[` test builtin
+ * (#154).
+ */
+bool token_is_word_list_token(token_type_t type);
+
 /* ============================================================================
  * Tokenizer Control
  * ============================================================================

--- a/meson.build
+++ b/meson.build
@@ -1079,6 +1079,27 @@ endif
          env: ['LUSH_TEST_BINARY=' + lush_exe.full_path()])
   endif
 
+  # #154 regression tests: leading-`[` bracket-glob parsing
+  if fs.exists('tests/unit/test_bracket_glob_parsing.c')
+    test_bracket_glob_sources = []
+    foreach s : src
+      if not s.endswith('lush.c')
+        test_bracket_glob_sources += s
+      endif
+    endforeach
+    test_bracket_glob_parsing = executable('test_bracket_glob_parsing',
+                                           'tests/unit/test_bracket_glob_parsing.c',
+                                           'tests/unit/test_executor_stubs.c',
+                                           test_bracket_glob_sources + lle_shell_sources,
+                                           include_directories: [inc, include_directories('tests')],
+                                           dependencies: [lle_dep, libm])
+    test('Bracket Glob Parsing (#154)', test_bracket_glob_parsing,
+         suite: 'unit',
+         timeout: 30,
+         depends: [lush_exe],
+         env: ['LUSH_TEST_BINARY=' + lush_exe.full_path()])
+  endif
+
   # Word-Context Analyzer Tests
   # Exercises lle_word_context_analyze across quote/escape state, word
   # boundaries respecting quote state, filename_portion_start computation,

--- a/src/parser.c
+++ b/src/parser.c
@@ -1110,20 +1110,10 @@ static bool collect_word_argument(parser_t *parser, node_t *parent) {
         return false;
     }
 
-    /// Acceptance test — same set parse_simple_command has used since the
-    /// unified-concatenation logic was introduced.
-    bool accepted =
-        (arg_token->type == TOK_STRING ||
-         arg_token->type == TOK_EXPANDABLE_STRING ||
-         arg_token->type == TOK_ARITH_EXP ||
-         arg_token->type == TOK_COMMAND_SUB ||
-         arg_token->type == TOK_BACKQUOTE ||
-         token_is_word_like(arg_token->type) ||
-         token_is_keyword(arg_token->type) || arg_token->type == TOK_VARIABLE ||
-         arg_token->type == TOK_RBRACKET || arg_token->type == TOK_ASSIGN ||
-         arg_token->type == TOK_COMMA || arg_token->type == TOK_GLOB ||
-         arg_token->type == TOK_QUESTION || arg_token->type == TOK_NOT_EQUAL);
-    if (!accepted) {
+    /// Acceptance test routed through the canonical predicate so a
+    /// leading-`[` glob like `[5].txt` is collected as a word here
+    /// instead of being mis-parsed as the `[` test builtin (#154).
+    if (!token_is_argument_word_token(arg_token->type)) {
         return false;
     }
 
@@ -1143,18 +1133,7 @@ static bool collect_word_argument(parser_t *parser, node_t *parent) {
     /// word concatenation depends on this being correct.
     size_t last_end_pos = arg_token->end_position;
 
-    while (
-        arg_token &&
-        (arg_token->type == TOK_STRING ||
-         arg_token->type == TOK_EXPANDABLE_STRING ||
-         arg_token->type == TOK_ARITH_EXP ||
-         arg_token->type == TOK_COMMAND_SUB ||
-         arg_token->type == TOK_BACKQUOTE ||
-         token_is_word_like(arg_token->type) ||
-         token_is_keyword(arg_token->type) || arg_token->type == TOK_VARIABLE ||
-         arg_token->type == TOK_RBRACKET || arg_token->type == TOK_ASSIGN ||
-         arg_token->type == TOK_COMMA || arg_token->type == TOK_GLOB ||
-         arg_token->type == TOK_QUESTION || arg_token->type == TOK_NOT_EQUAL)) {
+    while (arg_token && token_is_argument_word_token(arg_token->type)) {
 
         token_info_t *new_tokens =
             realloc(collected_tokens, (token_count + 1) * sizeof(token_info_t));
@@ -1284,7 +1263,26 @@ static bool collect_word_argument(parser_t *parser, node_t *parent) {
             for (int i = 0; i < token_count; i++) {
                 strcat(concatenated, dequoted[i]);
             }
-            node_t *arg_node = new_node(NODE_STRING_EXPANDABLE);
+            /// Choose the node type so the executor's glob / word-split
+            /// gate fires correctly. NODE_STRING_EXPANDABLE means
+            /// "this came from a double-quoted string -- no glob, no
+            /// split". If every collected token was an unquoted bare
+            /// word (no TOK_STRING / TOK_EXPANDABLE_STRING in the run)
+            /// the concatenation is a regular shell word and must
+            /// glob-expand: a leading `[5].txt` after the parser fix
+            /// for #154 reaches here, and emitting it as
+            /// NODE_STRING_EXPANDABLE would suppress the bracket-class
+            /// glob.
+            bool any_quoted = false;
+            for (int i = 0; i < token_count; i++) {
+                if (collected_tokens[i].type == TOK_STRING ||
+                    collected_tokens[i].type == TOK_EXPANDABLE_STRING) {
+                    any_quoted = true;
+                    break;
+                }
+            }
+            node_t *arg_node =
+                new_node(any_quoted ? NODE_STRING_EXPANDABLE : NODE_VAR);
             if (arg_node) {
                 arg_node->val.str = concatenated;
                 arg_node->val_type = VAL_STR;
@@ -1923,11 +1921,7 @@ static char *parse_scalar_assignment_string(parser_t *parser,
     /// and TOK_PLUS_ASSIGN are valid first tokens because POSIX
     /// ASSIGNMENT_WORD only delimits at the FIRST '='; `X===` has value
     /// `==`.
-    if (value_adjacent &&
-        (token_is_word_like(value->type) || value->type == TOK_VARIABLE ||
-         value->type == TOK_ARITH_EXP || value->type == TOK_COMMAND_SUB ||
-         value->type == TOK_BACKQUOTE || value->type == TOK_ASSIGN ||
-         value->type == TOK_PLUS_ASSIGN || value->type == TOK_COMMA)) {
+    if (value_adjacent && token_is_assignment_value_token(value->type)) {
 
         /// Build complete value by concatenating adjacent tokens
         size_t value_capacity = 256;
@@ -1947,12 +1941,7 @@ static char *parse_scalar_assignment_string(parser_t *parser,
         /// (a whitespace gap breaks the loop). A peek-ahead "this word
         /// starts a new assignment" check would mis-handle X=a=b by
         /// treating the inner '=' as a new operator.
-        while (value &&
-               (token_is_word_like(value->type) ||
-                value->type == TOK_VARIABLE || value->type == TOK_ARITH_EXP ||
-                value->type == TOK_COMMAND_SUB ||
-                value->type == TOK_BACKQUOTE || value->type == TOK_ASSIGN ||
-                value->type == TOK_PLUS_ASSIGN || value->type == TOK_COMMA)) {
+        while (value && token_is_assignment_value_token(value->type)) {
 
             size_t token_len = strlen(value->text);
             /// Quote re-wrapping policy for assignment-value
@@ -3838,11 +3827,7 @@ static node_t *parse_for_statement(parser_t *parser) {
         while (!tokenizer_match(parser->tokenizer, TOK_RPAREN) &&
                !tokenizer_match(parser->tokenizer, TOK_EOF)) {
             token_t *word_token = tokenizer_current(parser->tokenizer);
-            if (token_is_word_like(word_token->type) ||
-                word_token->type == TOK_VARIABLE ||
-                word_token->type == TOK_COMMAND_SUB ||
-                word_token->type == TOK_ARITH_EXP ||
-                word_token->type == TOK_BACKQUOTE) {
+            if (token_is_word_list_token(word_token->type)) {
                 node_t *word_node = new_node(NODE_VAR);
                 if (!word_node) {
                     free_node_tree(for_node);
@@ -3944,11 +3929,7 @@ static node_t *parse_for_statement(parser_t *parser) {
             continue;
         }
 
-        if (token_is_word_like(word_token->type) ||
-            word_token->type == TOK_VARIABLE ||
-            word_token->type == TOK_COMMAND_SUB ||
-            word_token->type == TOK_ARITH_EXP ||
-            word_token->type == TOK_BACKQUOTE) {
+        if (token_is_word_list_token(word_token->type)) {
 
             node_t *word_node = NULL;
 
@@ -4000,15 +3981,12 @@ static node_t *parse_for_statement(parser_t *parser) {
                 if (!next_tok || next_tok->position != current_end_pos) {
                     break;
                 }
-                bool is_continuation = token_is_word_like(next_tok->type) ||
-                                       next_tok->type == TOK_VARIABLE ||
-                                       next_tok->type == TOK_NUMBER ||
-                                       next_tok->type == TOK_COMMAND_SUB ||
-                                       next_tok->type == TOK_ARITH_EXP ||
-                                       next_tok->type == TOK_BACKQUOTE ||
-                                       next_tok->type == TOK_ASSIGN ||
-                                       next_tok->type == TOK_PLUS_ASSIGN ||
-                                       next_tok->type == TOK_COMMA;
+                bool is_continuation =
+                    token_is_word_list_token(next_tok->type) ||
+                    next_tok->type == TOK_NUMBER ||
+                    next_tok->type == TOK_ASSIGN ||
+                    next_tok->type == TOK_PLUS_ASSIGN ||
+                    next_tok->type == TOK_COMMA;
                 if (!is_continuation) {
                     break;
                 }
@@ -4166,11 +4144,7 @@ static node_t *parse_select_statement(parser_t *parser) {
 
             token_t *word_token = tokenizer_current(parser->tokenizer);
 
-            if (token_is_word_like(word_token->type) ||
-                word_token->type == TOK_VARIABLE ||
-                word_token->type == TOK_COMMAND_SUB ||
-                word_token->type == TOK_ARITH_EXP ||
-                word_token->type == TOK_BACKQUOTE) {
+            if (token_is_word_list_token(word_token->type)) {
 
                 node_t *word_node = NULL;
 

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -461,6 +461,31 @@ bool token_is_word_like(token_type_t type) {
            type == TOK_VARIABLE;
 }
 
+bool token_is_argument_word_token(token_type_t type) {
+    return type == TOK_STRING || type == TOK_EXPANDABLE_STRING ||
+           type == TOK_ARITH_EXP || type == TOK_COMMAND_SUB ||
+           type == TOK_BACKQUOTE || token_is_word_like(type) ||
+           token_is_keyword(type) || type == TOK_VARIABLE ||
+           type == TOK_LBRACKET || type == TOK_RBRACKET || type == TOK_ASSIGN ||
+           type == TOK_COMMA || type == TOK_GLOB || type == TOK_QUESTION ||
+           type == TOK_NOT_EQUAL;
+}
+
+bool token_is_assignment_value_token(token_type_t type) {
+    return token_is_word_like(type) || type == TOK_VARIABLE ||
+           type == TOK_ARITH_EXP || type == TOK_COMMAND_SUB ||
+           type == TOK_BACKQUOTE || type == TOK_ASSIGN ||
+           type == TOK_PLUS_ASSIGN || type == TOK_COMMA ||
+           type == TOK_LBRACKET || type == TOK_RBRACKET;
+}
+
+bool token_is_word_list_token(token_type_t type) {
+    return token_is_word_like(type) || type == TOK_VARIABLE ||
+           type == TOK_COMMAND_SUB || type == TOK_ARITH_EXP ||
+           type == TOK_BACKQUOTE || type == TOK_LBRACKET ||
+           type == TOK_RBRACKET;
+}
+
 /**
  * @brief Enable or disable keyword recognition
  *

--- a/tests/unit/test_bracket_glob_parsing.c
+++ b/tests/unit/test_bracket_glob_parsing.c
@@ -1,0 +1,197 @@
+/**
+ * @file test_bracket_glob_parsing.c
+ * @brief Regression tests for #154 -- leading-`[` bracket globs.
+ *
+ * Before the fix, any word that started with `[` was mis-parsed as an
+ * invocation of the `[` test builtin, regardless of whether it
+ * appeared as a command name, an argument, an assignment RHS, or a
+ * for/select word-list item. The parser raised
+ * `error[E1127]: '[' command missing closing ']'` instead of letting
+ * the glob expand.
+ *
+ * Each test below pins one user-facing position where a leading-`[`
+ * word must behave like a glob. The control tests confirm the
+ * legitimate `[ ... ]` test command still works.
+ *
+ * @author Michael Berry <trismegustis@gmail.com>
+ * @copyright Copyright (C) 2021-2026 Michael Berry
+ */
+
+#include "symtable.h"
+#include "test_framework.h"
+#include "test_shell_harness.h"
+
+#include <stdio.h>
+
+/// Common script preamble: create an isolated temp dir with files
+/// 5.txt and 6.txt, cd into it, and arrange cleanup on script exit.
+#define BRACKET_TEST_PREAMBLE                                                  \
+    "DIR=/tmp/lush_test_bracket_$$ && mkdir -p \"$DIR\" && "                   \
+    "touch \"$DIR/5.txt\" \"$DIR/6.txt\" && "                                  \
+    "trap 'rm -rf \"$DIR\"' EXIT && "                                          \
+    "cd \"$DIR\" && "
+
+/* ============================================================================
+ * #154 repro cases: every position where a leading-`[` word must glob
+ * ============================================================================
+ */
+
+TEST(echo_leading_bracket_glob_expands) {
+    /// echo [5].txt -> "5.txt\n". This is the headline #154 case.
+    run_result_t r = run_shell_subprocess(BRACKET_TEST_PREAMBLE "echo [5].txt");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "5.txt\n");
+}
+
+TEST(echo_leading_bracket_range_glob_expands) {
+    /// echo [0-9].txt -> "5.txt 6.txt\n" (alphabetic order).
+    run_result_t r =
+        run_shell_subprocess(BRACKET_TEST_PREAMBLE "echo [0-9].txt");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "5.txt 6.txt\n");
+}
+
+TEST(true_leading_bracket_arg_does_not_terminate) {
+    /// true [5].txt: before #154 fix this emitted E1127 (the parser
+    /// routed `[5].txt` to the `[` test builtin). After: argv[1] is
+    /// the glob-expanded "5.txt" and true returns 0.
+    run_result_t r = run_shell_subprocess(BRACKET_TEST_PREAMBLE "true [5].txt");
+    ASSERT_EXIT_STATUS(r, 0);
+}
+
+TEST(assignment_rhs_leading_bracket_is_literal) {
+    /// x=[5].txt; echo "$x" -- assignment RHS does NOT do glob
+    /// expansion (POSIX: pathname expansion happens at word-expansion
+    /// time on commands, not on assignment values). So `$x` is the
+    /// literal "[5].txt".
+    run_result_t r =
+        run_shell_subprocess(BRACKET_TEST_PREAMBLE "x=[5].txt; echo \"$x\"");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "[5].txt\n");
+}
+
+TEST(for_loop_word_list_leading_bracket_globs) {
+    /// for f in [5].txt; do echo "F=$f"; done -> "F=5.txt\n".
+    /// Before fix: word list was empty (TOK_LBRACKET rejected) so
+    /// the loop body never ran.
+    run_result_t r = run_shell_subprocess(
+        BRACKET_TEST_PREAMBLE "for f in [5].txt; do echo \"F=$f\"; done");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "F=5.txt\n");
+}
+
+TEST(for_loop_word_list_leading_bracket_range_globs) {
+    /// for f in [0-9].txt -> two iterations.
+    run_result_t r = run_shell_subprocess(
+        BRACKET_TEST_PREAMBLE "for f in [0-9].txt; do echo \"F=$f\"; done");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "F=5.txt\nF=6.txt\n");
+}
+
+/* ============================================================================
+ * Controls: legitimate `[ ... ]` test builtin still works
+ * ============================================================================
+ */
+
+TEST(test_command_true_branch_still_works) {
+    run_result_t r = run_shell("[ 1 = 1 ]; echo $?");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "0\n");
+}
+
+TEST(test_command_false_branch_still_works) {
+    run_result_t r = run_shell("[ 1 = 2 ]; echo $?");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "1\n");
+}
+
+TEST(bracket_command_missing_close_still_errors) {
+    /// Bare `[` with no closing `]` is still a malformed test
+    /// invocation -- the fix for #154 didn't touch this path.
+    run_result_t r = run_shell("[ 1 = 1");
+    ASSERT_STDERR_CONTAINS(r, "missing closing ']'");
+}
+
+/* ============================================================================
+ * Behavior matches across all modes (issue calls out posix/bash/zsh)
+ * ============================================================================
+ */
+
+TEST(leading_bracket_glob_works_in_posix_mode) {
+    run_result_t r =
+        run_shell_subprocess(BRACKET_TEST_PREAMBLE "mode posix; echo [5].txt");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "5.txt\n");
+}
+
+TEST(leading_bracket_glob_works_in_bash_mode) {
+    run_result_t r =
+        run_shell_subprocess(BRACKET_TEST_PREAMBLE "mode bash; echo [5].txt");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "5.txt\n");
+}
+
+TEST(leading_bracket_glob_works_in_zsh_mode) {
+    run_result_t r =
+        run_shell_subprocess(BRACKET_TEST_PREAMBLE "mode zsh; echo [5].txt");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "5.txt\n");
+}
+
+TEST(leading_bracket_glob_works_in_lush_mode) {
+    run_result_t r =
+        run_shell_subprocess(BRACKET_TEST_PREAMBLE "mode lush; echo [5].txt");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "5.txt\n");
+}
+
+/* ============================================================================
+ * Adjacency: a [ that follows a non-space char must keep working too
+ * ============================================================================
+ */
+
+TEST(non_leading_bracket_glob_still_works) {
+    /// `echo a[5].txt` -- the tokenizer already handles this case
+    /// (`[` is a mid-word char in is_word_char), so a single TOK_WORD
+    /// goes to the executor. This test guards against the parser fix
+    /// breaking the adjacent-bracket case.
+    run_result_t r = run_shell_subprocess(BRACKET_TEST_PREAMBLE
+                                          "touch a5.txt; echo a[5].txt");
+    ASSERT_EXIT_STATUS(r, 0);
+    ASSERT_STDOUT_EQ(r, "a5.txt\n");
+}
+
+/* ============================================================================
+ * MAIN
+ * ============================================================================
+ */
+
+int main(void) {
+    init_symtable();
+
+    printf("=== #154 bracket-glob parsing regression tests ===\n");
+
+    printf("\nRepro cases (every position where a leading-[ must glob):\n");
+    RUN_TEST(echo_leading_bracket_glob_expands);
+    RUN_TEST(echo_leading_bracket_range_glob_expands);
+    RUN_TEST(true_leading_bracket_arg_does_not_terminate);
+    RUN_TEST(assignment_rhs_leading_bracket_is_literal);
+    RUN_TEST(for_loop_word_list_leading_bracket_globs);
+    RUN_TEST(for_loop_word_list_leading_bracket_range_globs);
+
+    printf("\nControls (legitimate `[ ... ]` test command):\n");
+    RUN_TEST(test_command_true_branch_still_works);
+    RUN_TEST(test_command_false_branch_still_works);
+    RUN_TEST(bracket_command_missing_close_still_errors);
+
+    printf("\nMode coverage (issue calls out posix/bash/zsh/lush):\n");
+    RUN_TEST(leading_bracket_glob_works_in_posix_mode);
+    RUN_TEST(leading_bracket_glob_works_in_bash_mode);
+    RUN_TEST(leading_bracket_glob_works_in_zsh_mode);
+    RUN_TEST(leading_bracket_glob_works_in_lush_mode);
+
+    printf("\nAdjacency regression guard:\n");
+    RUN_TEST(non_leading_bracket_glob_still_works);
+
+    return TEST_RESULT();
+}


### PR DESCRIPTION
## Summary

A word that began with `[` was tokenized as `TOK_LBRACKET` regardless of position. The parser's acceptance lists for argument words, assignment values, and for/select word-list items did not include `TOK_LBRACKET`, so `echo [5].txt` and friends fell through into a fresh command parse: `[` became the command, `5 ] .txt` became its argv, and bin_test raised `error[E1127]: '[' command missing closing ']'`.

## Three concrete failure paths

| Site | Repro | Why it failed |
|---|---|---|
| Argument position | `echo [5].txt`, `cat [0-9]*.log`, `true [5].txt` | `collect_word_argument` rejected `TOK_LBRACKET` |
| Assignment RHS | `x=[5].txt` | `parse_scalar_assignment_string` rejected `TOK_LBRACKET` in value tokens |
| for/select word list | `for f in [5].txt; do ...; done` | `parse_for_statement` / `parse_select_statement` rejected `TOK_LBRACKET` |

## Fix

Three canonical predicates in `tokenizer.{h,c}`:

- `token_is_argument_word_token` -- argv-position word tokens
- `token_is_assignment_value_token` -- `x=...` continuation tokens
- `token_is_word_list_token` -- for/select word-list items

Each accepts `TOK_LBRACKET` (and `TOK_RBRACKET` where symmetric). The four affected sites in `parser.c` route through these predicates -- the inline acceptance lists collapse to one-line predicate calls.

## Second bug: `NODE_STRING_EXPANDABLE` overloaded

Once `[5].txt` reached the executor, the multi-token concatenation path in `collect_word_argument` always emitted a single `NODE_STRING_EXPANDABLE`. But the executor's glob gate skips `NODE_STRING_EXPANDABLE` (treating it as a double-quoted string -- which never globs).

Fixed by branching on whether the collected tokens included any quoted string:
- Any `TOK_STRING` / `TOK_EXPANDABLE_STRING` -> `NODE_STRING_EXPANDABLE` (correct double-quote semantics)
- All bare unquoted word tokens -> `NODE_VAR` (which the executor globs)

## Regression coverage

`tests/unit/test_bracket_glob_parsing.c` adds 14 tests:

- **6 repro cases**: every position the issue called out (`echo`, `true`, assignment RHS, two for-loop forms, range glob)
- **3 controls**: `[ 1 = 1 ]` true, `[ 1 = 2 ]` false, `[ 1 = 1` (no close) still errors
- **4 mode-coverage**: posix / bash / zsh / lush all work
- **1 adjacency-regression guard**: `echo a[5].txt` still works (was already fine, but the parser fix must not break it)

The legitimate `[ ... ]` test command is unaffected -- it has whitespace between `[` and `1`, so the adjacency loop never picks the tail into a single argument; `[` remains the command word and bin_test runs as before.

## Verification

- Net `+253 / -62` lines (313 added incl. 195 lines of tests, 62 removed via predicate consolidation)
- Clean build from scratch, zero warnings under `werror=true`
- 113/113 tests pass (was 112, +1 new file)

## Test plan

- [ ] CI build + test passes on macOS and Linux
- [ ] codecov/patch (predicates are pure functions + 14 new tests exercise every path)
- [ ] Reviewer spot-check: confirm `[5].txt`, `[0-9]*.log`, `for f in [a-z].txt` all behave like bash on a real terminal.