### PR TITLE
Login-shell viability: install target + SHLVL increment + .lushrc/.lushrc.toml split + XDG-first

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -15,8 +15,18 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-/** @brief Legacy user configuration file name (in home directory) */
-#define USER_CONFIG_FILE ".lushrc"
+/**
+ * @brief Home-directory TOML config fallback (legacy / adoption path).
+ *
+ * XDG (`~/.config/lush/lushrc.toml`) is the canonical default. This
+ * home-dir fallback exists for users not on XDG layouts. Note the
+ * `.toml` suffix: bare `~/.lushrc` is the SHELL-SCRIPT location (see
+ * RC_SCRIPT_FILE in config.c), not a TOML file. The two MUST stay
+ * separate -- previously this macro was `.lushrc` (no suffix) which
+ * collided with the script loader and emitted a spurious E1204 parse
+ * error whenever a user had a normal shell-script `~/.lushrc`.
+ */
+#define USER_CONFIG_FILE ".lushrc.toml"
 
 /** @brief System-wide configuration file path */
 #define SYSTEM_CONFIG_FILE "/etc/lush/lushrc"

--- a/meson.build
+++ b/meson.build
@@ -315,7 +315,8 @@ display_dep = declare_dependency(link_with: display_lib,
 lush_exe = executable('lush',
                         src + lle_shell_sources,
                         include_directories: inc,
-                        dependencies: [lle_dep, libm])
+                        dependencies: [lle_dep, libm],
+                        install: true)
 
 # ============================================================================
 # TEST INFRASTRUCTURE

--- a/src/config.c
+++ b/src/config.c
@@ -1292,69 +1292,87 @@ char *config_get_profile_script_path(void) {
 }
 
 /**
- * @brief Get the path to the login script file
+ * @brief Resolve a lush-specific script path, XDG default with ~/ fallback.
  *
- * Returns the full path to ~/.lush_login.
+ * Lush's per-user script lookup order is:
+ *   1. `${XDG_CONFIG_HOME:-~/.config}/lush/<xdg_basename>`  -- canonical
+ *   2. `~/<home_basename>`                                  -- fallback
  *
- * @return Allocated path string, or NULL on failure (caller must free)
+ * XDG is the default lush configuration location; `~/` is a fallback
+ * for users not on XDG layouts (cross-shell adoption ergonomics). See
+ * memory note [[config-file-conventions]].
+ *
+ * If the XDG path exists as a regular file, its path is returned.
+ * Otherwise the home-dir fallback path is returned regardless of
+ * whether the file exists (callers gate the actual source step on
+ * config_script_exists), so the migration UX ("file not found"
+ * messages) shows the legacy path the user is likely looking at.
+ *
+ * @param xdg_basename  basename under `<XDG>/lush/` (no leading slash)
+ * @param home_basename basename under `~/` (typically `.<name>`)
+ * @return malloc'd path string, or NULL on allocation / env failure
  */
-char *config_get_login_script_path(void) {
+static char *config_get_xdg_or_home_script(const char *xdg_basename,
+                                           const char *home_basename) {
+    char xdg_dir[CONFIG_PATH_MAX];
+    if (config_get_xdg_dir(xdg_dir, sizeof(xdg_dir)) == 0) {
+        char xdg_path[CONFIG_PATH_MAX];
+        if ((size_t)snprintf(xdg_path, sizeof(xdg_path), "%s/%s", xdg_dir,
+                             xdg_basename) < sizeof(xdg_path)) {
+            struct stat st;
+            if (stat(xdg_path, &st) == 0 && S_ISREG(st.st_mode)) {
+                return strdup(xdg_path);
+            }
+        }
+    }
+
     const char *home = getenv("HOME");
     if (!home) {
         return NULL;
     }
-
-    char *path = malloc(strlen(home) + strlen(LOGIN_SCRIPT_FILE) + 2);
+    char *path = malloc(strlen(home) + strlen(home_basename) + 2);
     if (!path) {
         return NULL;
     }
-
-    sprintf(path, "%s/%s", home, LOGIN_SCRIPT_FILE);
+    sprintf(path, "%s/%s", home, home_basename);
     return path;
+}
+
+/**
+ * @brief Get the path to the login script file
+ *
+ * Returns `${XDG_CONFIG_HOME:-~/.config}/lush/lush_login` if it
+ * exists, else `~/.lush_login`.
+ *
+ * @return Allocated path string, or NULL on failure (caller must free)
+ */
+char *config_get_login_script_path(void) {
+    return config_get_xdg_or_home_script("lush_login", LOGIN_SCRIPT_FILE);
 }
 
 /**
  * @brief Get the path to the RC script file
  *
- * Returns the full path to ~/.lushrc.
+ * Returns `${XDG_CONFIG_HOME:-~/.config}/lush/lushrc` if it exists,
+ * else `~/.lushrc`. XDG is canonical; `~/` is the adoption fallback.
  *
  * @return Allocated path string, or NULL on failure (caller must free)
  */
 char *config_get_rc_script_path(void) {
-    const char *home = getenv("HOME");
-    if (!home) {
-        return NULL;
-    }
-
-    char *path = malloc(strlen(home) + strlen(RC_SCRIPT_FILE) + 2);
-    if (!path) {
-        return NULL;
-    }
-
-    sprintf(path, "%s/%s", home, RC_SCRIPT_FILE);
-    return path;
+    return config_get_xdg_or_home_script("lushrc", RC_SCRIPT_FILE);
 }
 
 /**
  * @brief Get the path to the logout script file
  *
- * Returns the full path to ~/.lush_logout.
+ * Returns `${XDG_CONFIG_HOME:-~/.config}/lush/lush_logout` if it
+ * exists, else `~/.lush_logout`. XDG is canonical; `~/` is the
+ * adoption fallback. See config_get_xdg_or_home_script.
  *
  * @return Allocated path string, or NULL on failure (caller must free)
  */
 char *config_get_logout_script_path(void) {
-    const char *home = getenv("HOME");
-    if (!home) {
-        return NULL;
-    }
-
-    char *path = malloc(strlen(home) + strlen(LOGOUT_SCRIPT_FILE) + 2);
-    if (!path) {
-        return NULL;
-    }
-
-    sprintf(path, "%s/%s", home, LOGOUT_SCRIPT_FILE);
-    return path;
+    return config_get_xdg_or_home_script("lush_logout", LOGOUT_SCRIPT_FILE);
 }
 
 /**

--- a/src/init.c
+++ b/src/init.c
@@ -410,6 +410,28 @@ int init(int argc, char **argv, FILE **in) {
         env_ptr++;
     }
 
+    /// Increment SHLVL so nested shells reflect their depth (matches
+    /// bash and zsh). A missing or unparseable parent value reads as
+    /// 0, so a fresh top-level shell ends up at SHLVL=1. Bash treats
+    /// values >= 1000 as garbage and resets to 1; mirror that.
+    {
+        const char *cur = getenv("SHLVL");
+        long n = 0;
+        if (cur && *cur) {
+            char *end = NULL;
+            long v = strtol(cur, &end, 10);
+            if (end && *end == '\0' && v >= 0 && v < 1000) {
+                n = v;
+            }
+        }
+        n++;
+        char buf[24];
+        snprintf(buf, sizeof(buf), "%ld", n);
+        setenv("SHLVL", buf, 1);
+        symtable_set_global("SHLVL", buf);
+        symtable_export_global("SHLVL");
+    }
+
     init_shell_opts();
 
     /// Initialize POSIX shell options with defaults

--- a/tests/real_world/curated/bash/209_shell_invariants.sh
+++ b/tests/real_world/curated/bash/209_shell_invariants.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+## Per-shell invariants that bash sets up on startup and lush must
+## match (project-defaults-bash-zsh-consensus).
+##
+## diff_oracle runs this script through both lush and bash with the
+## same parent environment, so any variable lush sets up on startup
+## (SHLVL, $0, ...) must end up equal to bash's. Pre-fix, lush
+## inherited SHLVL unchanged while bash incremented; that divergence
+## would have failed this test.
+
+## --- SHLVL is set and incremented from parent ---------------------------
+
+echo "shlvl: $SHLVL"
+## sanity: numeric, >= 1
+case "$SHLVL" in
+    ''|*[!0-9]*) echo "shlvl-numeric: no" ;;
+    *)
+        if [ "$SHLVL" -ge 1 ]; then
+            echo "shlvl-numeric: yes (>=1)"
+        else
+            echo "shlvl-numeric: no (< 1)"
+        fi
+        ;;
+esac
+
+## --- Exit status round-trip ---------------------------------------------
+
+(exit 0); echo "after-true:  $?"
+(exit 1); echo "after-false: $?"
+(exit 7); echo "after-seven: $?"
+
+## --- $? carries through a pipeline (PIPESTATUS not tested here) ----------
+
+true | false; echo "pipe-last: $?"   ## 1 (last in pipe)
+false | true; echo "pipe-last: $?"   ## 0 (last in pipe)
+
+## --- Basic arithmetic still works ----------------------------------------
+
+echo $((2 + 3 * 4))      ## 14
+echo $((10 % 3))         ## 1


### PR DESCRIPTION
## Summary

Four critical blockers from the **login-shell viability audit** -- batched in one PR because each is small and any single one is insufficient to make lush daily-driveable.

### L1 — `meson install` target

`lush_exe = executable('lush', ...)` lacked `install: true`. `meson install` was a no-op, so lush had no stable path for `/etc/shells` or `chsh -s`. With this change `meson install` writes to `${bindir}` (typically `/usr/local/bin`).

### L2 — `SHLVL` never incremented

| parent | bash | zsh | lush (before) | lush (after) |
|---|---|---|---|---|
| 0 | 1 | 1 | 0 | **1** |
| 1 | 2 | 2 | 1 | **2** |
| 2 | 3 | 3 | 2 | **3** |
| garbage | 1 | 1 | (garbage) | **1** |

Per `project-defaults-bash-zsh-consensus`. Increment happens in shell init, not just login init, so every nested invocation reflects its actual depth.

### L3 — `~/.lushrc` no longer mis-parsed as TOML

The two config files have **different responsibilities** per the `[config-file-conventions]` memory:

- **`lushrc.toml`** — CREG (Central Configuration Registry). THE place to configure lush-specific behavior (`display.*`, `history.*`, `prompt.*`, `lle.*`).
- **`lushrc`** — traditional shell-script config. Aliases, exported env vars, function definitions. **NOT** for CREG tweaks.

`USER_CONFIG_FILE` was `.lushrc` (collision with the script loader), so a user putting normal shell-script content in `~/.lushrc` (its actual purpose) got `error[E1204]: invalid configuration line` every startup. Macro moves to `.lushrc.toml`.

### XDG-first lookup for all lush-specific scripts

Per the user's re-clarification of design intent, XDG (`~/.config/lush/`) is the **canonical default** for all lush-specific scripts. `~/.lushrc`, `~/.lush_login`, `~/.lush_logout` are home-dir **fallbacks for users not on XDG layouts** -- adoption ergonomics, not equal-status alternatives.

Previously the script getters were `~/`-only with no XDG check. Factored a `config_get_xdg_or_home_script` helper and wired it into `config_get_rc_script_path` / `_login_script_path` / `_logout_script_path`. `~/.profile` stays in `~/` because that's a cross-shell standard.

## Verification

| Check | Result |
|---|---|
| `meson install --dry-run` | `Installing lush to /usr/local/bin` ✓ |
| SHLVL 0/1/2 → lush 1/2/3 | matches bash ✓ |
| `~/.lushrc` script no longer emits E1204 | ✓ |
| `~/.lushrc.toml` still recognized as legacy TOML with migration notice | ✓ |
| XDG `lushrc` and `~/.lushrc` both exist → XDG wins | ✓ |
| Only `~/.lushrc` exists → home-dir fallback fires | ✓ |
| Full meson suite | **113/113** |
| Real-world scorecard | **27/27**, 0 unexpected divergences |
| Clean build, `werror=true` | zero warnings |

## Regression coverage

New parity script `tests/real_world/curated/bash/209_shell_invariants.sh` exercises SHLVL, exit-status round-trip, pipeline exit status, arithmetic. Runs through diff_oracle against bash on every `meson test`.

## Audit punch list remaining

L4 (job control auto-enable), L5 (`logout` builtin), L6 (`--login` long flag), L7 (ignoreeof enforcement), L8-L11 (parity tests for init-script chain + SIGHUP), L12 (POSIX `ENV` honor), L13-L15 (polish). Future PRs.

## Test plan

- [ ] CI build + test passes on macOS and Linux
- [ ] codecov/patch (parity script covers SHLVL; the macro/helper changes are exercised by the existing config_init path)
- [ ] Reviewer spot-check: `meson install --destdir=/tmp/lush-install -C build`, confirm a `lush` binary lands at `/tmp/lush-install/usr/local/bin/lush`