### PR TITLE
executor, input: per-batch driver + single canonical multiline analyzer (Fixes #151)

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -24,6 +24,7 @@
 #include "ht.h"
 #include "identifier.h"
 #include "init.h"
+#include "input_continuation.h"
 #include "lle/lle_pager.h"
 #include "lle/lle_shell_event_hub.h"
 #include "lle/lle_shell_integration.h"
@@ -1020,18 +1021,20 @@ int executor_execute(executor_t *executor, node_t *ast) {
     executor->has_error = false;
     executor->error_message = NULL;
 
-    /// Check if this is a command sequence (has siblings) or a single command
-    if (ast->next_sibling) {
-        /// This is a command sequence, execute all siblings
-        int result = execute_command_list(executor, ast);
-        executor->exit_status = result;
-        return result;
-    } else {
-        /// Single command, execute normally
-        int result = execute_node(executor, ast);
-        executor->exit_status = result;
-        return result;
-    }
+    /// Always route through execute_command_list. The historical
+    /// single-command shortcut (call execute_node directly) bypassed
+    /// the post-command bookkeeping that execute_command_chain runs
+    /// after every node: ERR-trap firing on non-zero exit, errexit
+    /// check, shell_exit_requested propagation. Those side-effects
+    /// must fire for batch-of-one inputs too -- a script's first
+    /// line, or any single-command -c invocation, has to behave the
+    /// same as the same line inside a longer list. The chain walker
+    /// already handles a 1-node chain correctly; collapsing onto it
+    /// removes the divergence between the "single" and "list" paths.
+    /// Surfaced while building the per-batch driver for issue #151.
+    int result = execute_command_list(executor, ast);
+    executor->exit_status = result;
+    return result;
 }
 
 /**
@@ -1044,6 +1047,142 @@ int executor_execute(executor_t *executor, node_t *ast) {
  * @param input Shell command string to parse and execute
  * @return Exit status of executed command, or error code
  */
+/// Find the end of the first syntactically-complete batch starting at
+/// `input`. A "batch" is the same logical unit `get_input_complete_counted`
+/// builds from a file: a single simple command, a multi-line construct
+/// (if/case/for/function/heredoc), or the contents of a quoted string
+/// spanning multiple lines. Returns the byte offset just past the last
+/// consumed character (including the terminating newline, if any).
+/// `*out_lines` receives the number of source lines this batch covers.
+///
+/// Reusing the canonical continuation analyzer (input_continuation.h)
+/// means a -c string with `shopt -s extglob\ncase ... esac` is split
+/// into the same two batches a file would produce -- the shopt batch
+/// runs, flips FEATURE_EXTENDED_GLOB, and the case batch is then
+/// tokenized with extglob in effect. Mode-accurate defaults stay
+/// intact (`-c '...; ...'` on one line is still one batch and still
+/// errors exactly as bash does -- bash doesn't fix the one-line form
+/// either). Drives issue #151.
+static size_t find_next_batch_end(const char *input, size_t input_len,
+                                  size_t *out_lines) {
+    continuation_state_t state;
+    continuation_state_init(&state);
+
+    size_t pos = 0;
+    size_t lines = 0;
+    bool produced_any = false;
+
+    while (pos < input_len) {
+        size_t line_start = pos;
+        while (pos < input_len && input[pos] != '\n') {
+            pos++;
+        }
+        size_t line_len = pos - line_start;
+
+        char *line = malloc(line_len + 1);
+        if (!line) {
+            continuation_state_cleanup(&state);
+            if (out_lines) {
+                *out_lines = lines;
+            }
+            return pos;
+        }
+        memcpy(line, input + line_start, line_len);
+        line[line_len] = '\0';
+
+        continuation_analyze_line(line, &state);
+        free(line);
+
+        /// A blank/whitespace-only line on its own doesn't constitute a
+        /// batch: skip past the newline and keep looking so we don't
+        /// hand the parser an empty string. Only treat it as
+        /// significant once a non-blank line has been seen.
+        bool blank = true;
+        for (size_t i = 0; i < line_len; i++) {
+            if (!isspace((unsigned char)input[line_start + i])) {
+                blank = false;
+                break;
+            }
+        }
+        if (!blank) {
+            produced_any = true;
+            lines++;
+        } else if (produced_any) {
+            lines++;
+        }
+
+        if (pos < input_len && input[pos] == '\n') {
+            pos++;
+        }
+
+        if (!produced_any) {
+            /// Don't end on a blank-prefix; keep scanning for the first
+            /// real line.
+            continue;
+        }
+
+        if (!continuation_needs_continuation(&state)) {
+            break;
+        }
+    }
+
+    continuation_state_cleanup(&state);
+    if (out_lines) {
+        *out_lines = lines;
+    }
+    return pos;
+}
+
+/// Parse + execute a single already-extracted batch. Owns the parser
+/// lifecycle and the stashed source-text view for the structured-error
+/// system. Factored out so executor_execute_command_line can iterate
+/// over batches without duplicating the parser plumbing.
+static int execute_one_batch(executor_t *executor, const char *batch,
+                             const char *source_name, size_t starting_line) {
+    parser_t *parser =
+        parser_new_with_source(batch, source_name, starting_line);
+    if (!parser) {
+        set_executor_error(executor, "Failed to create parser");
+        return 1;
+    }
+
+    node_t *ast = parser_parse(parser);
+
+    if (shell_opts.syntax_check) {
+        int rc = 0;
+        if (parser_has_error(parser)) {
+            parser_display_errors(parser, stderr, isatty(STDERR_FILENO));
+            const char *legacy_err = parser_error(parser);
+            if (legacy_err) {
+                set_executor_error(executor, legacy_err);
+            }
+            rc = 2;
+        }
+        parser_free(parser);
+        return rc;
+    }
+
+    if (parser_has_error(parser)) {
+        parser_display_errors(parser, stderr, isatty(STDERR_FILENO));
+        const char *legacy_err = parser_error(parser);
+        if (legacy_err) {
+            set_executor_error(executor, legacy_err);
+        }
+        parser_free(parser);
+        return 1;
+    }
+
+    if (!ast) {
+        parser_free(parser);
+        return 0;
+    }
+
+    int rc = executor_execute(executor, ast);
+    free_node_tree(ast);
+    parser_free(parser);
+    return rc;
+}
+
 int executor_execute_command_line(executor_t *executor, const char *input,
                                   size_t starting_line) {
     if (!executor || !input) {
@@ -1058,13 +1197,12 @@ int executor_execute_command_line(executor_t *executor, const char *input,
     /// source line via executor_get_source_line() and attach it via
     /// shell_error_set_source_line() to produce the full rust-style
     /// snippet block (`N | source line / ^~~~~`). The stash is set to
-    /// the input we're about to parse and restored on exit so re-entrant
-    /// dispatch (e.g. command substitution running its own batch
-    /// recursively) doesn't leak text from one batch into another.
+    /// the current batch we're about to parse and restored on exit so
+    /// re-entrant dispatch (e.g. command substitution running its own
+    /// batch recursively) doesn't leak text from one batch into
+    /// another.
     const char *saved_source_text = executor->source_text;
     size_t saved_source_starting_line = executor->source_starting_line;
-    executor->source_text = input;
-    executor->source_starting_line = starting_line;
 
     /// Preprocess input to handle line continuation (backslash-newline)
     /// This is needed for -c option where the string comes directly without
@@ -1092,69 +1230,103 @@ int executor_execute_command_line(executor_t *executor, const char *input,
         }
     }
 
-    /// Parse the input, using script filename if executing a script
     const char *source_name = executor->current_script_file
                                   ? executor->current_script_file
                                   : "<stdin>";
+
+    /// Iterate over syntactically-complete batches. The file/stdin path
+    /// already batches at the reader (get_input_complete_counted); -c
+    /// and other in-process callers (eval-style, traps, autoload, fc,
+    /// shell-hooks) used to bypass that batching and hand multi-batch
+    /// strings to a single parse. Re-using the canonical continuation
+    /// analyzer here closes that gap so every entry point sees the
+    /// same batch granularity. Issue #151.
+    size_t input_pos = 0;
+    size_t input_len = strlen(parse_input);
+    size_t batch_starting_line = starting_line;
     int result = 0;
-    parser_t *parser =
-        parser_new_with_source(parse_input, source_name, starting_line);
-    if (!parser) {
-        set_executor_error(executor, "Failed to create parser");
-        result = 1;
-        goto cleanup;
-    }
 
-    node_t *ast = parser_parse(parser);
+    while (input_pos < input_len) {
+        size_t batch_lines = 0;
+        size_t batch_consumed = find_next_batch_end(
+            parse_input + input_pos, input_len - input_pos, &batch_lines);
+        if (batch_consumed == 0) {
+            break;
+        }
 
-    /// Check syntax check mode (set -n) - parse but don't execute
-    if (shell_opts.syntax_check) {
-        if (parser_has_error(parser)) {
-            /// Display structured errors if available
-            parser_display_errors(parser, stderr, isatty(STDERR_FILENO));
-            /// Set executor error for legacy compatibility (may be NULL with
-            /// new system)
-            const char *legacy_err = parser_error(parser);
-            if (legacy_err) {
-                set_executor_error(executor, legacy_err);
+        /// Trim the trailing newline (if any) for the batch buffer the
+        /// parser sees, but report the full consumed length to the
+        /// caller-line tracker via batch_lines.
+        size_t batch_text_len = batch_consumed;
+        if (batch_text_len > 0 &&
+            parse_input[input_pos + batch_text_len - 1] == '\n') {
+            batch_text_len--;
+        }
+
+        /// Skip a pure-whitespace batch (no parser invocation needed).
+        bool all_blank = true;
+        for (size_t i = 0; i < batch_text_len; i++) {
+            if (!isspace((unsigned char)parse_input[input_pos + i])) {
+                all_blank = false;
+                break;
             }
-            result = 2; /// Syntax error
-        } else {
-            result = 0; /// Syntax check successful
         }
-        parser_free(parser);
-        goto cleanup;
-    }
-
-    if (parser_has_error(parser)) {
-        /// Display structured errors if available
-        parser_display_errors(parser, stderr, isatty(STDERR_FILENO));
-        /// Set executor error for legacy compatibility (may be NULL with new
-        /// system)
-        const char *legacy_err = parser_error(parser);
-        if (legacy_err) {
-            set_executor_error(executor, legacy_err);
+        if (all_blank) {
+            input_pos += batch_consumed;
+            batch_starting_line += batch_lines;
+            continue;
         }
-        parser_free(parser);
-        result = 1;
-        goto cleanup;
+
+        char *batch = malloc(batch_text_len + 1);
+        if (!batch) {
+            set_executor_error(executor, "Failed to allocate batch buffer");
+            result = 1;
+            break;
+        }
+        memcpy(batch, parse_input + input_pos, batch_text_len);
+        batch[batch_text_len] = '\0';
+
+        executor->source_text = batch;
+        executor->source_starting_line = batch_starting_line;
+
+        result = execute_one_batch(executor, batch, source_name,
+                                   batch_starting_line);
+
+        free(batch);
+
+        input_pos += batch_consumed;
+        batch_starting_line += batch_lines;
+
+        /// Honor mid-stream shell-exit requests: ${var:?word}, builtin
+        /// exit, errexit-style abort, etc. The remaining batches must
+        /// not run once the shell has decided to terminate the script.
+        if (executor->shell_exit_requested) {
+            break;
+        }
+
+        /// Parse / syntax-check failure in non-first batch: stop
+        /// processing further batches and surface the error. This
+        /// matches bash's behavior where a parse error in the middle
+        /// of a -c string aborts the rest.
+        if (result != 0 && shell_opts.syntax_check) {
+            break;
+        }
+
+        /// `set -e` (errexit) at batch granularity: a non-zero result
+        /// from a batch -- where the chain inside the batch already
+        /// honored set -e's exemption rules (conditional context,
+        /// pipeline LHS, etc.) and STILL surfaced non-zero -- aborts
+        /// the remaining batches, matching bash's script-wide errexit
+        /// semantics. Without this the historical "test passes / real
+        /// script keeps running" divergence persisted because the
+        /// chain returned to the batch loop but the loop kept feeding
+        /// new batches.
+        if (shell_opts.exit_on_error && result != 0) {
+            break;
+        }
     }
 
-    if (!ast) {
-        parser_free(parser);
-        result = 0; /// Empty command
-        goto cleanup;
-    }
-
-    result = executor_execute(executor, ast);
-
-    free_node_tree(ast);
-    parser_free(parser);
-
-cleanup:
     free(processed_input);
-    /// Restore previous source-text stash so re-entrant batches don't
-    /// leak text from one batch into another.
     executor->source_text = saved_source_text;
     executor->source_starting_line = saved_source_starting_line;
     return result;

--- a/src/input.c
+++ b/src/input.c
@@ -18,656 +18,47 @@
 #include "input.h"
 #include "errors.h"
 #include "init.h"
+#include "input_continuation.h"
 #include "lle/lle_shell_integration.h"
-#include "lle/utf8_support.h"
 #include "lush.h"
 #include "symtable.h"
 
-#include <ctype.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
-/// ============================================================================
-/// UTF-8 HELPER (uses LLE's UTF-8 support)
-/// ============================================================================
-
-/**
- * @brief Get the byte length of a UTF-8 character at the given position
- *
- * Determines the number of bytes in a UTF-8 character sequence starting
- * at the given position. Uses LLE's UTF-8 support for sequence detection
- * and validation.
- *
- * @param p Pointer to the start of a UTF-8 character sequence
- * @return Number of bytes in the character (1-4), or 0 if p is NULL/empty,
- *         or 1 for invalid sequences (safe fallback)
- */
-static int utf8_char_len(const char *p) {
-    if (!p || !*p)
-        return 0;
-
-    unsigned char c = (unsigned char)*p;
-
-    /// ASCII (0x00-0x7F) - single byte
-    if (c < 0x80)
-        return 1;
-
-    /// Use LLE's UTF-8 sequence length detection
-    int len = lle_utf8_sequence_length(c);
-
-    /// Validate the sequence
-    if (len > 1 && lle_utf8_is_valid_sequence(p, len)) {
-        return len;
-    }
-
-    /// Invalid sequence - skip one byte
-    return 1;
-}
-
-/// Input state for multiline parsing
-typedef struct {
-    int quote_count;
-    int double_quote_count;
-    int backtick_count;
-    int paren_count;
-    int brace_count;
-    int bracket_count;
-    bool in_single_quote;
-    bool in_double_quote;
-    bool in_backtick;
-    bool escaped;
-    bool in_here_doc;
-    char *here_doc_delimiter;
-    bool has_continuation;
-    bool in_command_substitution;
-    bool in_arithmetic;
-    bool in_function_definition;
-    bool saw_posix_func_parens; ///< Saw name() pattern, waiting for {
-    bool in_case_statement;
-    bool in_if_statement;
-    bool in_while_loop;
-    bool in_for_loop;
-    bool in_until_loop;
-    int compound_command_depth;
-} input_state_t;
-
-/// Global state
-static input_state_t global_state = {0};
+/// Single canonical analyzer: the multiline-input state and the
+/// per-line analyzer live in input_continuation.c (see
+/// input_continuation.h). This file used to carry a parallel
+/// `input_state_t` + private `analyze_line`/`is_input_complete`
+/// implementation, which had drifted ~200 lines from the shared one
+/// (missing the herestring `<<<` guard, missing trailing `&&`/`||`
+/// continuation, missing the context stack, etc.). The duplicate is
+/// retired here; this file now only carries the reader plumbing
+/// (getline loop, accumulator buffer, prompt selection) and dispatches
+/// the state work to the shared API. Drives issue #151 / duplicate-
+/// path audit.
+static continuation_state_t global_state = {0};
 static bool state_initialized = false;
 
-/// Forward declarations
-static void init_input_state(input_state_t *state);
-static void cleanup_input_state(input_state_t *state);
-static void analyze_line(const char *line, input_state_t *state);
-static bool is_input_complete(input_state_t *state);
-static const char *get_continuation_prompt(input_state_t *state);
-static bool is_control_keyword(const char *word);
-static bool is_terminator(const char *line);
-
-/// Public function to get current continuation prompt
-const char *lush_get_current_continuation_prompt(void);
-static char *convert_multiline_for_history(const char *input);
-
 /// ============================================================================
-/// INPUT STATE MANAGEMENT
+/// CONTINUATION PROMPT SELECTION
 /// ============================================================================
 
-/**
- * @brief Initialize an input state structure to default values
- *
- * Zeros out all fields and sets the here document delimiter to NULL.
- * Must be called before first use of an input_state_t structure.
- *
- * @param state Pointer to the input state structure to initialize
- */
-static void init_input_state(input_state_t *state) {
-    memset(state, 0, sizeof(input_state_t));
-    state->here_doc_delimiter = NULL;
-}
-
-/**
- * @brief Clean up an input state structure and free allocated memory
- *
- * Frees the here document delimiter if allocated and zeros the structure.
- * Safe to call on an already-cleaned state.
- *
- * @param state Pointer to the input state structure to clean up
- */
-static void cleanup_input_state(input_state_t *state) {
-    if (state->here_doc_delimiter) {
-        free(state->here_doc_delimiter);
-        state->here_doc_delimiter = NULL;
-    }
-    memset(state, 0, sizeof(input_state_t));
-}
-
-/// ============================================================================
-/// MULTILINE INPUT ANALYSIS
-/// ============================================================================
-
-/**
- * @brief Check if a word is a shell control flow keyword
- *
- * Identifies shell reserved words that affect control flow and require
- * special handling for multiline input parsing (if, then, else, fi, etc.).
- *
- * @param word The word to check
- * @return true if word is a control keyword, false otherwise
- */
-static bool is_control_keyword(const char *word) {
-    const char *keywords[] = {"if",   "then", "else",  "elif",     "fi",
-                              "case", "esac", "while", "until",    "do",
-                              "done", "for",  "in",    "function", "select",
-                              "{",    "}"};
-
-    for (size_t i = 0; i < sizeof(keywords) / sizeof(keywords[0]); i++) {
-        if (strcmp(word, keywords[i]) == 0) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/**
- * @brief Check if a line contains a compound command terminator
- *
- * Checks if the line (after skipping whitespace) starts with a terminator
- * keyword like fi, done, esac, or closing brace.
- *
- * @param line The line to check
- * @return true if line starts with a terminator, false otherwise
- */
-MAYBE_UNUSED
-static bool is_terminator(const char *line) {
-    /// Skip whitespace
-    while (*line && isspace(*line))
-        line++;
-
-    /// Check for terminators
-    return (strncmp(line, "fi", 2) == 0 || strncmp(line, "done", 4) == 0 ||
-            strncmp(line, "esac", 4) == 0 || strcmp(line, "}") == 0);
-}
-
-/**
- * @brief Analyze a line of input to update parsing state
- *
- * Processes a line character by character to track quotes, parentheses,
- * braces, brackets, here documents, escape sequences, and control keywords.
- * Updates the input state structure to reflect what constructs are currently
- * open and whether continuation input is needed.
- *
- * @param line The line of input to analyze
- * @param state The input state structure to update
- */
-static void analyze_line(const char *line, input_state_t *state) {
-    if (!line || !state)
-        return;
-
-    const char *p = line;
-    char word[256] = {0};
-    int word_pos = 0;
-    (void)word_pos; /// Reserved for word boundary tracking
-    bool at_word_start = true;
-    (void)at_word_start; /// Reserved for word start detection
-
-    while (*p) {
-        unsigned char uc = (unsigned char)*p;
-        char c = *p;
-
-        /// UTF-8 multi-byte sequence handling:
-        /// If this is a non-ASCII byte (high bit set), it's part of a UTF-8
-        /// multi-byte character. Skip the entire sequence since shell syntax
-        /// characters are all ASCII. This prevents misinterpreting UTF-8
-        /// continuation bytes as shell metacharacters.
-        if (uc >= 0x80) {
-            int char_len = utf8_char_len(p);
-
-            /// If we're collecting a word, flush it first (UTF-8 chars break
-            /// words for keyword detection purposes - keywords are ASCII only)
-            if (word_pos > 0) {
-                word[word_pos] = '\0';
-                /// Keywords are ASCII-only, so no need to check here
-                word_pos = 0;
-                memset(word, 0, sizeof(word));
-            }
-
-            /// Skip the entire UTF-8 sequence
-            p += (char_len > 0) ? char_len : 1;
-            at_word_start = true;
-            continue;
-        }
-
-        /// Handle escape sequences
-        if (state->escaped) {
-            state->escaped = false;
-            p++;
-            continue;
-        }
-
-        if (c == '\\') {
-            state->escaped = true;
-            p++;
-            continue;
-        }
-
-        /// Handle quotes
-        if (c == '\'' && !state->in_double_quote && !state->in_backtick) {
-            state->in_single_quote = !state->in_single_quote;
-            if (state->in_single_quote) {
-                state->quote_count++;
-            }
-        } else if (c == '"' && !state->in_single_quote) {
-            state->in_double_quote = !state->in_double_quote;
-            if (state->in_double_quote) {
-                state->double_quote_count++;
-            }
-        } else if (c == '`' && !state->in_single_quote) {
-            state->in_backtick = !state->in_backtick;
-            if (state->in_backtick) {
-                state->backtick_count++;
-            }
-        }
-
-        /// Skip if we're in quotes
-        if (state->in_single_quote || state->in_double_quote ||
-            state->in_backtick) {
-            p++;
-            continue;
-        }
-
-        /// Handle parentheses, braces, brackets
-        if (c == '(') {
-            state->paren_count++;
-            /// Check for POSIX function definition: name() or name ()
-            /// We just accumulated a word and now see '(' followed by ')'
-            if (word_pos > 0 && *(p + 1) == ')') {
-                /// This is name() pattern - mark that we're in a POSIX func def
-                state->saw_posix_func_parens = true;
-            }
-        } else if (c == ')') {
-            state->paren_count--;
-        } else if (c == '{') {
-            state->brace_count++;
-        } else if (c == '}') {
-            state->brace_count--;
-        } else if (c == '[') {
-            state->bracket_count++;
-        } else if (c == ']') {
-            state->bracket_count--;
-        }
-
-        /// Handle here document detection
-        if (c == '<' && *(p + 1) == '<' && !state->in_here_doc) {
-            /// Found <<, look for delimiter
-            const char *delim_start = p + 2;
-
-            /// Skip optional '-' for <<-
-            if (*delim_start == '-') {
-                delim_start++;
-            }
-
-            /// Skip whitespace
-            while (*delim_start == ' ' || *delim_start == '\t') {
-                delim_start++;
-            }
-
-            /// Extract delimiter (up to end of line or whitespace)
-            const char *delim_end = delim_start;
-            while (*delim_end && *delim_end != '\n' && *delim_end != ' ' &&
-                   *delim_end != '\t') {
-                delim_end++;
-            }
-
-            if (delim_end > delim_start) {
-                /// Handle quoted delimiters - strip surrounding quotes
-                const char *actual_delim_start = delim_start;
-                const char *actual_delim_end = delim_end;
-
-                /// Check for single or double quotes
-                if ((*delim_start == '\'' || *delim_start == '"') &&
-                    delim_end > delim_start + 1 &&
-                    *(delim_end - 1) == *delim_start) {
-                    /// Strip quotes
-                    actual_delim_start++;
-                    actual_delim_end--;
-                }
-
-                /// Found a delimiter, enter here document mode
-                state->in_here_doc = true;
-                if (state->here_doc_delimiter) {
-                    free(state->here_doc_delimiter);
-                }
-                size_t delim_len = actual_delim_end - actual_delim_start;
-                state->here_doc_delimiter = malloc(delim_len + 1);
-                if (state->here_doc_delimiter) {
-                    strncpy(state->here_doc_delimiter, actual_delim_start,
-                            delim_len);
-                    state->here_doc_delimiter[delim_len] = '\0';
-                }
-            }
-        }
-
-        /// Check if current line is a here document delimiter (ends here doc)
-        if (state->in_here_doc && state->here_doc_delimiter) {
-            /// Check if this entire line matches the delimiter
-            const char *line_start = line;
-            while (*line_start == ' ' || *line_start == '\t') {
-                line_start++; /// Skip leading whitespace
-            }
-
-            if (strncmp(line_start, state->here_doc_delimiter,
-                        strlen(state->here_doc_delimiter)) == 0) {
-                /// Check if delimiter is followed by end of line or whitespace
-                const char *after_delim =
-                    line_start + strlen(state->here_doc_delimiter);
-                if (*after_delim == '\0' || *after_delim == '\n' ||
-                    *after_delim == ' ' || *after_delim == '\t') {
-                    /// This line is the delimiter, end here document
-                    state->in_here_doc = false;
-                    free(state->here_doc_delimiter);
-                    state->here_doc_delimiter = NULL;
-                }
-            }
-        }
-
-        /// Collect words for keyword analysis
-        if (isalnum(c) || c == '_') {
-            if (word_pos < (int)sizeof(word) - 1) {
-                word[word_pos++] = c;
-            }
-            at_word_start = false;
-        } else if (c == '{' || c == '}') {
-            /// Handle { and } as single-character keywords
-            if (word_pos > 0) {
-                /// Process any accumulated word first
-                word[word_pos] = '\0';
-
-                /// Check for control keywords
-                if (is_control_keyword(word)) {
-
-                    if (strcmp(word, "if") == 0) {
-                        state->in_if_statement = true;
-                        state->compound_command_depth++;
-                    } else if (strcmp(word, "while") == 0) {
-                        state->in_while_loop = true;
-                        state->compound_command_depth++;
-                    } else if (strcmp(word, "for") == 0) {
-                        state->in_for_loop = true;
-                        state->compound_command_depth++;
-                    } else if (strcmp(word, "until") == 0) {
-                        state->in_until_loop = true;
-                        state->compound_command_depth++;
-                    } else if (strcmp(word, "case") == 0) {
-                        state->in_case_statement = true;
-                        state->compound_command_depth++;
-                    } else if (strcmp(word, "function") == 0) {
-                        state->in_function_definition = true;
-                        state->compound_command_depth++;
-                    } else if (strcmp(word, "fi") == 0) {
-                        state->in_if_statement = false;
-                        state->has_continuation = false;
-                        if (state->compound_command_depth > 0) {
-                            state->compound_command_depth--;
-                        }
-                    } else if (strcmp(word, "done") == 0) {
-                        state->in_while_loop = false;
-                        state->in_for_loop = false;
-                        state->in_until_loop = false;
-                        state->has_continuation = false;
-                        if (state->compound_command_depth > 0) {
-                            state->compound_command_depth--;
-                        }
-                    } else if (strcmp(word, "esac") == 0) {
-                        state->in_case_statement = false;
-                        state->has_continuation = false;
-                        if (state->compound_command_depth > 0) {
-                            state->compound_command_depth--;
-                        }
-                    }
-                }
-
-                word_pos = 0;
-                memset(word, 0, sizeof(word));
-            }
-
-            /// Now handle the { or } character as a single-character keyword
-            if (c == '{') {
-                /// Check if this is a POSIX function definition: name() { ... }
-                /// saw_posix_func_parens is set when we saw the () pattern
-                if (state->saw_posix_func_parens) {
-                    /// This is a POSIX-style function definition
-                    state->in_function_definition = true;
-                    state->compound_command_depth++;
-                    state->saw_posix_func_parens = false;
-                } else if (!state->in_function_definition) {
-                    /// Regular brace group (not a function)
-                    state->compound_command_depth++;
-                }
-                /// If already in_function_definition (from 'function' keyword),
-                /// don't increment again - the keyword handler already did
-            } else if (c == '}') {
-                if (state->compound_command_depth > 0) {
-                    state->compound_command_depth--;
-                }
-                if (state->compound_command_depth == 0) {
-                    state->in_function_definition = false;
-                    state->saw_posix_func_parens = false;
-                }
-            }
-        } else {
-            if (word_pos > 0) {
-                word[word_pos] = '\0';
-
-                /// Check for control keywords
-                if (is_control_keyword(word)) {
-
-                    if (strcmp(word, "if") == 0) {
-                        state->in_if_statement = true;
-                        state->compound_command_depth++;
-                    } else if (strcmp(word, "while") == 0) {
-                        state->in_while_loop = true;
-                        state->compound_command_depth++;
-                    } else if (strcmp(word, "for") == 0) {
-                        state->in_for_loop = true;
-                        state->compound_command_depth++;
-                    } else if (strcmp(word, "until") == 0) {
-                        state->in_until_loop = true;
-                        state->compound_command_depth++;
-                    } else if (strcmp(word, "case") == 0) {
-                        state->in_case_statement = true;
-                        state->compound_command_depth++;
-                    } else if (strcmp(word, "function") == 0) {
-                        state->in_function_definition = true;
-                        state->compound_command_depth++;
-                    } else if (strcmp(word, "{") == 0) {
-                        state->compound_command_depth++;
-                    } else if (strcmp(word, "fi") == 0) {
-                        state->in_if_statement = false;
-                        state->has_continuation =
-                            false; /// Clear continuation flag when closing if
-                        if (state->compound_command_depth > 0) {
-                            state->compound_command_depth--;
-                        }
-                    } else if (strcmp(word, "done") == 0) {
-                        state->in_while_loop = false;
-                        state->in_for_loop = false;
-                        state->in_until_loop = false;
-                        state->has_continuation =
-                            false; /// Clear continuation flag when closing loop
-                        if (state->compound_command_depth > 0) {
-                            state->compound_command_depth--;
-                        }
-                    } else if (strcmp(word, "esac") == 0) {
-                        state->in_case_statement = false;
-                        state->has_continuation =
-                            false; /// Clear continuation flag when closing case
-                        if (state->compound_command_depth > 0) {
-                            state->compound_command_depth--;
-                        }
-                    } else if (strcmp(word, "}") == 0) {
-                        if (state->compound_command_depth > 0) {
-                            state->compound_command_depth--;
-                        }
-                        if (state->compound_command_depth == 0) {
-                            state->in_function_definition = false;
-                        }
-                    }
-                }
-
-                word_pos = 0;
-                memset(word, 0, sizeof(word));
-            }
-        }
-
-        /// Check for line continuation
-        if (c == '\\' && *(p + 1) == '\0') {
-            state->has_continuation = true;
-        }
-
-        p++;
-    }
-
-    /// Handle remaining word
-    /// Trailing logical/pipe operator forces line continuation. A line
-    /// ending in `&&`, `||`, or `|` (after trailing whitespace, with the
-    /// operator not inside quotes) has its statement obviously not
-    /// complete -- the next command appears on the following line. Bash
-    /// and zsh both keep reading; without this check, lush treats the
-    /// line as one statement and the parser sees the operator with
-    /// nothing on its right.
-    if (!state->in_single_quote && !state->in_double_quote &&
-        !state->in_backtick && !state->in_here_doc) {
-        const char *trim_end = line + strlen(line);
-        while (trim_end > line &&
-               (*(trim_end - 1) == ' ' || *(trim_end - 1) == '\t')) {
-            trim_end--;
-        }
-        size_t trim_len = (size_t)(trim_end - line);
-        if (trim_len >= 2 && ((trim_end[-2] == '&' && trim_end[-1] == '&') ||
-                              (trim_end[-2] == '|' && trim_end[-1] == '|'))) {
-            state->has_continuation = true;
-        } else if (trim_len >= 1 && trim_end[-1] == '|' &&
-                   (trim_len < 2 || trim_end[-2] != '|')) {
-            /// Bare `|` at end of line (not part of `||`); pipeline
-            /// continues on next line.
-            state->has_continuation = true;
-        }
-    }
-
-    /// Check final word at end of line if any
-    if (word_pos > 0) {
-        word[word_pos] = '\0';
-
-        if (is_control_keyword(word)) {
-            /// Handle keywords found at end of line
-            if (strcmp(word, "then") == 0 || strcmp(word, "do") == 0) {
-                state->has_continuation = true;
-            } else if (strcmp(word, "done") == 0) {
-                state->in_while_loop = false;
-                state->in_for_loop = false;
-                state->in_until_loop = false;
-                state->has_continuation =
-                    false; /// Clear continuation flag when closing loop
-                if (state->compound_command_depth > 0) {
-                    state->compound_command_depth--;
-                }
-            } else if (strcmp(word, "esac") == 0) {
-                state->in_case_statement = false;
-                state->has_continuation =
-                    false; /// Clear continuation flag when closing case
-                if (state->compound_command_depth > 0) {
-                    state->compound_command_depth--;
-                }
-            } else if (strcmp(word, "}") == 0) {
-                if (state->compound_command_depth > 0) {
-                    state->compound_command_depth--;
-                }
-                if (state->compound_command_depth == 0) {
-                    state->in_function_definition = false;
-                }
-            } else if (strcmp(word, "fi") == 0) {
-                state->in_if_statement = false;
-                state->has_continuation =
-                    false; /// Clear continuation flag when closing if
-                if (state->compound_command_depth > 0) {
-                    state->compound_command_depth--;
-                }
-            }
-        }
-    }
-}
-
-/**
- * @brief Check if the current input is syntactically complete
- *
- * Examines the input state to determine if all opened constructs
- * (quotes, parentheses, compound commands, etc.) have been closed.
- *
- * @param state The input state to check
- * @return true if input is complete, false if more input is needed
- */
-static bool is_input_complete(input_state_t *state) {
-    if (!state)
-        return true;
-
-    /// Check for unmatched quotes
-    if (state->in_single_quote || state->in_double_quote ||
-        state->in_backtick) {
-        return false;
-    }
-
-    /// Check for unmatched parentheses, braces, brackets
-    if (state->paren_count > 0 || state->brace_count > 0 ||
-        state->bracket_count > 0) {
-        return false;
-    }
-
-    /// Check for incomplete compound commands
-    if (state->compound_command_depth > 0) {
-        return false;
-    }
-
-    /// Check for line continuation
-    if (state->has_continuation) {
-        return false;
-    }
-
-    /// Check for incomplete control structures
-    if (state->in_if_statement || state->in_while_loop || state->in_for_loop ||
-        state->in_until_loop || state->in_case_statement ||
-        state->in_function_definition) {
-        return false;
-    }
-
-    /// Check for here documents
-    if (state->in_here_doc) {
-        return false;
-    }
-
-    return true;
-}
-
-/**
- * @brief Get the appropriate continuation prompt for the current state
- *
- * Returns a context-specific prompt based on what construct is currently
- * being entered (quote, function, if, loop, case, etc.). Falls back to
- * the PS2 environment variable or "> " if not set.
- *
- * @param state The current input state
- * @return Prompt string to display
- */
-static const char *get_continuation_prompt(input_state_t *state) {
+/// Return the prompt string for a partially-read multiline construct.
+/// Inspects the shared continuation_state_t to choose between
+/// "quote>", "function>", "if>", "loop>", "case>", or the user's PS2
+/// for the generic continuation case. Static because only the
+/// LLE-driven readline path consults it; everything else asks the
+/// shared API directly.
+static const char *get_continuation_prompt(const continuation_state_t *state) {
     if (!state)
         return "> ";
 
-    /// Use PS2 from symbol table, with fallback
     const char *ps2 = symtable_get_global_default("PS2", "> ");
 
-    /// Could customize based on state if desired
     if (state->in_single_quote || state->in_double_quote) {
         return "quote> ";
     } else if (state->in_function_definition) {
@@ -717,41 +108,6 @@ const char *lush_get_current_continuation_prompt(void) {
     return get_continuation_prompt(&global_state);
 }
 
-/**
- * @brief Convert multiline input to single line for history storage
- *
- * Replaces newline characters with spaces to create a single-line
- * representation suitable for storing in command history.
- *
- * @param input The multiline input string
- * @return Allocated single-line string, or NULL on failure
- */
-MAYBE_UNUSED
-static char *convert_multiline_for_history(const char *input) {
-    if (!input)
-        return NULL;
-
-    size_t len = strlen(input);
-    char *converted = malloc(len + 1);
-    if (!converted)
-        return NULL;
-
-    char *dst = converted;
-    const char *src = input;
-
-    while (*src) {
-        if (*src == '\n') {
-            *dst++ = ' ';
-        } else {
-            *dst++ = *src;
-        }
-        src++;
-    }
-
-    *dst = '\0';
-    return converted;
-}
-
 /// ============================================================================
 /// PUBLIC INPUT FUNCTIONS
 /// ============================================================================
@@ -763,7 +119,7 @@ static char *convert_multiline_for_history(const char *input) {
  * Should be called when input processing is complete or on error cleanup.
  */
 void free_input_buffers(void) {
-    cleanup_input_state(&global_state);
+    continuation_state_cleanup(&global_state);
     state_initialized = false;
 }
 
@@ -800,61 +156,6 @@ char *get_input(FILE *in) {
 }
 
 /**
- * @brief Check if current state requires additional input lines
- *
- * Determines if the input state indicates an incomplete construct
- * that requires continuation input (open quotes, compound commands,
- * here documents, unmatched brackets, etc.).
- *
- * @param state Pointer to the input state to check
- * @return true if more input is needed, false if complete
- */
-static bool needs_continuation(input_state_t *state) {
-    if (!state)
-        return false;
-
-    /// Need continuation if we're in any compound structure
-    if (state->compound_command_depth > 0) {
-        return true;
-    }
-
-    /// Need continuation if we're in any specific construct
-    if (state->in_function_definition || state->in_case_statement ||
-        state->in_if_statement || state->in_while_loop || state->in_for_loop ||
-        state->in_until_loop) {
-        return true;
-    }
-
-    /// POSIX function header `name()` seen but body brace not yet opened.
-    /// The function body may start on a following line; keep reading
-    /// until the `{` arrives (analyze_line clears this flag when it does).
-    /// Without this, `name()\n{ body }` is split into two statements and
-    /// the parser sees `name()` followed by EOF.
-    if (state->saw_posix_func_parens) {
-        return true;
-    }
-
-    /// Need continuation if we have pending quotes or escapes
-    if (state->in_single_quote || state->in_double_quote || state->escaped ||
-        state->has_continuation) {
-        return true;
-    }
-
-    /// Need continuation if we're in a here document
-    if (state->in_here_doc) {
-        return true;
-    }
-
-    /// Need continuation if we have unmatched brackets
-    if (state->paren_count > 0 || state->bracket_count > 0 ||
-        state->brace_count > 0) {
-        return true;
-    }
-
-    return false;
-}
-
-/**
  * @brief Read a complete command from interactive input
  *
  * Reads input lines using GNU readline until a syntactically complete
@@ -871,7 +172,7 @@ char *ln_gets(void) {
 
     /// Initialize state if needed
     if (!state_initialized) {
-        init_input_state(&global_state);
+        continuation_state_init(&global_state);
         state_initialized = true;
     }
 
@@ -911,14 +212,14 @@ char *ln_gets(void) {
                 accumulated_input = NULL;
                 accumulated_size = 0;
                 accumulated_capacity = 0;
-                init_input_state(&global_state);
+                continuation_state_init(&global_state);
                 return result;
             }
             return NULL;
         }
 
         /// Analyze this line to update state
-        analyze_line(line, &global_state);
+        continuation_analyze_line(line, &global_state);
 
         /// Handle accumulation
         size_t line_len = strlen(line);
@@ -962,15 +263,15 @@ char *ln_gets(void) {
         line = NULL;
 
         /// Check if input is complete
-        if (is_input_complete(&global_state)) {
+        if (continuation_is_complete(&global_state)) {
             char *result = accumulated_input;
             accumulated_input = NULL;
             accumulated_size = 0;
             accumulated_capacity = 0;
 
             /// Reset state for next input
-            cleanup_input_state(&global_state);
-            init_input_state(&global_state);
+            continuation_state_cleanup(&global_state);
+            continuation_state_init(&global_state);
 
             /// Note: History is handled by readline system automatically
             return result;
@@ -1005,7 +306,8 @@ char *get_input_complete_counted(FILE *in, size_t *lines_consumed) {
 
     char *accumulated = NULL;
     size_t accumulated_len = 0;
-    input_state_t state = {0};
+    continuation_state_t state = {0};
+    continuation_state_init(&state);
     /// Count of source lines this batch consumed. Includes lines joined
     /// via backslash continuation since they still advance the file's
     /// cumulative line counter even though they don't appear as
@@ -1031,7 +333,7 @@ char *get_input_complete_counted(FILE *in, size_t *lines_consumed) {
         }
 
         /// Analyze this line to update state
-        analyze_line(line, &state);
+        continuation_analyze_line(line, &state);
 
         /// Check if previous line had backslash continuation
         /// If so, we need to join lines without newline and remove the
@@ -1050,6 +352,7 @@ char *get_input_complete_counted(FILE *in, size_t *lines_consumed) {
                 malloc(read + 2); /// +2 for newline and null terminator
             if (!accumulated) {
                 free(line);
+                continuation_state_cleanup(&state);
                 return NULL;
             }
             strcpy(accumulated, line);
@@ -1061,6 +364,7 @@ char *get_input_complete_counted(FILE *in, size_t *lines_consumed) {
             if (!new_accumulated) {
                 free(accumulated);
                 free(line);
+                continuation_state_cleanup(&state);
                 return NULL;
             }
             accumulated = new_accumulated;
@@ -1075,7 +379,7 @@ char *get_input_complete_counted(FILE *in, size_t *lines_consumed) {
         }
 
         /// Check if we have a complete construct
-        if (!needs_continuation(&state)) {
+        if (!continuation_needs_continuation(&state)) {
             break;
         }
     }
@@ -1083,7 +387,7 @@ char *get_input_complete_counted(FILE *in, size_t *lines_consumed) {
     /// If we reach EOF while waiting for continuation, handle gracefully
     /// This prevents hanging on malformed input while preserving legitimate
     /// multiline support
-    if (accumulated != NULL && needs_continuation(&state)) {
+    if (accumulated != NULL && continuation_needs_continuation(&state)) {
         /// We have partial input that needs continuation but hit EOF
         /// Check what type of continuation we're waiting for
         if (state.in_single_quote || state.in_double_quote) {
@@ -1091,11 +395,19 @@ char *get_input_complete_counted(FILE *in, size_t *lines_consumed) {
             /// errors Don't wait indefinitely - return to parser for error
             /// handling
             free(line);
+            if (lines_consumed) {
+                *lines_consumed = source_lines;
+            }
+            continuation_state_cleanup(&state);
             return accumulated;
         } else if (!state.in_here_doc) {
             /// Other non-here-document continuations should also be handled as
             /// syntax errors on EOF
             free(line);
+            if (lines_consumed) {
+                *lines_consumed = source_lines;
+            }
+            continuation_state_cleanup(&state);
             return accumulated;
         }
         /// For here documents, continue normal processing (this is expected
@@ -1106,6 +418,7 @@ char *get_input_complete_counted(FILE *in, size_t *lines_consumed) {
     if (lines_consumed) {
         *lines_consumed = source_lines;
     }
+    continuation_state_cleanup(&state);
     return accumulated;
 }
 

--- a/src/input_continuation.c
+++ b/src/input_continuation.c
@@ -625,15 +625,37 @@ void continuation_analyze_line(const char *line, continuation_state_t *state) {
         state->escaped = false; /// Reset for next line
     }
 
-    /// Check if line ends with pipe character (requires continuation)
-    /// Need to check backwards from end, skipping whitespace
-    const char *end = line + strlen(line);
-    while (end > line && isspace(*(end - 1))) {
-        end--;
-    }
-    if (end > line && *(end - 1) == '|') {
-        /// Line ends with pipe - needs continuation
-        state->has_continuation = true;
+    /// Trailing logical/pipe operator forces line continuation. A line
+    /// ending in `&&`, `||`, or a bare `|` (after trailing whitespace,
+    /// with the operator not inside quotes) has its statement
+    /// obviously not complete -- the next command appears on the
+    /// following line. Bash and zsh both keep reading; without this
+    /// check, an `&&`-at-EOL is treated as one statement and the
+    /// parser sees the operator with nothing on its right.
+    ///
+    /// The local analyzer in src/input.c already does this for the
+    /// file/stdin reader path; this shared analyzer is used by the
+    /// executor's per-batch splitter (issue #151) and by the LLE
+    /// interactive multi-line driver. The two analyzers should
+    /// eventually collapse onto a single canonical implementation
+    /// (tracked: duplicate-path audit).
+    if (!state->in_single_quote && !state->in_double_quote &&
+        !state->in_backtick && !state->in_here_doc) {
+        const char *trim_end = line + strlen(line);
+        while (trim_end > line &&
+               (*(trim_end - 1) == ' ' || *(trim_end - 1) == '\t')) {
+            trim_end--;
+        }
+        size_t trim_len = (size_t)(trim_end - line);
+        if (trim_len >= 2 && ((trim_end[-2] == '&' && trim_end[-1] == '&') ||
+                              (trim_end[-2] == '|' && trim_end[-1] == '|'))) {
+            state->has_continuation = true;
+        } else if (trim_len >= 1 && trim_end[-1] == '|' &&
+                   (trim_len < 2 || trim_end[-2] != '|')) {
+            /// Bare `|` at end of line (not part of `||`); pipeline
+            /// continues on next line.
+            state->has_continuation = true;
+        }
     }
 
     /// Handle remaining word at end of line
@@ -729,6 +751,17 @@ bool continuation_is_complete(const continuation_state_t *state) {
 
     /// Check for here documents
     if (state->in_here_doc) {
+        return false;
+    }
+
+    /// POSIX function header `name()` seen but body brace not yet
+    /// opened. The function body may start on a following line; keep
+    /// reading until the `{` arrives (analyze_line clears this flag
+    /// when it does). Without this, `name()\n{ body }` is split into
+    /// two statements and the parser sees `name()` followed by EOF.
+    /// Ported from input.c's local needs_continuation as part of the
+    /// dual-analyzer unification.
+    if (state->saw_posix_func_parens) {
         return false;
     }
 

--- a/src/lush.c
+++ b/src/lush.c
@@ -361,6 +361,20 @@ int main(int argc, char **argv) {
             exit_flag = true;
         }
 
+        /// `set -e` (errexit) across batches: the executor's per-batch
+        /// driver already honors exit_on_error inside a single batch
+        /// (execute_command_chain returns early on non-zero, respecting
+        /// all bash exemption rules). When that non-zero result reaches
+        /// the read loop, errexit also has to STOP reading further
+        /// script lines -- otherwise a non-interactive script keeps
+        /// running after the failing command, diverging from bash. The
+        /// interactive shell deliberately ignores errexit at this layer
+        /// so a failed prompt command doesn't kill the session.
+        if (shell_opts.exit_on_error && last_exit_status != 0 &&
+            !is_interactive_shell()) {
+            exit_flag = true;
+        }
+
         /// Advance cumulative line counter by the number of source
         /// lines consumed by this batch. Interactive mode skips this
         /// since the counter stays at 1.

--- a/tests/unit/test_executor.c
+++ b/tests/unit/test_executor.c
@@ -573,6 +573,62 @@ TEST(rt_case_extglob_alternation) {
     ASSERT_STDOUT_EQ(r, "pet:cat\npet:dog\nword:bird\n");
 }
 
+TEST(rt_bash_shopt_extglob_takes_effect_next_batch) {
+    /// Issue #151: bash-mode `shopt -s extglob` on its own line must
+    /// flip FEATURE_EXTENDED_GLOB before the next batch is tokenized,
+    /// so an extglob shape in a following case statement parses
+    /// instead of erroring at the tokenizer. Drives the per-batch
+    /// driver in executor_execute_command_line: each top-level
+    /// statement runs to completion (executing any feature flips)
+    /// before the next is parsed, matching bash's parse-then-execute
+    /// model line by line.
+    ///
+    /// The same-line form (`shopt -s extglob; case ... esac` on one
+    /// line) intentionally still errors -- bash itself errors there
+    /// too, since the shopt hasn't run by the time the case is
+    /// tokenized. Mode-accurate defaults stay intact.
+    run_result_t r = run_shell("mode bash\n"
+                               "shopt -s extglob\n"
+                               "case cat in @(cat|dog)) echo pet;; esac\n");
+    run_shell("mode lush\n");
+    ASSERT_STDOUT_EQ(r, "pet\n");
+}
+
+TEST(rt_set_e_aborts_remaining_batches) {
+    /// `set -e` must abort subsequent batches in a non-interactive
+    /// shell, matching bash. The per-batch driver respects errexit
+    /// across batch boundaries -- a failing batch returns non-zero
+    /// to the loop and the loop stops feeding more lines. Without
+    /// this, multi-line scripts kept running past failing commands.
+    run_result_t r = run_shell("set -e\n"
+                               "false\n"
+                               "echo should-not-print\n");
+    ASSERT_EXIT_STATUS(r, 1);
+    ASSERT_STDOUT_EQ(r, "");
+    /// Harness shares shell_opts globally across run_shell calls
+    /// (see project-shell-harness-global-state); clear errexit so
+    /// subsequent tests don't observe it.
+    run_shell("set +e\n");
+}
+
+TEST(rt_err_trap_fires_across_batch_boundaries) {
+    /// The ERR trap must fire when a command in a later batch returns
+    /// non-zero. Previously the trap-firing logic lived only inside
+    /// the command-list walker; a single-command AST (each batch in
+    /// the per-batch driver) bypassed it. Routing executor_execute
+    /// through the command chain unconditionally fixed this.
+    executor_t *exec = executor_new();
+    ASSERT_NOT_NULL(exec, "executor_new failed");
+    run_result_t r =
+        run_shell_with_executor(exec, "trap 'echo TRAP_FIRED' ERR\n"
+                                      "false\n"
+                                      "echo continuing\n"
+                                      "trap - ERR\n");
+    ASSERT_STDOUT_CONTAINS(r, "TRAP_FIRED");
+    ASSERT_STDOUT_CONTAINS(r, "continuing");
+    executor_free(exec);
+}
+
 TEST(rt_case_plain_alternation_unregressed) {
     /// The paren/bracket-aware separator must still split ordinary
     /// top-level `|` alternation, including an empty alternative.
@@ -4465,6 +4521,9 @@ int main(void) {
     RUN_TEST(case_wildcard);
     RUN_TEST(case_posix_character_class);
     RUN_TEST(rt_case_extglob_alternation);
+    RUN_TEST(rt_bash_shopt_extglob_takes_effect_next_batch);
+    RUN_TEST(rt_set_e_aborts_remaining_batches);
+    RUN_TEST(rt_err_trap_fires_across_batch_boundaries);
     RUN_TEST(rt_case_plain_alternation_unregressed);
     RUN_TEST(trap_err_fires_on_nonzero_exit);
     RUN_TEST(trap_err_silent_on_zero_exit);


### PR DESCRIPTION
## Summary
Three coupled architectural fixes converge on closing #151:

1. **Per-batch driver in `executor_execute_command_line`.** Reuses the shared `continuation_analyze_line` + `continuation_needs_continuation` API to walk the input string into syntactically-complete batches. Each batch parses and executes before the next is tokenized, so `shopt -s extglob` flips `FEATURE_EXTENDED_GLOB` before the next batch's case-line is tokenized. Mode-accurate: same-line `shopt -s extglob; case ... esac` still errors exactly as bash does. Set -e + `shell_exit_requested` are honored across batch boundaries; `lush.c`'s main loop gets the parallel set -e check for the file/stdin reader path.

2. **Single canonical multiline analyzer.** `src/input.c` carried a parallel `input_state_t` + private `analyze_line`/`is_input_complete` that had drifted ~200 lines from the shared `src/input_continuation.c` (missing the herestring `<<<` guard, missing `&&`/`||` continuation, missing the context stack). The duplicate is retired; `src/input.c` now only carries reader plumbing (getline loop, accumulator, prompt selection) and dispatches state work to the shared API. `saw_posix_func_parens` ported to `continuation_is_complete`. Net diff: **-408 lines**, one canonical way to ask "is this multiline input complete?".

3. **`executor_execute` always routes through `execute_command_list`.** The historical single-command shortcut bypassed the post-command bookkeeping the chain walker runs (ERR-trap firing on non-zero, errexit, `shell_exit_requested`). The chain walker already handles a 1-node chain; collapsing onto it removes the divergence between the "single" and "list" paths and fixes a long-standing ERR-trap miss in file-script execution.

## Test plan
- [x] Full local suite: 114/114 green
- [x] Real-world scorecard: 100%
- [x] werror-clean build
- [x] Three new regression tests (`rt_bash_shopt_extglob_takes_effect_next_batch`, `rt_set_e_aborts_remaining_batches`, `rt_err_trap_fires_across_batch_boundaries`)
- [x] Verified scenarios: multi-line and one-line `-c`, file scripts, `eval`, herestring `<<<`, quoted/unquoted heredocs spanning lines, `name()` + `{...}` on separate lines, `for/done`, trailing `&&` / `|` / `\`-newline continuations

Fixes #151.