### PR TITLE
tests/integration: login-shell viability L8-L11 (PTY where required)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2545,3 +2545,77 @@ if fs.exists('tests/integration/test_env_sourcing.sh')
        suite: 'integration',
        timeout: 30)
 endif
+
+# Login-shell startup-file chain ordering (#L8).
+# Bash-style: spawns lush with controlled $HOME, asserts markers
+# appear in stdout in the canonical order. No PTY needed -- file
+# sourcing order is determined inside the shell process and does
+# not depend on controlling-terminal semantics.
+if fs.exists('tests/integration/test_login_init_chain.sh')
+  test('login startup-file chain',
+       find_program('tests/integration/test_login_init_chain.sh'),
+       args: [lush_exe.full_path()],
+       suite: 'integration',
+       timeout: 30)
+endif
+
+# Non-login interactive startup-file chain (#L9).
+# Verifies that an interactive non-login shell sources ~/.lushrc
+# only, NOT ~/.profile or ~/.lush_login. The POSIX $ENV side is
+# already covered by test_env_sourcing.sh.
+if fs.exists('tests/integration/test_nonlogin_init.sh')
+  test('non-login startup chain',
+       find_program('tests/integration/test_nonlogin_init.sh'),
+       args: [lush_exe.full_path()],
+       suite: 'integration',
+       timeout: 30)
+endif
+
+# Logout-script firing on explicit `exit` / `logout` (#L11 explicit).
+# Bash-style: lush -l -i with stdin pipe. The SIGHUP-induced variant
+# of this test is below as a PTY-required C test program.
+if fs.exists('tests/integration/test_logout_explicit.sh')
+  test('logout script (explicit exit)',
+       find_program('tests/integration/test_logout_explicit.sh'),
+       args: [lush_exe.full_path()],
+       suite: 'integration',
+       timeout: 30)
+endif
+
+# PTY-based tests follow the zsh Test/W02jobs.ztst model: any test
+# whose subject is defined by terminal semantics (SIGHUP delivery on
+# controlling-terminal hangup, SIGHUP cascade to the foreground
+# process group) requires a real PTY. forkpty(3) is BSD-derived but
+# available on macOS, Linux glibc, and the BSDs.
+#
+# macOS exposes forkpty via <util.h>; Linux glibc via <pty.h>; both
+# require linking against libutil on most BSDs and on Linux glibc.
+host_os = host_machine.system()
+if host_os == 'linux' or host_os == 'darwin' or host_os == 'freebsd' or host_os == 'openbsd' or host_os == 'netbsd'
+  cc = meson.get_compiler('c')
+  libutil_dep = cc.find_library('util', required: false)
+
+  # L10: SIGHUP cascade to background jobs at login-shell exit.
+  if fs.exists('tests/integration/test_pty_sighup_cascade.c')
+    test_pty_cascade = executable('test_pty_sighup_cascade',
+                                  ['tests/integration/test_pty_sighup_cascade.c'],
+                                  dependencies: libutil_dep)
+    test('PTY SIGHUP cascade to bg jobs',
+         test_pty_cascade,
+         args: [lush_exe.full_path()],
+         suite: 'integration',
+         timeout: 30)
+  endif
+
+  # L11 (SIGHUP variant): logout script fires on SIGHUP-induced exit.
+  if fs.exists('tests/integration/test_pty_sighup_logout.c')
+    test_pty_logout = executable('test_pty_sighup_logout',
+                                 ['tests/integration/test_pty_sighup_logout.c'],
+                                 dependencies: libutil_dep)
+    test('PTY logout script on SIGHUP',
+         test_pty_logout,
+         args: [lush_exe.full_path()],
+         suite: 'integration',
+         timeout: 30)
+  endif
+endif

--- a/tests/integration/pty_helpers.h
+++ b/tests/integration/pty_helpers.h
@@ -1,0 +1,426 @@
+/**
+ * @file pty_helpers.h
+ * @brief Shared PTY-harness primitives for terminal-required login tests.
+ *
+ * Provides the minimum infrastructure needed to spawn lush on the
+ * slave end of a pseudo-terminal, drive it from the master end, and
+ * inspect outputs / signal behavior from the parent.
+ *
+ * This is the same approach the zsh test suite takes (Test/W02jobs.ztst
+ * uses the zsh/zpty module, which is a forkpty(3) wrapper) for any
+ * test whose subject is *defined by* terminal semantics: SIGHUP
+ * delivery on controlling-terminal hangup, SIGTTIN/SIGTTOU, job
+ * control on the foreground process group. Bash's upstream tests do
+ * NOT cover those cases; lush is following zsh's lead here.
+ *
+ * Header-only and pulled into each test file that needs it.
+ */
+
+#ifndef PTY_HELPERS_H
+#define PTY_HELPERS_H
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/select.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) ||      \
+    defined(__NetBSD__)
+#include <util.h>
+#elif defined(__linux__)
+#include <pty.h>
+#else
+#error "PTY harness requires a platform that exposes forkpty(3)"
+#endif
+
+/// Maximum bytes of PTY output the harness buffers from a single run.
+/// Test scenarios should fit comfortably; if not the test is doing too
+/// much.
+#define PTY_BUF_SIZE 65536
+
+typedef struct pty_session {
+    pid_t pid;       ///< Child shell PID
+    int master_fd;   ///< Parent end of the pseudo-terminal (child's
+                     ///< stdout/stderr)
+    int stdin_fd;    ///< Parent end of the stdin pipe to the child
+    char *home_dir;  ///< Owned; mktemp'd; caller frees via pty_cleanup
+    char *output;    ///< Owned; accumulated stdout/stderr from master FD
+    size_t out_len;  ///< Bytes consumed in `output`
+    size_t out_cap;  ///< Allocated size of `output`
+    int exit_status; ///< waitpid status (set by pty_wait)
+    bool reaped;     ///< true once waitpid returned
+} pty_session_t;
+
+/// Fail-printing helper. Test programs use this to surface assertion
+/// failures uniformly on stderr.
+static inline void pty_fail(const char *test_name, const char *fmt, ...) {
+    va_list ap;
+    fprintf(stderr, "%s: FAIL: ", test_name);
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fprintf(stderr, "\n");
+}
+
+/// Pass-printing helper.
+static inline void pty_ok(const char *test_name, const char *msg) {
+    fprintf(stdout, "%s: OK: %s\n", test_name, msg);
+}
+
+/// Sleep for `ms` milliseconds. POSIX nanosleep wrapper that retries
+/// on EINTR; this is the only signal that should reach us during a
+/// PTY test and we want the delay to be honored despite it.
+static inline void pty_sleep_ms(int ms) {
+    struct timespec ts = {.tv_sec = ms / 1000,
+                          .tv_nsec = (long)(ms % 1000) * 1000000L};
+    while (nanosleep(&ts, &ts) == -1 && errno == EINTR) {
+        ;
+    }
+}
+
+/// Make a fresh empty temp directory the caller owns (freed via
+/// pty_cleanup). Returns NULL on failure with errno set.
+static inline char *pty_make_tmpdir(void) {
+    const char *base = getenv("TMPDIR");
+    if (!base || !*base) {
+        base = "/tmp";
+    }
+    size_t n = strlen(base) + strlen("/lush_pty.XXXXXX") + 1;
+    char *path = (char *)malloc(n);
+    if (!path) {
+        return NULL;
+    }
+    snprintf(path, n, "%s/lush_pty.XXXXXX", base);
+    if (!mkdtemp(path)) {
+        free(path);
+        return NULL;
+    }
+    return path;
+}
+
+/// rm -rf equivalent for a directory the harness created. Best-effort;
+/// failures are logged to stderr but don't abort.
+static inline void pty_rmrf(const char *path) {
+    if (!path) {
+        return;
+    }
+    /// Fork+exec rm -rf -- simpler and safer than rolling our own
+    /// recursive walk for a test harness.
+    pid_t p = fork();
+    if (p == 0) {
+        execlp("rm", "rm", "-rf", path, (char *)NULL);
+        _exit(127);
+    } else if (p > 0) {
+        int st;
+        waitpid(p, &st, 0);
+    }
+}
+
+/// Write a marker echo line to a file. Used to seed startup files
+/// (~/.lush_login, ~/.lush_logout, etc.).
+static inline int pty_write_marker(const char *path, const char *marker) {
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        return -1;
+    }
+    fprintf(f, "echo \"%s\"\n", marker);
+    fclose(f);
+    return 0;
+}
+
+/// Spawn lush with a hybrid stdio layout:
+///   - stdin  = pipe (NOT a TTY -- avoids LLE raw mode, gives line-
+///              mode getline reads on the lush side)
+///   - stdout = PTY slave (TTY -- preserves controlling-terminal
+///              semantics required for SIGHUP delivery, tcsetpgrp,
+///              job control)
+///   - stderr = PTY slave
+///   - PTY slave is the child's controlling terminal (TIOCSCTTY)
+///
+/// This split is the canonical recipe for testing terminal-dependent
+/// shell behavior without engaging the shell's interactive line
+/// editor. zsh achieves the same effect via `-fiV +Z` (where -V
+/// disables zle); lush has no equivalent flag yet, so we instead
+/// rely on lle_readline.c's existing isatty(STDIN_FILENO) fallback
+/// (returns simple getline output for non-TTY stdin even under -i).
+///
+/// argv must be a NULL-terminated list (first element conventionally
+/// "lush"). The child inherits a minimal env: HOME=session->home_dir,
+/// PATH (from parent), TERM=dumb.
+static inline int pty_spawn(pty_session_t *session, const char *lush_path,
+                            const char *const argv[]) {
+    memset(session, 0, sizeof(*session));
+    session->home_dir = pty_make_tmpdir();
+    if (!session->home_dir) {
+        perror("pty_spawn: mkdtemp");
+        return -1;
+    }
+
+    session->output = (char *)calloc(1, PTY_BUF_SIZE);
+    if (!session->output) {
+        pty_rmrf(session->home_dir);
+        free(session->home_dir);
+        return -1;
+    }
+    session->out_cap = PTY_BUF_SIZE;
+
+    /// stdin pipe (parent writes to [1], child reads from [0]).
+    int in_pipe[2];
+    if (pipe(in_pipe) != 0) {
+        perror("pty_spawn: pipe");
+        free(session->output);
+        pty_rmrf(session->home_dir);
+        free(session->home_dir);
+        return -1;
+    }
+
+    /// PTY pair for stdout/stderr.
+    int master, slave;
+    if (openpty(&master, &slave, NULL, NULL, NULL) != 0) {
+        perror("pty_spawn: openpty");
+        close(in_pipe[0]);
+        close(in_pipe[1]);
+        free(session->output);
+        pty_rmrf(session->home_dir);
+        free(session->home_dir);
+        return -1;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("pty_spawn: fork");
+        close(in_pipe[0]);
+        close(in_pipe[1]);
+        close(master);
+        close(slave);
+        free(session->output);
+        pty_rmrf(session->home_dir);
+        free(session->home_dir);
+        return -1;
+    }
+
+    if (pid == 0) {
+        /// Child: become session leader so we can acquire a
+        /// controlling terminal.
+        setsid();
+
+        /// Make the PTY slave our controlling terminal. On macOS
+        /// and BSDs, opening the slave again after setsid() acquires
+        /// it; on Linux, TIOCSCTTY is the explicit ioctl. Use both
+        /// patterns for cross-platform safety.
+#ifdef TIOCSCTTY
+        ioctl(slave, TIOCSCTTY, 0);
+#endif
+
+        /// Wire stdio: stdin <- pipe read end, stdout/stderr <-
+        /// PTY slave.
+        dup2(in_pipe[0], STDIN_FILENO);
+        dup2(slave, STDOUT_FILENO);
+        dup2(slave, STDERR_FILENO);
+
+        /// Close everything we don't need.
+        if (in_pipe[0] > STDERR_FILENO) {
+            close(in_pipe[0]);
+        }
+        close(in_pipe[1]);
+        if (slave > STDERR_FILENO) {
+            close(slave);
+        }
+        close(master);
+
+        /// Build a minimal envp so the test doesn't inherit user
+        /// state. execve is the portable env-replacement path
+        /// (clearenv is GNU-only).
+        const char *parent_path = getenv("PATH");
+        char home_buf[1024];
+        char path_buf[2048];
+        char term_buf[] = "TERM=dumb";
+        snprintf(home_buf, sizeof(home_buf), "HOME=%s", session->home_dir);
+        snprintf(path_buf, sizeof(path_buf), "PATH=%s",
+                 parent_path ? parent_path : "/usr/bin:/bin");
+        char *envp[] = {home_buf, path_buf, term_buf, NULL};
+        execve(lush_path, (char *const *)argv, envp);
+        perror("pty_spawn: execve");
+        _exit(127);
+    }
+
+    /// Parent: keep the master + stdin-write ends. Drop the slave +
+    /// stdin-read ends so the child's hangup detection works
+    /// (master close → SIGHUP on slave).
+    close(in_pipe[0]);
+    close(slave);
+
+    session->pid = pid;
+    session->master_fd = master;
+    session->stdin_fd = in_pipe[1];
+    return 0;
+}
+
+/// Write a NUL-terminated string to the child's stdin (the pipe end).
+/// Returns 0 on success or -1 with errno set.
+static inline int pty_send(pty_session_t *session, const char *s) {
+    size_t len = strlen(s);
+    const char *p = s;
+    while (len > 0) {
+        ssize_t n = write(session->stdin_fd, p, len);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        p += n;
+        len -= (size_t)n;
+    }
+    return 0;
+}
+
+/// Drain whatever the master FD has available right now, with a
+/// timeout. Appends to session->output until the FD blocks for
+/// `timeout_ms` or the child exits (read returns 0). Always safe to
+/// call multiple times.
+static inline void pty_drain(pty_session_t *session, int timeout_ms) {
+    while (session->out_len + 1 < session->out_cap) {
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        FD_SET(session->master_fd, &rfds);
+        struct timeval tv = {.tv_sec = timeout_ms / 1000,
+                             .tv_usec = (timeout_ms % 1000) * 1000};
+        int r = select(session->master_fd + 1, &rfds, NULL, NULL, &tv);
+        if (r < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return;
+        }
+        if (r == 0) {
+            return; /// Timed out
+        }
+        ssize_t n = read(session->master_fd, session->output + session->out_len,
+                         session->out_cap - session->out_len - 1);
+        if (n <= 0) {
+            return; /// Slave closed or read error
+        }
+        session->out_len += (size_t)n;
+        session->output[session->out_len] = '\0';
+    }
+}
+
+/// Wait for the child to exit. Returns waitpid status (also stashed
+/// in session->exit_status). Does NOT close master_fd -- caller may
+/// want to drain remaining output first.
+static inline int pty_wait(pty_session_t *session, int timeout_ms) {
+    /// Poll-with-timeout: waitpid(WNOHANG) loop with small sleeps.
+    int elapsed = 0;
+    while (elapsed < timeout_ms) {
+        int st;
+        pid_t r = waitpid(session->pid, &st, WNOHANG);
+        if (r == session->pid) {
+            session->exit_status = st;
+            session->reaped = true;
+            return st;
+        }
+        if (r < 0 && errno == ECHILD) {
+            /// Already reaped (shouldn't happen).
+            session->reaped = true;
+            return 0;
+        }
+        pty_sleep_ms(50);
+        elapsed += 50;
+    }
+    /// Timed out: hard-kill so the test doesn't hang the suite.
+    kill(session->pid, SIGKILL);
+    int st;
+    waitpid(session->pid, &st, 0);
+    session->exit_status = st;
+    session->reaped = true;
+    return st;
+}
+
+/// Send SIGHUP to the child shell, drain any final output, wait for
+/// exit. Convenience for the hangup-simulated-via-signal pattern
+/// (closing the master FD is the alternative but is messier --
+/// in-flight writes from the child get SIGPIPE'd, output is lost).
+static inline int pty_sighup_and_wait(pty_session_t *session, int drain_ms,
+                                      int exit_ms) {
+    if (kill(session->pid, SIGHUP) != 0) {
+        if (errno != ESRCH) {
+            perror("pty_sighup_and_wait: kill");
+        }
+    }
+    pty_drain(session, drain_ms);
+    return pty_wait(session, exit_ms);
+}
+
+/// Close the parent's end of the child's stdin. This delivers EOF to
+/// the child, which will cause its read loop to terminate and run
+/// through the clean exit path (including login-shell logout
+/// scripts). Idempotent.
+static inline void pty_close_stdin(pty_session_t *session) {
+    if (session && session->stdin_fd >= 0) {
+        close(session->stdin_fd);
+        session->stdin_fd = -1;
+    }
+}
+
+/// Release session resources. Safe to call regardless of how the
+/// session ended.
+static inline void pty_cleanup(pty_session_t *session) {
+    if (!session) {
+        return;
+    }
+    if (session->stdin_fd >= 0) {
+        close(session->stdin_fd);
+        session->stdin_fd = -1;
+    }
+    if (session->master_fd >= 0) {
+        close(session->master_fd);
+        session->master_fd = -1;
+    }
+    if (session->pid > 0 && !session->reaped) {
+        kill(session->pid, SIGKILL);
+        int st;
+        waitpid(session->pid, &st, 0);
+    }
+    free(session->output);
+    session->output = NULL;
+    pty_rmrf(session->home_dir);
+    free(session->home_dir);
+    session->home_dir = NULL;
+}
+
+/// Read a long-decimal value following a marker `<prefix><digits>` in
+/// the accumulated output. Returns -1 if not found.
+static inline long pty_extract_long_after(const pty_session_t *session,
+                                          const char *prefix) {
+    if (!session->output) {
+        return -1;
+    }
+    const char *p = strstr(session->output, prefix);
+    if (!p) {
+        return -1;
+    }
+    p += strlen(prefix);
+    char *end = NULL;
+    errno = 0;
+    long v = strtol(p, &end, 10);
+    if (end == p || errno != 0) {
+        return -1;
+    }
+    return v;
+}
+
+#endif /// PTY_HELPERS_H

--- a/tests/integration/test_login_init_chain.sh
+++ b/tests/integration/test_login_init_chain.sh
@@ -1,0 +1,159 @@
+#!/bin/sh
+## Integration test for the login-shell startup-file chain (#L8).
+##
+## Verifies that for a login shell (`lush -l`) the four startup files
+## are sourced in the canonical order:
+##
+##   1. /etc/profile + /etc/profile.d/*.sh + /etc/lushrc   (system-wide)
+##   2. ~/.profile                                          (POSIX, in bash mode)
+##   3. ~/.lush_login    or ~/.config/lush/lush_login       (lush-specific)
+##   4. ~/.lushrc        or ~/.config/lush/lushrc           (per-shell startup)
+##
+## The system-wide step (1) is skipped here because writing to /etc/*
+## requires root and is platform-variable; lush's existing manual
+## smoke covers that path. The user-scoped chain (steps 2-4) is what
+## this fixture pins.
+##
+## Approach mirrors bash's `tests/invocation.tests` pattern: spawn the
+## shell with a controlled $HOME, pre-populate each startup file with
+## an `echo MARKER` line, run with `-l -i` and `</dev/null` so the
+## reader sees immediate EOF, and verify the captured stdout shows
+## the markers in the right order. No PTY is needed -- the source
+## ordering is determined entirely inside the shell process.
+##
+## meson passes the lush binary path as $1.
+
+set -e
+
+LUSH="${1:?lush binary path required as first argument}"
+TMPDIR_BASE="${TMPDIR:-/tmp}"
+
+HOME_DIR=$(mktemp -d "$TMPDIR_BASE/lush_login_chain.XXXXXX")
+trap 'rm -rf "$HOME_DIR"' EXIT
+
+fail() {
+    printf '%s: FAIL: %s\n' "$0" "$1" >&2
+    exit 1
+}
+
+ok() {
+    printf '%s: OK: %s\n' "$0" "$1"
+}
+
+## Capture the stdout of a controlled lush -l -i run. ENV is cleared
+## so the existing $ENV-sourcing test is not entangled. PS1/PROMPT
+## variables are also cleared to keep prompt rendering out of the
+## captured stream; lush still writes a styled prompt to stderr in
+## interactive mode, hence the 2>/dev/null on the capture.
+run_login() {
+    env -i HOME="$HOME_DIR" PATH="$PATH" TERM=dumb \
+        "$LUSH" -l -i </dev/null 2>/dev/null
+}
+
+## ---- 1. all four files present, ~/-based paths ------------------------
+
+cat > "$HOME_DIR/.profile" <<'EOF'
+echo "MARK_PROFILE"
+EOF
+cat > "$HOME_DIR/.lush_login" <<'EOF'
+echo "MARK_LUSH_LOGIN"
+EOF
+cat > "$HOME_DIR/.lushrc" <<'EOF'
+echo "MARK_LUSHRC"
+EOF
+
+actual=$(run_login)
+case "$actual" in
+    *MARK_PROFILE*MARK_LUSH_LOGIN*MARK_LUSHRC*)
+        ok "all-four-present: profile -> lush_login -> lushrc"
+        ;;
+    *)
+        fail "ordering wrong or markers missing
+got: $actual" ;;
+esac
+
+## ---- 2. XDG-canonical lush_login wins over ~/.lush_login --------------
+
+mkdir -p "$HOME_DIR/.config/lush"
+cat > "$HOME_DIR/.config/lush/lush_login" <<'EOF'
+echo "MARK_XDG_LUSH_LOGIN"
+EOF
+## Also write the ~/ fallback with a different marker so we can detect
+## if both fired (they shouldn't).
+cat > "$HOME_DIR/.lush_login" <<'EOF'
+echo "MARK_HOME_LUSH_LOGIN"
+EOF
+
+actual=$(run_login)
+case "$actual" in
+    *MARK_XDG_LUSH_LOGIN*)
+        case "$actual" in
+            *MARK_HOME_LUSH_LOGIN*)
+                fail "both XDG and ~/ lush_login fired; XDG should win and ~/ should be skipped
+got: $actual" ;;
+            *)
+                ok "xdg-precedence: XDG lush_login wins, ~/ skipped" ;;
+        esac
+        ;;
+    *)
+        fail "XDG lush_login did not fire
+got: $actual" ;;
+esac
+
+## ---- 3. .lushrc fires AFTER login scripts -----------------------------
+
+## With both ~/.lush_login (overwritten above) and ~/.lushrc set, the
+## lush_login marker must appear before the lushrc marker. The XDG
+## precedence test above already proved XDG-vs-fallback selection;
+## reuse the XDG file here.
+actual=$(run_login)
+case "$actual" in
+    *MARK_XDG_LUSH_LOGIN*MARK_LUSHRC*)
+        ok "ordering: lush_login fires before lushrc" ;;
+    *MARK_LUSHRC*MARK_XDG_LUSH_LOGIN*)
+        fail "wrong ordering: lushrc fired before lush_login
+got: $actual" ;;
+    *)
+        fail "missing markers
+got: $actual" ;;
+esac
+
+## ---- 4. .profile is sourced in bash mode ------------------------------
+
+## .profile is meant to be portable across POSIX shells; lush sources
+## it with shell_mode_set(BASH) temporarily. We can confirm by writing
+## a bash-only construct into .profile and checking it didn't blow up.
+## The simplest tell: `[[ ... ]]` is a bash/zsh extension; if .profile
+## is run in pure POSIX mode lush would error. (lush's POSIX mode
+## accepts [[ ]] anyway as a curated extension, so use `shopt` -- which
+## is bash-only and POSIX-mode rejects.)
+cat > "$HOME_DIR/.profile" <<'EOF'
+shopt -s nullglob 2>/dev/null && echo "MARK_PROFILE_BASH_MODE_OK"
+EOF
+## Keep XDG lush_login and lushrc from step 3 in place.
+
+actual=$(run_login)
+case "$actual" in
+    *MARK_PROFILE_BASH_MODE_OK*)
+        ok ".profile sources in bash mode (shopt accepted)" ;;
+    *)
+        fail ".profile did not run shopt cleanly in bash mode
+got: $actual" ;;
+esac
+
+## ---- 5. missing files are silent --------------------------------------
+
+rm -f "$HOME_DIR/.profile" "$HOME_DIR/.lushrc"
+rm -rf "$HOME_DIR/.config"
+rm -f "$HOME_DIR/.lush_login"
+
+actual=$(run_login)
+case "$actual" in
+    *FAIL*|*error*|*Error*)
+        fail "missing startup files should be silent
+got: $actual" ;;
+    *)
+        ok "no startup files present: clean silent startup" ;;
+esac
+
+printf '%s: all 5 assertions passed\n' "$0"

--- a/tests/integration/test_logout_explicit.sh
+++ b/tests/integration/test_logout_explicit.sh
@@ -1,0 +1,156 @@
+#!/bin/sh
+## Integration test for explicit-exit logout-script firing (#L11 explicit).
+##
+## Verifies that ~/.lush_logout (or XDG ~/.config/lush/lush_logout) is
+## sourced when a login shell terminates via `exit` or the `logout`
+## builtin. Mirrors bash's `tests/invocation.tests` style:
+##
+##     HOME=$TDIR ${THIS_SH} --login -c 'logout'
+##
+## Non-login shells must NOT fire the logout script.
+##
+## The SIGHUP-induced-exit case (where the controlling terminal hangs
+## up and lush runs logout in response to the signal) is a separate
+## test that requires a PTY harness and is not covered here.
+##
+## meson passes the lush binary path as $1.
+
+set -e
+
+LUSH="${1:?lush binary path required as first argument}"
+TMPDIR_BASE="${TMPDIR:-/tmp}"
+
+HOME_DIR=$(mktemp -d "$TMPDIR_BASE/lush_logout_explicit.XXXXXX")
+trap 'rm -rf "$HOME_DIR"' EXIT
+
+fail() {
+    printf '%s: FAIL: %s\n' "$0" "$1" >&2
+    exit 1
+}
+
+ok() {
+    printf '%s: OK: %s\n' "$0" "$1"
+}
+
+## ---- 1. login + explicit `exit` runs ~/.lush_logout -------------------
+
+cat > "$HOME_DIR/.lush_logout" <<'EOF'
+echo "MARK_LOGOUT"
+EOF
+
+actual=$(env -i HOME="$HOME_DIR" PATH="$PATH" TERM=dumb \
+            "$LUSH" -l -i <<'INPUT' 2>/dev/null
+exit
+INPUT
+)
+case "$actual" in
+    *MARK_LOGOUT*)
+        ok "login + exit: ~/.lush_logout fires" ;;
+    *)
+        fail "login + exit did not fire ~/.lush_logout
+got: $actual" ;;
+esac
+
+## ---- 2. login + `logout` builtin runs ~/.lush_logout ------------------
+
+actual=$(env -i HOME="$HOME_DIR" PATH="$PATH" TERM=dumb \
+            "$LUSH" -l -i <<'INPUT' 2>/dev/null
+logout
+INPUT
+)
+case "$actual" in
+    *MARK_LOGOUT*)
+        ok "login + logout builtin: ~/.lush_logout fires" ;;
+    *)
+        fail "login + logout did not fire ~/.lush_logout
+got: $actual" ;;
+esac
+
+## ---- 3. XDG ~/.config/lush/lush_logout wins over ~/ -------------------
+
+mkdir -p "$HOME_DIR/.config/lush"
+cat > "$HOME_DIR/.config/lush/lush_logout" <<'EOF'
+echo "MARK_LOGOUT_XDG"
+EOF
+
+actual=$(env -i HOME="$HOME_DIR" PATH="$PATH" TERM=dumb \
+            "$LUSH" -l -i <<'INPUT' 2>/dev/null
+exit
+INPUT
+)
+case "$actual" in
+    *MARK_LOGOUT_XDG*)
+        case "$actual" in
+            *MARK_LOGOUT*)
+                ## MARK_LOGOUT is a substring of MARK_LOGOUT_XDG, so the
+                ## case branch above matched both. Distinguish by checking
+                ## the BASE marker without the XDG suffix in isolation.
+                ## More explicit: count occurrences -- the XDG file
+                ## printed once; if ~/ also fired we'd see two markers
+                ## of which one is the bare MARK_LOGOUT only.
+                count_bare=$(printf '%s' "$actual" | grep -c '^MARK_LOGOUT$' || true)
+                if [ "$count_bare" -gt 0 ]; then
+                    fail "both XDG and ~/ lush_logout fired
+got: $actual" ;
+                fi
+                ok "xdg-precedence: XDG lush_logout wins" ;;
+        esac
+        ;;
+    *)
+        fail "XDG lush_logout did not fire
+got: $actual" ;;
+esac
+
+## ---- 4. non-login shell does NOT fire ~/.lush_logout ------------------
+
+## Use a marker that will only appear if lush_logout incorrectly runs.
+## Both XDG and ~/ logout scripts are present from earlier steps.
+actual=$(env -i HOME="$HOME_DIR" PATH="$PATH" TERM=dumb \
+            "$LUSH" -i <<'INPUT' 2>/dev/null
+exit
+INPUT
+)
+case "$actual" in
+    *MARK_LOGOUT*)
+        fail "non-login shell incorrectly fired logout script
+got: $actual" ;;
+    *)
+        ok "non-login: logout scripts skipped" ;;
+esac
+
+## ---- 5. -c mode does NOT fire logout scripts --------------------------
+
+actual=$(env -i HOME="$HOME_DIR" PATH="$PATH" TERM=dumb \
+            "$LUSH" -l -c 'echo BODY' 2>/dev/null)
+
+case "$actual" in
+    *MARK_LOGOUT*)
+        ## bash actually DOES fire ~/.bash_logout on -l -c too. lush's
+        ## current behavior on this edge is what the test pins, but
+        ## verify it matches bash:
+        bash_check=$(env -i HOME="$HOME_DIR" PATH="$PATH" TERM=dumb \
+                        bash -l -c 'echo BODY' 2>/dev/null || true)
+        case "$bash_check" in
+            *MARK_LOGOUT*)
+                ok "-l -c: logout fires (matches bash)" ;;
+            *)
+                fail "-l -c fires logout but bash does NOT -- divergence
+lush: $actual
+bash: $bash_check" ;;
+        esac
+        ;;
+    *)
+        bash_check=$(env -i HOME="$HOME_DIR" PATH="$PATH" TERM=dumb \
+                        bash -l -c 'echo BODY' 2>/dev/null || true)
+        case "$bash_check" in
+            *MARK_LOGOUT*)
+                fail "lush -l -c skipped logout but bash fires it -- divergence
+lush: $actual
+bash: $bash_check" ;;
+            *)
+                ok "-l -c: logout skipped (matches bash)" ;;
+        esac
+        ;;
+esac
+
+printf '%s: all 5 assertions passed\n' "$0"

--- a/tests/integration/test_nonlogin_init.sh
+++ b/tests/integration/test_nonlogin_init.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+## Integration test for the non-login interactive startup chain (#L9).
+##
+## Verifies that a non-login interactive shell (`lush -i`, no `-l`)
+## sources ONLY the per-shell startup file (`~/.lushrc` or XDG
+## `~/.config/lush/lushrc`) -- not `.profile`, not `.lush_login`,
+## not the system profile chain. POSIX semantics: profile and
+## login_script are login-shell-only.
+##
+## Approach mirrors the bash `tests/invocation.tests` pattern --
+## controlled $HOME with pre-written startup files, run with `-i`,
+## assert markers from non-login files do NOT appear in stdout.
+##
+## (The POSIX `$ENV` sourcing path -- which IS specific to the
+## non-login interactive case -- is covered by test_env_sourcing.sh
+## and not duplicated here.)
+##
+## meson passes the lush binary path as $1.
+
+set -e
+
+LUSH="${1:?lush binary path required as first argument}"
+TMPDIR_BASE="${TMPDIR:-/tmp}"
+
+HOME_DIR=$(mktemp -d "$TMPDIR_BASE/lush_nonlogin_init.XXXXXX")
+trap 'rm -rf "$HOME_DIR"' EXIT
+
+fail() {
+    printf '%s: FAIL: %s\n' "$0" "$1" >&2
+    exit 1
+}
+
+ok() {
+    printf '%s: OK: %s\n' "$0" "$1"
+}
+
+run_nonlogin() {
+    env -i HOME="$HOME_DIR" PATH="$PATH" TERM=dumb \
+        "$LUSH" -i </dev/null 2>/dev/null
+}
+
+## ---- 1. only ~/.lushrc fires; .profile and .lush_login do NOT ---------
+
+cat > "$HOME_DIR/.profile"    <<'EOF'
+echo "MARK_PROFILE"
+EOF
+cat > "$HOME_DIR/.lush_login" <<'EOF'
+echo "MARK_LUSH_LOGIN"
+EOF
+cat > "$HOME_DIR/.lushrc"     <<'EOF'
+echo "MARK_LUSHRC"
+EOF
+
+actual=$(run_nonlogin)
+
+case "$actual" in
+    *MARK_PROFILE*)
+        fail "non-login shell incorrectly sourced .profile
+got: $actual" ;;
+esac
+case "$actual" in
+    *MARK_LUSH_LOGIN*)
+        fail "non-login shell incorrectly sourced .lush_login
+got: $actual" ;;
+esac
+case "$actual" in
+    *MARK_LUSHRC*)
+        ok "non-login: only .lushrc fired (profile/lush_login skipped)" ;;
+    *)
+        fail ".lushrc did not fire
+got: $actual" ;;
+esac
+
+## ---- 2. XDG-canonical lushrc wins over ~/.lushrc ----------------------
+
+mkdir -p "$HOME_DIR/.config/lush"
+cat > "$HOME_DIR/.config/lush/lushrc" <<'EOF'
+echo "MARK_XDG_LUSHRC"
+EOF
+## Replace ~/.lushrc with a distinct marker so we can detect dual-fire.
+cat > "$HOME_DIR/.lushrc" <<'EOF'
+echo "MARK_HOME_LUSHRC"
+EOF
+
+actual=$(run_nonlogin)
+
+case "$actual" in
+    *MARK_XDG_LUSHRC*)
+        case "$actual" in
+            *MARK_HOME_LUSHRC*)
+                fail "both XDG and ~/ lushrc fired
+got: $actual" ;;
+            *)
+                ok "xdg-precedence: XDG lushrc wins, ~/ skipped" ;;
+        esac
+        ;;
+    *)
+        fail "XDG lushrc did not fire
+got: $actual" ;;
+esac
+
+## ---- 3. -c mode skips all startup files -------------------------------
+
+## POSIX: a -c shell is non-interactive and runs nothing but its
+## argument. None of the markers above should appear.
+actual=$(env -i HOME="$HOME_DIR" PATH="$PATH" TERM=dumb \
+            "$LUSH" -c 'echo MARK_BODY' 2>/dev/null)
+
+case "$actual" in
+    *MARK_BODY*)
+        case "$actual" in
+            *MARK_*LUSHRC*|*MARK_PROFILE*|*MARK_LUSH_LOGIN*)
+                fail "-c mode sourced a startup file
+got: $actual" ;;
+            *)
+                ok "-c mode: body runs, no startup files sourced" ;;
+        esac
+        ;;
+    *)
+        fail "-c mode: body did not run
+got: $actual" ;;
+esac
+
+printf '%s: all 3 assertions passed\n' "$0"

--- a/tests/integration/test_pty_sighup_cascade.c
+++ b/tests/integration/test_pty_sighup_cascade.c
@@ -1,0 +1,128 @@
+/**
+ * @file test_pty_sighup_cascade.c
+ * @brief L10: SIGHUP cascade to background jobs at login-shell exit.
+ *
+ * Spawns lush as a login shell on the slave end of a pseudo-terminal,
+ * starts a background `sleep` process inside it, captures the bg PID
+ * from the shell's $! print, then drives the shell to exit and
+ * verifies the kernel/lush delivered SIGHUP to the background process
+ * group (the `sleep` is dead within a short grace period after the
+ * shell terminates).
+ *
+ * This is the canonical test pattern zsh uses in Test/W02jobs.ztst
+ * via the zsh/zpty module. Behavior under test is *defined by*
+ * terminal semantics, so a real PTY is required -- the stdin-pipe
+ * variant of this same scenario would short-circuit the kernel's
+ * controlling-terminal-driven signal delivery and validate nothing
+ * meaningful.
+ *
+ * Usage: test_pty_sighup_cascade <lush-binary-path>
+ */
+
+#include "pty_helpers.h"
+
+#define TEST "test_pty_sighup_cascade"
+
+static int run_test(const char *lush_path) {
+    pty_session_t s;
+    const char *argv[] = {"lush", "-l", "-i", NULL};
+    if (pty_spawn(&s, lush_path, argv) != 0) {
+        pty_fail(TEST, "pty_spawn failed");
+        return 1;
+    }
+
+    /// Give lush a moment to finish init and print its first prompt.
+    pty_drain(&s, 500);
+
+    /// Start a background sleep and print its PID. The sleep duration
+    /// (60s) is long enough that we can definitively distinguish "still
+    /// alive" from "killed by SIGHUP" via a kill(pid, 0) probe; short
+    /// enough that a runaway test scrubs itself off the system in a
+    /// minute.
+    if (pty_send(&s, "sleep 60 &\n") != 0) {
+        pty_fail(TEST, "send sleep failed: %s", strerror(errno));
+        pty_cleanup(&s);
+        return 1;
+    }
+    if (pty_send(&s, "echo BGPID:$!\n") != 0) {
+        pty_fail(TEST, "send echo failed: %s", strerror(errno));
+        pty_cleanup(&s);
+        return 1;
+    }
+
+    /// Wait for the BGPID line to appear.
+    int waited = 0;
+    while (waited < 3000 && pty_extract_long_after(&s, "BGPID:") < 0) {
+        pty_drain(&s, 100);
+        waited += 100;
+    }
+
+    long bgpid = pty_extract_long_after(&s, "BGPID:");
+    if (bgpid <= 0) {
+        pty_fail(TEST,
+                 "did not capture BGPID from lush output (got %ld bytes)\n"
+                 "output: %s",
+                 (long)s.out_len, s.output);
+        pty_cleanup(&s);
+        return 1;
+    }
+
+    /// Sanity: the bg sleep is alive right now.
+    if (kill((pid_t)bgpid, 0) != 0) {
+        pty_fail(TEST,
+                 "background sleep pid %ld not alive before shell exit: %s",
+                 bgpid, strerror(errno));
+        pty_cleanup(&s);
+        return 1;
+    }
+
+    /// Drive the login shell to exit cleanly. send_sighup_to_jobs()
+    /// is in lush's exit path (lush.c) regardless of whether the
+    /// shell exited via `exit` or via SIGHUP-from-the-PTY; we test
+    /// the explicit-exit path here since it's the most-common
+    /// daily-driver case. The SIGHUP-induced-exit case (terminal
+    /// hangup vs. user typing exit) is covered separately in
+    /// test_pty_sighup_logout.
+    if (pty_send(&s, "exit\n") != 0) {
+        pty_fail(TEST, "send exit failed: %s", strerror(errno));
+        pty_cleanup(&s);
+        return 1;
+    }
+    /// Close stdin so the shell's read returns EOF if `exit` somehow
+    /// gets queued past the prompt redraw -- defensive against a
+    /// blocked-on-read shell that ate the line but didn't terminate.
+    pty_close_stdin(&s);
+
+    /// Wait for lush to exit. 5s is comfortably more than enough.
+    pty_drain(&s, 1000);
+    pty_wait(&s, 5000);
+
+    /// Brief grace period so the SIGHUP to the bg process group has
+    /// time to actually terminate the sleep. The kill(0) probe is the
+    /// real assertion.
+    pty_sleep_ms(500);
+
+    if (kill((pid_t)bgpid, 0) == 0) {
+        /// Still alive: SIGHUP didn't cascade. Clean up the sleep so
+        /// it doesn't outlive the test, then fail.
+        kill((pid_t)bgpid, SIGKILL);
+        pty_fail(TEST,
+                 "background sleep pid %ld still alive after login shell "
+                 "exited; SIGHUP cascade did not fire",
+                 bgpid);
+        pty_cleanup(&s);
+        return 1;
+    }
+
+    pty_ok(TEST, "background sleep killed by SIGHUP on login shell exit");
+    pty_cleanup(&s);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <lush-binary-path>\n", argv[0]);
+        return 2;
+    }
+    return run_test(argv[1]);
+}

--- a/tests/integration/test_pty_sighup_logout.c
+++ b/tests/integration/test_pty_sighup_logout.c
@@ -1,0 +1,94 @@
+/**
+ * @file test_pty_sighup_logout.c
+ * @brief L11 (SIGHUP variant): logout script fires when a login shell
+ *        is hung up via SIGHUP, not just on explicit `exit`/`logout`.
+ *
+ * The explicit-exit case (`logout` builtin / `exit` from a login
+ * shell) is covered by tests/integration/test_logout_explicit.sh
+ * without a PTY -- it doesn't depend on controlling-terminal
+ * semantics. The SIGHUP-induced case is different: when the user's
+ * terminal goes away (ssh disconnect, terminal emulator killed, etc.)
+ * the kernel sends SIGHUP to the foreground process group. The
+ * login shell's job is to handle that gracefully: run ~/.lush_logout,
+ * SIGHUP its own background children, then exit. This test pins that
+ * sequence.
+ *
+ * Approach: spawn lush -l -i in a PTY. Pre-seed ~/.lush_logout with
+ * an `echo` marker. Wait for init to finish. Send SIGHUP directly
+ * to the shell pid (simulates a terminal hangup -- the equivalent
+ * kernel behavior on PTY close-from-master, but without the SIGPIPE
+ * complications). Drain the PTY for the marker, wait for exit, and
+ * assert both pieces fired.
+ *
+ * Usage: test_pty_sighup_logout <lush-binary-path>
+ */
+
+#include "pty_helpers.h"
+
+#define TEST "test_pty_sighup_logout"
+#define LOGOUT_MARKER "LUSH_PTY_LOGOUT_FIRED"
+
+static int run_test(const char *lush_path) {
+    pty_session_t s;
+    const char *argv[] = {"lush", "-l", "-i", NULL};
+    if (pty_spawn(&s, lush_path, argv) != 0) {
+        pty_fail(TEST, "pty_spawn failed");
+        return 1;
+    }
+
+    /// lush resolves ~/.lush_logout lazily at exit
+    /// (config_execute_logout_scripts -> config_get_logout_script_path).
+    /// Seeding it after pty_spawn but before we deliver SIGHUP is
+    /// fine -- the file just has to exist at exit time.
+    char logout_path[1024];
+    snprintf(logout_path, sizeof(logout_path), "%s/.lush_logout", s.home_dir);
+    if (pty_write_marker(logout_path, LOGOUT_MARKER) != 0) {
+        pty_fail(TEST, "could not seed ~/.lush_logout: %s", strerror(errno));
+        pty_cleanup(&s);
+        return 1;
+    }
+
+    /// Give the shell a moment to settle through init.
+    pty_drain(&s, 500);
+
+    /// Send SIGHUP. drain_ms generous so the logout script's echo
+    /// reaches us through the PTY before the slave closes; exit_ms
+    /// also generous in case logout scripts do real work.
+    pty_sighup_and_wait(&s, /*drain_ms=*/1500, /*exit_ms=*/5000);
+
+    /// Final drain in case anything is still buffered (rare; the
+    /// drain-during-sighup-wait should already have everything).
+    pty_drain(&s, 200);
+
+    /// Assertion 1: lush actually exited (not still running, not
+    /// SIGKILL'd by our timeout fallback).
+    if (!WIFEXITED(s.exit_status) && !WIFSIGNALED(s.exit_status)) {
+        pty_fail(TEST, "shell neither exited nor was signalled; status=%d",
+                 s.exit_status);
+        pty_cleanup(&s);
+        return 1;
+    }
+
+    /// Assertion 2: ~/.lush_logout output reached us via the PTY
+    /// before the slave closed.
+    if (!strstr(s.output, LOGOUT_MARKER)) {
+        pty_fail(TEST,
+                 "no '%s' marker in PTY output -- logout script did not fire "
+                 "on SIGHUP\noutput (%zu bytes): %.512s",
+                 LOGOUT_MARKER, s.out_len, s.output);
+        pty_cleanup(&s);
+        return 1;
+    }
+
+    pty_ok(TEST, "~/.lush_logout fired on SIGHUP-driven exit");
+    pty_cleanup(&s);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <lush-binary-path>\n", argv[0]);
+        return 2;
+    }
+    return run_test(argv[1]);
+}


### PR DESCRIPTION
## Summary
Four login-shell punch-list items, structured the way bash and zsh themselves test these behaviors. Investigation of the oracle test suites (bash `tests/invocation.tests`, zsh `Test/W02jobs.ztst` + `zsh/zpty`, dash ships no tests) gave a clean split:

- **PTY required**: behaviors *defined by* controlling-terminal semantics (SIGHUP cascade, kernel-driven foreground-pgroup signaling)
- **PTY not required**: behaviors internal to the shell process (startup-file sourcing order, logout on explicit `exit`)

This PR follows that split exactly.

## What ships
| Item | File | Approach |
|------|------|----------|
| L8 login startup-file chain | `test_login_init_chain.sh` | Bash-style `env -i HOME=$TDIR ./lush -l -i` |
| L9 non-login interactive chain | `test_nonlogin_init.sh` | Bash-style, asserts profile/lush_login NOT sourced |
| L11 explicit logout | `test_logout_explicit.sh` | Mirrors bash's `tests/invocation.tests` literally |
| L10 SIGHUP cascade to bg jobs | `test_pty_sighup_cascade.c` | PTY (zsh-style) |
| L11 SIGHUP logout | `test_pty_sighup_logout.c` | PTY |
| Shared harness | `pty_helpers.h` | header-only: openpty + pipe + setsid + TIOCSCTTY + execve |

## PTY architecture
Hybrid stdio: `stdin = pipe` (avoids LLE raw mode via the existing `isatty(STDIN_FILENO)` fallback in `lle_readline.c`) and `stdout/stderr = PTY slave` with `TIOCSCTTY` (gives lush a real controlling terminal for SIGHUP semantics). zsh's `Src/zsh -fiV +Z` recipe does the same thing via the `-V` (no-zle) flag; lush doesn't have an equivalent yet, but the isatty fallback gives us the same effect.

Cross-platform: `<util.h>` on macOS/BSDs, `<pty.h>` on Linux glibc, links `libutil` where required.

## Test plan
- [x] Local: 119/119 meson tests pass (was 114; +5 new integration tests)
- [x] Werror-clean build
- [x] All 5 fixtures pass directly: `./tests/integration/*.sh` + `./build/test_pty_sighup_*`
- [x] CI: Linux build + tests (the cross-platform compat is the actual gate here)

Refs login-shell punch-list. After this lands, remaining: L14 (motd/.hushlogin), L15 (restricted -r).