### PR TITLE
executor: $FUNCNAME exposes active function name during call (Fixes #185)

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -9414,6 +9414,13 @@ static int execute_function_call(executor_t *executor,
         return 1;
     }
 
+    /// Expose the currently-executing function's name as FUNCNAME for
+    /// the body of the call (bash + zsh consensus; #185). The scope
+    /// push above means this local automatically goes out of scope
+    /// when the function returns, matching bash's "FUNCNAME is unset
+    /// outside any function" behavior.
+    (void)symtable_set_local_var(executor->symtable, "FUNCNAME", function_name);
+
     /// Set parameters (both positional and named)
     if (func->params) {
         /// Set named parameters with defaults

--- a/tests/real_world/curated/bash/211_function_locals_and_recursion.sh
+++ b/tests/real_world/curated/bash/211_function_locals_and_recursion.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 ## Function semantics: local variables, dynamic scope, recursion,
-## return-vs-exit. The dynamic-scoping rules here are the same
-## across bash, zsh, and dash (zsh defaults to dynamic like bash;
-## per `project-defaults-bash-zsh-consensus` lush follows that
-## consensus).
-##
-## NOTE: $FUNCNAME inspection is intentionally NOT exercised here
-## because lush's $FUNCNAME is unset inside function bodies (the
-## three reference shells set it). Tracked separately so this script
-## stays in the green column while the underlying gap is addressed.
+## return-vs-exit, $FUNCNAME. The dynamic-scoping rules here are
+## the same across bash, zsh, and dash (zsh defaults to dynamic
+## like bash; per `project-defaults-bash-zsh-consensus` lush follows
+## that consensus).
+
+## --- 0. $FUNCNAME is set during function body execution ----------------
+named() {
+    echo "name: $FUNCNAME"
+}
+named
+echo "outside-funcname: [$FUNCNAME]"   ## empty outside any function
 
 ## --- 1. local hides the outer binding inside the function --------------
 x=outer


### PR DESCRIPTION
## Summary

bash and zsh both set `\$FUNCNAME` to the currently-executing function's name during the body of the call, and unset it (or leave it empty) outside any function. lush left it unset everywhere -- a real divergence from the bash/zsh consensus per `project-defaults-bash-zsh-consensus`.

(dash also doesn't set `\$FUNCNAME`; it's a bash/zsh extension. But the two-shell agreement is enough for the consensus rule to fire.)

## Fix

`execute_function_call_with_def` pushes a `SCOPE_FUNCTION` via `symtable_push_scope` right before binding parameters. The fix sets `FUNCNAME` as a local var **right after** that push: function scope owns the binding, so `symtable_pop_scope` on function return automatically takes `FUNCNAME` out of view -- no separate teardown needed. Matches bash's "`\$FUNCNAME` is unset outside any function" guarantee.

```sh
# pre-fix
$ ./build/lush -c 'named() { echo "\$FUNCNAME"; }; named'

# post-fix
$ ./build/lush -c 'named() { echo "\$FUNCNAME"; }; named'
named
```

## Test coverage

The carved-out NOTE in `tests/real_world/curated/bash/211_function_locals_and_recursion.sh` is reinstated as test case 0:

```sh
named() {
    echo "name: \$FUNCNAME"
}
named
echo "outside-funcname: [\$FUNCNAME]"   ## empty outside any function
```

Both lines now match bash byte-for-byte under diff_oracle.

## Out of scope

bash's `\$FUNCNAME`-as-array semantics (the call stack of nested function names, indexed) is a separate extension and is NOT included here -- this fix lands the simple scalar form that both bash and zsh expose as their everyday surface.

## Verification

| Check | Result |
|---|---|
| Full meson suite | **114/114** |
| Real-world scorecard | **32/32**, 0 unexpected divergences |
| Clean rebuild, \`werror=true\` | zero warnings |

## Test plan

- [ ] CI build + test passes on macOS and Linux
- [ ] codecov/patch (211 covers the new code path; the symtable_pop_scope teardown is exercised by every existing function-call test in test_executor.c)
- [ ] Reviewer: confirm \`./build/lush -c 'f() { echo \$FUNCNAME; }; f'\` prints \`f\`