### PR TITLE
symtable: release array backing memory on scalar overwrite (Fixes #163)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,14 @@ jobs:
           str="hello world"
           echo ${str^^}
           [[ "foo" == "foo" ]] && echo "match"
+          # Issue #163: scalar / empty / re-array overwrite of an
+          # existing array binding must release the prior
+          # array_value_t backing memory. Each of these used to leak
+          # a 190-byte array struct under valgrind.
+          drain1=(a b c); drain1=scalar
+          drain2=(a b c); drain2=
+          drain3=(a b c); drain3=(d e f g)
+          loopvar=(a b c); for loopvar in 1 2 3; do :; done
           exit 0
           EOF
 

--- a/src/symtable.c
+++ b/src/symtable.c
@@ -672,19 +672,33 @@ int symtable_set_var(symtable_manager_t *manager, const char *name,
     }
     name = canon;
 
-    /// Readonly enforcement (current scope). If an entry already lives
-    /// in this scope and carries SYMVAR_READONLY, refuse the write and
-    /// return SYMTABLE_ERR_READONLY so callers can surface a specific
-    /// error message. The check looks at the existing serialized entry
-    /// rather than the incoming `flags` argument so re-asserting the
-    /// readonly bit (`readonly X=1` twice) is correctly refused -- bash
-    /// matches this behavior.
+    /// Readonly enforcement (current scope) + array-backing release.
+    /// If an entry already lives in this scope:
+    ///   - When it carries SYMVAR_READONLY, refuse the write and return
+    ///     SYMTABLE_ERR_READONLY so callers can surface a specific
+    ///     error message. The check looks at the existing serialized
+    ///     entry rather than the incoming `flags` argument so
+    ///     re-asserting the readonly bit (`readonly X=1` twice) is
+    ///     correctly refused -- bash matches this behavior.
+    ///   - When it is SYMVAR_ARRAY, free the array_value_t backing
+    ///     memory before the ht_strstr_insert below overwrites the
+    ///     hex-encoded pointer string. The pointer lives only in the
+    ///     serialized value (no separate C pointer), so without this
+    ///     hand-off the array becomes unreachable and leaks. Drives
+    ///     issue #163. The unset path (flags includes SYMVAR_UNSET) is
+    ///     skipped here because symtable_unset_var has already walked
+    ///     the scope chain via find_var and freed the array_value_t --
+    ///     freeing again would double-free.
     const char *existing_serialized =
         ht_strstr_get(manager->current_scope->vars_ht, name);
     if (existing_serialized) {
         symvar_t *existing = deserialize_variable(name, existing_serialized);
         if (existing) {
             bool readonly_blocked = (existing->flags & SYMVAR_READONLY) != 0;
+            if (existing->type == SYMVAR_ARRAY && existing->array &&
+                !(flags & SYMVAR_UNSET)) {
+                symtable_array_free(existing->array);
+            }
             free_symvar(existing);
             if (readonly_blocked) {
                 free(canon);

--- a/tests/unit/test_symtable.c
+++ b/tests/unit/test_symtable.c
@@ -409,6 +409,56 @@ TEST(array_associative) {
  * ============================================================================
  */
 
+/// Issue #163: scalar assignment over an existing array binding must
+/// release the array_value_t backing memory. The previous serialized
+/// value was a hex-encoded pointer string; ht_strstr_insert overwrites
+/// it as ASCII text, leaving no C pointer to the array. Without the
+/// hand-off in symtable_set_var the array becomes unreachable -- the
+/// CI memcheck-linux job picks it up as "definitely lost".
+///
+/// This test exercises the type-switch path so a regression that
+/// reintroduces the leak still crashes or misbehaves observably
+/// (kind-flip stops working, lookup returns stale array, etc.). The
+/// quantitative leak signal stays with the valgrind CI job.
+TEST(array_scalar_overwrite_releases_backing) {
+    init_symtable();
+    symtable_manager_t *mgr = symtable_get_global_manager();
+    if (!mgr) {
+        printf(
+            "    (Skipped - global manager not initialized in test context)\n");
+        return;
+    }
+
+    array_value_t *arr = symtable_array_create(false);
+    ASSERT_NOT_NULL(arr, "array_create");
+    symtable_array_append(arr, "one");
+    symtable_array_append(arr, "two");
+    symtable_array_append(arr, "three");
+    int rc = symtable_set_array("lush_163_arr", arr);
+    ASSERT_EQ(rc, 0, "set_array should store the binding");
+
+    /// Confirm the array round-trips before we overwrite it.
+    array_value_t *probe = symtable_get_array("lush_163_arr");
+    ASSERT_NOT_NULL(probe, "array binding lookup before overwrite");
+    ASSERT_EQ(symtable_array_length(probe), 3, "length 3 before overwrite");
+
+    /// Scalar assignment over the same name -- the path that used to
+    /// leak the array_value_t.
+    rc = symtable_set_var(mgr, "lush_163_arr", "scalar_value", SYMVAR_NONE);
+    ASSERT_EQ(rc, 0, "scalar overwrite should succeed");
+
+    /// The binding is now a scalar; array lookup must return NULL.
+    probe = symtable_get_array("lush_163_arr");
+    ASSERT_NULL(probe, "array lookup after scalar overwrite returns NULL");
+
+    char *scalar = symtable_get_var(mgr, "lush_163_arr");
+    ASSERT_NOT_NULL(scalar, "scalar lookup after overwrite");
+    ASSERT_STR_EQ(scalar, "scalar_value", "scalar value matches");
+    free(scalar);
+
+    symtable_unset_var(mgr, "lush_163_arr");
+}
+
 TEST(value_view_scalar_lookup) {
     /// symtable_lookup queries the global manager. Ensure it is up;
     /// init_symtable() is a no-op if already initialized.
@@ -569,6 +619,7 @@ int main(void) {
 
     printf("\nArray tests:\n");
     RUN_TEST(array_create);
+    RUN_TEST(array_scalar_overwrite_releases_backing);
     RUN_TEST(value_view_scalar_lookup);
     RUN_TEST(value_view_list_lookup);
     RUN_TEST(value_view_map_lookup);


### PR DESCRIPTION
## Summary
The intermittent valgrind leak in `execute_array_assignment` was a deterministic cleanup hole, not iteration luck. Arrays are stored as hex-encoded pointer strings in `vars_ht`'s serialized value -- there is no C pointer to the `array_value_t`, only its ASCII representation. When a scalar assignment overwrites an existing array binding, `ht_strstr_insert` rewrites the serialized string and the only handle to the `array_value_t` is gone.

Fixed in `symtable_set_var`: when the existing entry in the current scope is `SYMVAR_ARRAY`, free its `array_value_t` before the `ht_strstr_insert` overwrites the hex pointer. The unset path (signalled by `SYMVAR_UNSET` in flags) is skipped here to avoid a double-free with `symtable_unset_var`'s existing scope-walk free.

## Leak paths fixed
- `arr=(...)` then `arr=scalar`
- `arr=(...)` then `arr=` (empty assign)
- `arr=(...)` then `for arr in 1 2 3; do ...` (loop var was array)

The `arr=(...)` then `arr=(...)` (array rebind) path was already correct via `symtable_set_array`'s existing free.

## Test plan
- [x] New unit test `array_scalar_overwrite_releases_backing` exercises the type-switch path
- [x] CI memcheck script (`.github/workflows/ci.yml`) gains four leak-shaped scenarios so valgrind catches regressions
- [x] Full local suite: 114/114 pass
- [x] CI valgrind job (`memory-check-linux`) is the quantitative gate