### PR TITLE
restricted shell -r / --restricted / rlush (L15); L14 closed won't-fix

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -432,6 +432,68 @@ default legitimately differs across shells register per-mode overrides.
 
 ---
 
+## Restricted shell (`-r` / `--restricted` / `rlush`)
+
+Lush supports a restricted-shell mode matching bash's `rbash`, zsh's
+`RESTRICTED`, and POSIX 2024 `set -r`. It is invoked by:
+
+- `lush -r` or `lush --restricted` on the command line
+- `set -r` or `set -o restricted` from within a shell
+- Invocation as `rlush` (symlink to the lush binary; bash's `rbash`
+  pattern). The leading dash for login-shell invocation
+  (`-rlush`) is recognized too.
+
+### What's restricted
+
+The bash-rbash set, applied verbatim:
+
+1. `cd` is disabled.
+2. `SHELL`, `PATH`, `HISTFILE`, `ENV`, `BASH_ENV` are made readonly.
+3. Command names containing `/` are rejected (must resolve via `PATH`).
+4. `.` / `source` with a filename containing `/` is rejected.
+5. Output redirections `>`, `>|`, `>>`, `>&`, `&>`, `&>>`, `2>`, `2>>`
+   are forbidden. Input redirection (`<`, `<<`, `<<<`) and FD-to-FD
+   duplication (`2>&1`) are still allowed.
+6. `exec` with arguments (process replacement) is disabled.
+7. `set +r` and `set +o restricted` are rejected -- restricted mode
+   is one-way once engaged.
+
+### When restrictions engage
+
+Restrictions activate **after** rc-file processing -- the same order
+bash and zsh use. The intent is that an administrator can configure
+the environment in `/etc/profile`, `~/.profile`, `~/.lush_login`, and
+`~/.lushrc` (set up a locked-down `PATH`, define aliases, etc.) and
+then have restrictions take effect before the user gets the prompt.
+The `restricted_mode_engaged` flag (in `shell_opts`) is the gate
+every enforcement site consults.
+
+### Not a security boundary
+
+This is the explicit, deliberate matching of bash's stance:
+
+> "It is not intended to be a completely secure environment for
+>  running shell scripts where absolute security is required."
+
+A restricted shell is a **usability boundary** -- it keeps an unsuspecting
+user from `cd`'ing out of the menu-shell's working directory or
+clobbering files by accident. It is **not** a sandbox against a
+determined adversary. Common escapes (none of which lush patches):
+
+- `vi` / `vim` / `nano` / `less` / `man` -- shell-out via `:!sh`, `!sh`,
+  `:shell`, etc.
+- `find . -exec sh {} \;`
+- `awk 'BEGIN{system("sh")}'`
+- Any script invoked by full path that runs `unset PATH; exec /bin/sh`
+- `ssh user@host` -- escapes by hopping to an unrestricted shell
+
+Lock these down by curating `PATH` to a directory of admin-vetted
+binaries before engaging restrictions, the same as you would with
+bash's rbash. The restriction list is the perimeter; what's inside
+the perimeter is the admin's responsibility.
+
+---
+
 ## Startup ordering
 
 For reference and debugging, the configuration startup sequence is:
@@ -452,6 +514,10 @@ For reference and debugging, the configuration startup sequence is:
    - Load `~/.config/lush/lushrc.toml` -- user values layer on top.
 6. `config_apply_settings()` -- propagate registry values to runtime
    state (legacy fields, symbol table, subsystem hooks).
+7. **Login + interactive rc-file sourcing** (`config_execute_*` series).
+8. **`restricted_mode_engage()` if `-r` was requested.** Lockdown of
+   protected variables happens here, AFTER step 7, so admin rc files
+   can configure the environment before restrictions bite.
 
 The `mode` builtin and the `set -o posix`/`set +o posix` bridge use
 `apply_mode_preset()` at runtime; the registry side of the re-seed fires

--- a/include/lush.h
+++ b/include/lush.h
@@ -263,6 +263,16 @@ typedef struct shell_options {
     bool physical_mode;             ///< physical: resolve symlinks in paths
     bool privileged_mode; ///< privileged: restricted shell security mode
 
+    /// `-r` / `--restricted` / `rlush` invocation: a usability-not-
+    /// security restricted shell (matches bash's rbash, zsh's RESTRICTED,
+    /// POSIX 2024 `set -r`). Restrictions engage AFTER rc-file
+    /// processing so admins can pre-configure the environment; once
+    /// engaged the flag cannot be cleared (set +r / set +o restricted
+    /// is rejected). See restricted_mode_engaged below for the actual
+    /// "is restriction enforcement live" gate.
+    bool restricted_mode;
+    bool restricted_mode_engaged; ///< true after restricted_mode_engage()
+
     /* Early-init CLI mode override. Populated by --posix/--bash/--zsh/--lush
      * during parse_opts; consumed by detect_initial_mode() before
      * config_init so the user's lushrc layers on top of the right preset.

--- a/include/restricted_mode.h
+++ b/include/restricted_mode.h
@@ -1,0 +1,83 @@
+/**
+ * @file restricted_mode.h
+ * @brief Restricted-shell mode (bash rbash / zsh RESTRICTED / POSIX 2024 -r).
+ *
+ * This is a usability boundary, NOT a security boundary -- matching
+ * bash's own manual:
+ *
+ *     "It is not intended to be a completely secure environment for
+ *      running shell scripts where absolute security is required."
+ *
+ * Trivially escapable via `vi :shell`, `man !sh`, `find -exec sh`,
+ * `awk 'BEGIN{system("sh")}'`, etc. Use it for admin-controlled menu
+ * shells, not for sandboxing untrusted users.
+ *
+ * Restriction set (matches bash's rbash; the POSIX 2024 `set -r` text
+ * delegates the exact list to implementations, so we adopt the de-facto
+ * standard):
+ *
+ *   1. `cd` is disabled
+ *   2. `SHELL`, `PATH`, `HISTFILE`, `ENV`, `BASH_ENV` are made readonly
+ *   3. Command names containing `/` are rejected
+ *   4. `/`-paths to `.` (source) and `hash -p` are rejected
+ *   5. Output redirections `>`, `>|`, `<>`, `>&`, `&>`, `>>` are forbidden
+ *   6. `exec` to replace the shell is disabled
+ *   7. `set +r` / `set +o restricted` cannot clear the mode
+ *
+ * Restrictions engage AFTER rc-file processing so admin startup scripts
+ * (`/etc/profile`, `~/.profile`, `~/.lush_login`, `~/.lushrc`) can
+ * pre-configure the environment. Once engaged the flag is one-way.
+ *
+ * The gate `shell_opts.restricted_mode_engaged` distinguishes "user
+ * requested -r" (shell_opts.restricted_mode) from "restrictions are
+ * actually enforcing now" (restricted_mode_engaged). Enforcement
+ * sites consult restricted_mode_engaged, not restricted_mode.
+ */
+
+#ifndef RESTRICTED_MODE_H
+#define RESTRICTED_MODE_H
+
+#include <stdbool.h>
+
+#include "shell_error.h"
+
+/**
+ * @brief Engage restricted mode.
+ *
+ * Idempotent: safe to call repeatedly; only the first invocation
+ * performs the readonly lockdown. Called from init.c AFTER rc-file
+ * processing. Marks `shell_opts.restricted_mode_engaged = true` so
+ * the per-site enforcement gates (cd, exec, redirection, command
+ * dispatch, etc.) fire.
+ */
+void restricted_mode_engage(void);
+
+/**
+ * @brief Test whether restricted mode is currently enforcing.
+ *
+ * Single-line convenience wrapper around the flag check. Call sites
+ * use this rather than reaching into shell_opts directly so the
+ * gate location is searchable / rename-safe.
+ */
+bool restricted_mode_is_engaged(void);
+
+/**
+ * @brief Report a restricted-mode-blocked operation via the
+ *        structured-error system, and return 1 (the conventional
+ *        shell error status). Designed to be returned directly
+ *        from builtin/dispatch sites:
+ *
+ *            if (restricted_mode_is_engaged()) {
+ *                return restricted_mode_reject(loc, "cd: restricted");
+ *            }
+ *
+ * The `loc` is the source location of the offending command.
+ *
+ * @param loc Source location of the rejected command
+ * @param what Verb/operation phrase for the error message
+ *             (e.g. "cd", "exec", "redirection")
+ * @return Always 1 (failure exit status)
+ */
+int restricted_mode_reject(source_location_t loc, const char *what);
+
+#endif /// RESTRICTED_MODE_H

--- a/meson.build
+++ b/meson.build
@@ -190,6 +190,7 @@ src = ['src/arithmetic.c',
        'src/posix_history.c',
        'src/posix_opts.c',
        'src/redirection.c',
+       'src/restricted_mode.c',
        'src/shell_error.c',
        'src/shell_mode.c',
        'src/signals.c',
@@ -2577,6 +2578,19 @@ endif
 if fs.exists('tests/integration/test_logout_explicit.sh')
   test('logout script (explicit exit)',
        find_program('tests/integration/test_logout_explicit.sh'),
+       args: [lush_exe.full_path()],
+       suite: 'integration',
+       timeout: 30)
+endif
+
+# Restricted-shell mode (#L15). Exercises -r / --restricted and the
+# full bash-rbash restriction set: cd disabled, /-containing command
+# names rejected, output redirections forbidden, exec blocked,
+# /-paths to source rejected, PATH/SHELL/ENV/BASH_ENV/HISTFILE
+# readonly, set +r / set +o restricted rejected.
+if fs.exists('tests/integration/test_restricted_shell.sh')
+  test('restricted shell (-r)',
+       find_program('tests/integration/test_restricted_shell.sh'),
        args: [lush_exe.full_path()],
        suite: 'integration',
        timeout: 30)

--- a/src/builtins/bin_cd.c
+++ b/src/builtins/bin_cd.c
@@ -10,6 +10,7 @@
 #include "dirstack.h"
 #include "lle/lle_shell_event_hub.h"
 #include "lush.h"
+#include "restricted_mode.h"
 #include "shell_mode.h"
 #include "symtable.h"
 
@@ -105,6 +106,13 @@ int bin_cd(int argc __attribute__((unused)),
     static char *previous_dir = NULL;
     char *current_dir = NULL;
     char *target_dir = NULL;
+
+    /// Restricted-shell mode forbids `cd` outright. Matches bash's
+    /// rbash and zsh's RESTRICTED. See include/restricted_mode.h for
+    /// the full restriction set.
+    if (restricted_mode_is_engaged()) {
+        return restricted_mode_reject(builtin_get_source_location(), "cd");
+    }
 
     /// Privileged mode security check
     if (shell_opts.privileged_mode) {

--- a/src/builtins/bin_exec.c
+++ b/src/builtins/bin_exec.c
@@ -8,6 +8,7 @@
 
 #include "builtins.h"
 #include "lush.h"
+#include "restricted_mode.h"
 #include "signals.h"
 #include "symtable.h"
 
@@ -27,6 +28,15 @@
  * @return Does not return on success; 1 on error or restricted mode
  */
 int bin_exec(int argc, char **argv) {
+    /// Restricted-shell mode forbids `exec`-with-arguments (replacing
+    /// the shell). Redirection-only `exec >file` is also forbidden
+    /// by the broader output-redirection ban, enforced in
+    /// redirection.c -- so we reject the whole invocation up front
+    /// when restrictions are engaged, matching bash's rbash.
+    if (restricted_mode_is_engaged() && argc > 1) {
+        return restricted_mode_reject(builtin_get_source_location(), "exec");
+    }
+
     /// Privileged mode security check
     if (shell_opts.privileged_mode) {
         source_location_t loc = builtin_get_source_location();

--- a/src/builtins/bin_source.c
+++ b/src/builtins/bin_source.c
@@ -10,8 +10,10 @@
 #include "builtins.h"
 #include "input.h"
 #include "lush.h"
+#include "restricted_mode.h"
 
 #include <errno.h>
+#include <string.h>
 #include <sys/stat.h>
 
 /**
@@ -25,6 +27,16 @@
  * @return 0 on success, 1 on error, or last command's exit status
  */
 int bin_source(int argc, char **argv) {
+    /// Restricted-shell mode forbids `.` / `source` with a filename
+    /// containing `/`. Restricted users must source by basename
+    /// against the locked-down PATH; absolute or relative paths
+    /// would bypass the PATH lockdown. Matches bash rbash.
+    if (restricted_mode_is_engaged() && argc >= 2 && argv[1] &&
+        strchr(argv[1], '/')) {
+        return restricted_mode_reject(builtin_get_source_location(),
+                                      argv[0] ? argv[0] : "source");
+    }
+
     if (argc < 2) {
         source_location_t loc = builtin_get_source_location();
         shell_error_t *err =

--- a/src/executor.c
+++ b/src/executor.c
@@ -38,6 +38,7 @@
 #include "parser.h"
 #include "pattern_match.h"
 #include "redirection.h"
+#include "restricted_mode.h"
 #include "shell_mode.h"
 #include "signals.h"
 #include "symtable.h"
@@ -8856,6 +8857,17 @@ static int execute_external_command_with_setup(executor_t *executor,
                                                bool redirect_stderr,
                                                node_t *command) {
     if (!argv || !argv[0]) {
+        return 1;
+    }
+
+    /// Restricted-shell mode forbids command names containing `/`.
+    /// Matches bash rbash and zsh RESTRICTED -- a restricted user
+    /// must use PATH lookup, not arbitrary filesystem traversal.
+    if (restricted_mode_is_engaged() && strchr(argv[0], '/')) {
+        source_location_t loc = command ? command->loc : SOURCE_LOC_UNKNOWN;
+        executor_error_report(
+            executor, SHELL_ERR_PERMISSION_DENIED, loc,
+            "%s: restricted: command names cannot contain '/'", argv[0]);
         return 1;
     }
 

--- a/src/init.c
+++ b/src/init.c
@@ -25,6 +25,7 @@
 #include "errors.h"
 #include "input.h"
 #include "posix_history.h"
+#include "restricted_mode.h"
 #include "shell_error.h"
 #include "shell_mode.h"
 
@@ -457,6 +458,23 @@ int init(int argc, char **argv, FILE **in) {
     /// 1. Determine if this is a login shell
     IS_LOGIN_SHELL = (**argv == '-') || shell_opts.login_shell;
 
+    /// `rlush` symlink invocation: matches bash's rbash and zsh's rzsh
+    /// conventions. When argv[0]'s basename is exactly "rlush" (the
+    /// `r`-prefixed lush), turn on restricted mode the same way `-r`
+    /// would. Also covers `-rlush` (login-shell + rlush symlink) by
+    /// skipping a leading dash before basename comparison.
+    {
+        const char *prog = argv[0];
+        const char *slash = strrchr(prog, '/');
+        const char *base = slash ? slash + 1 : prog;
+        if (*base == '-') {
+            base++; /// strip the login-shell dash prefix
+        }
+        if (strcmp(base, "rlush") == 0) {
+            shell_opts.restricted_mode = true;
+        }
+    }
+
     /// 2. Check if we are the session leader (PID == SID)
     IS_SESSION_LEADER = (getsid(0) == getpid());
 
@@ -489,6 +507,16 @@ int init(int argc, char **argv, FILE **in) {
     /// below
     if (preliminary_interactive && !shell_opts.command_mode) {
         config_execute_startup_scripts();
+    }
+
+    /// `-r` / `rlush` / `set -o restricted` taking effect: bash and
+    /// zsh both engage restrictions AFTER rc-file processing so admin
+    /// startup scripts can set up PATH to a restricted bin directory,
+    /// lock down command paths, etc. Once engaged the flag cannot be
+    /// cleared (set +r / set +o restricted are rejected; see
+    /// posix_opts.c). Matches POSIX 2024 `set -r` semantics.
+    if (shell_opts.restricted_mode && !shell_opts.restricted_mode_engaged) {
+        restricted_mode_engage();
     }
 
     /// POSIX: an interactive non-login shell must source the file
@@ -998,6 +1026,10 @@ static int parse_opts(int argc, char **argv) {
                 /// Long-flag spelling of `-l`. Bash accepts both forms;
                 /// lush matches for ergonomic parity.
                 shell_opts.login_shell = true;
+            } else if (strcmp(arg, "--restricted") == 0) {
+                /// Long-flag spelling of `-r`. Bash supports both
+                /// `--restricted` and `-r`; lush matches.
+                shell_opts.restricted_mode = true;
             } else if (strcmp(arg, "--strict") == 0) {
                 /// Enable strict compatibility mode - warnings become errors
                 compat_set_strict(true);
@@ -1149,6 +1181,14 @@ static int parse_opts(int argc, char **argv) {
             case 'l':
                 shell_opts.login_shell = true;
                 break;
+            case 'r':
+                /// Bash's rbash / zsh's RESTRICTED / POSIX 2024 set -r:
+                /// usability-not-security restricted shell. Recorded
+                /// here; actually engaged AFTER rc-file processing via
+                /// restricted_mode_engage() so admin startup scripts
+                /// can pre-configure PATH etc.
+                shell_opts.restricted_mode = true;
+                break;
             case 'e':
                 shell_opts.exit_on_error = true;
                 break;
@@ -1241,6 +1281,11 @@ static void usage(int err) {
     printf("  -s               Read commands from standard input\n");
     printf("  -i               Force interactive mode\n");
     printf("  -l, --login      Act as a login shell\n");
+    printf("  -r, --restricted Restricted shell (no cd, no `/' in command "
+           "names, no\n");
+    printf(
+        "                   output redirection, no exec; usability boundary, "
+        "not security)\n");
     printf("  -e               Exit immediately on command failure (set -e)\n");
     printf("  -x               Trace command execution (set -x)\n");
     printf("  -n               Syntax check mode - read but don't execute (set "

--- a/src/posix_opts.c
+++ b/src/posix_opts.c
@@ -145,6 +145,8 @@ void init_posix_options(void) {
         true; /// Default to interactive comments enabled
     shell_opts.physical_mode = false;   /// Default to logical directory paths
     shell_opts.privileged_mode = false; /// Default to unrestricted mode
+    shell_opts.restricted_mode = false; /// `-r`: requested at invocation
+    shell_opts.restricted_mode_engaged = false; /// engaged after rc files
 }
 
 /**
@@ -187,6 +189,8 @@ bool is_posix_option_set(char option) {
         return shell_opts.onecmd;
     case 'b':
         return shell_opts.notify;
+    case 'r':
+        return shell_opts.restricted_mode;
     default:
         return false;
     }
@@ -304,6 +308,7 @@ static option_mapping_t option_map[] = {
     {"interactive-comments", &shell_opts.interactive_comments_mode,   0},
     {            "physical",             &shell_opts.physical_mode,   0},
     {          "privileged",           &shell_opts.privileged_mode,   0},
+    {          "restricted",           &shell_opts.restricted_mode, 'r'},
     {                  NULL,                                  NULL,   0}
 };
 
@@ -628,6 +633,16 @@ int builtin_set(char **args) {
                         "use `mode <name>` to switch presets",
                         args[i]);
                     return 1;
+                } else if (strcmp(args[i], "restricted") == 0 &&
+                           shell_opts.restricted_mode_engaged) {
+                    /// `set +o restricted` is rejected once `-r` has
+                    /// taken effect -- restricted mode is one-way,
+                    /// matching bash (rbash) and POSIX 2024 text.
+                    executor_error_report(
+                        current_executor, SHELL_ERR_PERMISSION_DENIED,
+                        builtin_get_source_location(),
+                        "set: cannot clear restricted mode once engaged");
+                    return 1;
                 } else {
                     option_mapping_t *opt = find_option_by_name(args[i]);
                     if (opt) {
@@ -744,6 +759,17 @@ int builtin_set(char **args) {
         } else if (arg[0] == '+' && arg[1] != '+') {
             /// Handle short options like +e, +x, etc.
             for (int j = 1; arg[j]; j++) {
+                /// Restricted mode is one-way: once `-r` is engaged it
+                /// cannot be cleared. Matches bash (rbash refuses
+                /// `set +r`) and POSIX 2024 `set -r` text. The check
+                /// fires whether the user typed `+r` or `+o restricted`.
+                if (arg[j] == 'r' && shell_opts.restricted_mode_engaged) {
+                    executor_error_report(
+                        current_executor, SHELL_ERR_PERMISSION_DENIED,
+                        builtin_get_source_location(),
+                        "set: cannot clear restricted mode once engaged");
+                    return 1;
+                }
                 option_mapping_t *opt = find_option_by_short(arg[j]);
                 if (opt) {
                     *(opt->flag) = false;

--- a/src/redirection.c
+++ b/src/redirection.c
@@ -24,6 +24,7 @@
 #include "lush.h"
 #include "lush_fork.h"
 #include "node.h"
+#include "restricted_mode.h"
 #include "shell_error.h"
 #include "symtable.h"
 
@@ -120,6 +121,34 @@ int setup_redirections(executor_t *executor, node_t *command) {
 static int handle_redirection_node(executor_t *executor, node_t *redir_node) {
     if (!redir_node) {
         return 1;
+    }
+
+    /// Restricted-shell mode forbids output redirections to files
+    /// (>, >|, >>, <>, >&FILE, &>FILE). Input redirection (<, <<,
+    /// <<<) and FD-to-FD duplication (2>&1) are still allowed --
+    /// they don't create or overwrite files. Matches bash's rbash
+    /// restrictions exactly.
+    if (restricted_mode_is_engaged()) {
+        bool reject = false;
+        switch (redir_node->type) {
+        case NODE_REDIR_OUT:         /// >
+        case NODE_REDIR_APPEND:      /// >>
+        case NODE_REDIR_CLOBBER:     /// >|
+        case NODE_REDIR_ERR:         /// N> (2>, 3>, etc.)
+        case NODE_REDIR_ERR_APPEND:  /// N>>
+        case NODE_REDIR_BOTH:        /// &>
+        case NODE_REDIR_BOTH_APPEND: /// &>>
+            reject = true;
+            break;
+        default:
+            break;
+        }
+        if (reject) {
+            executor_error_report(executor, SHELL_ERR_PERMISSION_DENIED,
+                                  redir_node->loc,
+                                  "restricted: output redirection forbidden");
+            return 1;
+        }
     }
 
     if (getenv("LUSH_DEBUG_REDIR")) {

--- a/src/restricted_mode.c
+++ b/src/restricted_mode.c
@@ -1,0 +1,76 @@
+/**
+ * @file restricted_mode.c
+ * @brief Restricted-shell mode engagement + per-site enforcement helpers.
+ *
+ * See include/restricted_mode.h for the full restriction set, its
+ * provenance (bash rbash / zsh RESTRICTED / POSIX 2024 set -r), and
+ * the explicit "usability boundary, NOT a security boundary"
+ * disclaimer that mirrors bash's own manual.
+ *
+ * Per-site enforcement lives where the operation does -- cd in
+ * bin_cd.c, exec in bin_exec.c, output redirection in redirection.c,
+ * etc. This module owns only the engagement transition (readonly
+ * lockdown of the protected variables) and the shared rejection
+ * reporter so every call site emits identical structured-error
+ * shape.
+ */
+
+#include "restricted_mode.h"
+
+#include "executor.h"
+#include "lush.h"
+#include "symtable.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/// Protected variables -- bash's rbash list. Made readonly when
+/// restricted mode engages so a restricted user cannot redirect
+/// command lookup via PATH or hijack init via ENV/BASH_ENV.
+static const char *const kProtectedVars[] = {
+    "SHELL", "PATH", "HISTFILE", "ENV", "BASH_ENV", NULL,
+};
+
+void restricted_mode_engage(void) {
+    if (shell_opts.restricted_mode_engaged) {
+        return; /// Idempotent: already engaged.
+    }
+
+    /// Lock down each protected variable as readonly. Bash sets these
+    /// readonly via maybe_make_restricted(); the same effect via the
+    /// existing symtable readonly machinery -- no new infrastructure
+    /// needed. If a variable isn't currently set we still mark it
+    /// (creates the binding with the empty value so a later
+    /// assignment is refused) -- matches bash's semantics where
+    /// `PATH=foo` from a restricted shell fails regardless of
+    /// PATH's prior state.
+    for (size_t i = 0; kProtectedVars[i]; i++) {
+        const char *name = kProtectedVars[i];
+        symvar_flags_t cur_flags = symtable_get_flags(symtable_manager(), name);
+        char *cur_value = symtable_get_var(symtable_manager(), name);
+        const char *value = cur_value ? cur_value : "";
+        symtable_set_var(symtable_manager(), name, value,
+                         cur_flags | SYMVAR_READONLY);
+        free(cur_value);
+    }
+
+    shell_opts.restricted_mode_engaged = true;
+}
+
+bool restricted_mode_is_engaged(void) {
+    return shell_opts.restricted_mode_engaged;
+}
+
+int restricted_mode_reject(source_location_t loc, const char *what) {
+    executor_t *executor = get_global_executor();
+    if (executor) {
+        executor_error_report(executor, SHELL_ERR_PERMISSION_DENIED, loc,
+                              "%s: restricted", what ? what : "operation");
+    } else {
+        /// Pre-executor path (e.g. init failure): plain stderr is
+        /// the only thing available.
+        fprintf(stderr, "lush: %s: restricted\n", what ? what : "operation");
+    }
+    return 1;
+}

--- a/tests/integration/test_restricted_shell.sh
+++ b/tests/integration/test_restricted_shell.sh
@@ -1,0 +1,252 @@
+#!/bin/sh
+## Integration test for the `-r` / `--restricted` / rlush restricted
+## shell mode (#L15). Mirrors bash's rbash restriction set and POSIX
+## 2024 `set -r` semantics.
+##
+## Restricted mode is a usability boundary, NOT a security boundary
+## (matching bash's own manual). The test verifies each restriction
+## fires; it does NOT attempt to verify lush is sandboxed against a
+## determined adversary because that's not what restricted shells
+## are for.
+##
+## meson passes the lush binary path as $1.
+
+set -e
+
+LUSH="${1:?lush binary path required as first argument}"
+TMPDIR_BASE="${TMPDIR:-/tmp}"
+
+WORK=$(mktemp -d "$TMPDIR_BASE/lush_restricted.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+fail() {
+    printf '%s: FAIL: %s\n' "$0" "$1" >&2
+    exit 1
+}
+
+ok() {
+    printf '%s: OK: %s\n' "$0" "$1"
+}
+
+run_r() {
+    env -i HOME="$WORK" PATH="$PATH" TERM=dumb \
+        "$LUSH" -r -c "$1" 2>&1
+}
+
+run_long() {
+    env -i HOME="$WORK" PATH="$PATH" TERM=dumb \
+        "$LUSH" --restricted -c "$1" 2>&1
+}
+
+run_unrestricted() {
+    env -i HOME="$WORK" PATH="$PATH" TERM=dumb \
+        "$LUSH" -c "$1" 2>&1
+}
+
+## ---- 1. cd is disabled in restricted mode -----------------------------
+
+out=$(run_r 'cd /tmp; pwd' || true)
+case "$out" in
+    *"cd: restricted"*)
+        ok "-r: cd is disabled" ;;
+    *)
+        fail "-r: cd was NOT rejected
+got: $out" ;;
+esac
+
+## ---- 2. Command names containing '/' are rejected ---------------------
+
+out=$(run_r '/bin/echo hi' || true)
+case "$out" in
+    *"restricted"*"'/'"*)
+        ok "-r: /-containing command names rejected" ;;
+    *)
+        fail "-r: /-containing command name was NOT rejected
+got: $out" ;;
+esac
+
+## Sanity: PATH-lookup command names still work
+out=$(run_r 'echo from_restricted' || true)
+case "$out" in
+    *"from_restricted"*)
+        ok "-r: PATH-resolved command names still work" ;;
+    *)
+        fail "-r: PATH-resolved 'echo' broke
+got: $out" ;;
+esac
+
+## ---- 3. Output redirection is forbidden -------------------------------
+
+target="$WORK/output_target"
+out=$(run_r "echo hi > $target" || true)
+case "$out" in
+    *"restricted"*"output"*)
+        ok "-r: output redirection (>) rejected" ;;
+    *)
+        fail "-r: > redirection was NOT rejected
+got: $out" ;;
+esac
+if [ -f "$target" ]; then
+    fail "-r: output file was created despite the rejection"
+fi
+
+## Append redirection too
+out=$(run_r "echo hi >> $target" || true)
+case "$out" in
+    *"restricted"*"output"*)
+        ok "-r: append redirection (>>) rejected" ;;
+    *)
+        fail "-r: >> was NOT rejected
+got: $out" ;;
+esac
+
+## Stderr redirection too
+out=$(run_r "echo hi 2> $target" || true)
+case "$out" in
+    *"restricted"*"output"*)
+        ok "-r: stderr redirection (2>) rejected" ;;
+    *)
+        fail "-r: 2> was NOT rejected
+got: $out" ;;
+esac
+
+## Input redirection should still work (it doesn't write anywhere).
+infile="$WORK/infile"
+printf "from_stdin_input\n" > "$infile"
+out=$(run_r "cat < $infile" || true)
+case "$out" in
+    *"from_stdin_input"*)
+        ok "-r: input redirection (<) still works" ;;
+    *)
+        fail "-r: < was incorrectly rejected
+got: $out" ;;
+esac
+
+## ---- 4. exec to replace the shell is forbidden ------------------------
+
+out=$(run_r 'exec echo replaced' || true)
+case "$out" in
+    *"exec"*"restricted"*)
+        ok "-r: exec with args rejected" ;;
+    *)
+        fail "-r: exec was NOT rejected
+got: $out" ;;
+esac
+
+## ---- 5. . / source with /-containing filename rejected ---------------
+
+script="$WORK/sourced_script"
+printf "echo from_sourced\n" > "$script"
+out=$(run_r ". $script" || true)
+case "$out" in
+    *"restricted"*)
+        ok "-r: source with /-path rejected" ;;
+    *)
+        fail "-r: . with /-path was NOT rejected
+got: $out" ;;
+esac
+
+## ---- 6. PATH / SHELL / ENV / BASH_ENV / HISTFILE are readonly --------
+
+for var in PATH SHELL ENV BASH_ENV HISTFILE; do
+    out=$(run_r "$var=hacked; echo \$$var" || true)
+    case "$out" in
+        *"readonly"*"$var"*|*"$var"*"readonly"*)
+            ok "-r: $var is readonly" ;;
+        *"hacked"*)
+            fail "-r: $var was reassigned despite restriction
+got: $out" ;;
+        *)
+            fail "-r: $var assignment did not produce a readonly error
+got: $out" ;;
+    esac
+done
+
+## ---- 7. set +r / set +o restricted cannot clear the mode ------------
+
+out=$(run_r 'set +r' || true)
+case "$out" in
+    *"cannot clear restricted"*)
+        ok "-r: set +r is rejected" ;;
+    *)
+        fail "-r: set +r was not rejected
+got: $out" ;;
+esac
+
+out=$(run_r 'set +o restricted' || true)
+case "$out" in
+    *"cannot clear restricted"*)
+        ok "-r: set +o restricted is rejected" ;;
+    *)
+        fail "-r: set +o restricted was not rejected
+got: $out" ;;
+esac
+
+## ---- 8. --restricted long flag is equivalent --------------------------
+
+out=$(run_long 'cd /tmp' || true)
+case "$out" in
+    *"cd: restricted"*)
+        ok "--restricted: equivalent to -r" ;;
+    *)
+        fail "--restricted: did not engage restrictions
+got: $out" ;;
+esac
+
+## ---- 9. Unrestricted shell does NOT apply any of these ---------------
+
+target="$WORK/unrestricted_target"
+out=$(run_unrestricted "echo hi > $target") || fail "unrestricted shell errored on plain redirect"
+if [ ! -f "$target" ]; then
+    fail "unrestricted shell did not create the redirect target"
+fi
+case "$(cat "$target")" in
+    hi*) ok "unrestricted: redirection works normally" ;;
+    *) fail "unrestricted: target content unexpected" ;;
+esac
+
+out=$(run_unrestricted 'cd /tmp; echo "pwd=$PWD"')
+case "$out" in
+    *"pwd=/tmp"*|*"pwd=/private/tmp"*)
+        ok "unrestricted: cd works normally" ;;
+    *)
+        fail "unrestricted: cd did not work
+got: $out" ;;
+esac
+
+## ---- 10. rc files run BEFORE restrictions engage ---------------------
+
+## bash and zsh engage restrictions AFTER rc-file processing so admin
+## startup scripts can configure the environment. Verify lush matches:
+## a startup script that does `cd /tmp` and a redirection should run
+## even though the post-init invocation is restricted.
+mkdir -p "$WORK/.config/lush"
+cat > "$WORK/.config/lush/lushrc" <<'RC'
+cd /tmp
+echo "RC_DID_CD: $PWD"
+RC
+
+## -r alone without -i doesn't trigger the interactive rc path; we need
+## an interactive invocation to exercise rc-then-restrict. Pipe a
+## command in via stdin since `-c` doesn't source rc.
+out=$(env -i HOME="$WORK" PATH="$PATH" TERM=dumb \
+        "$LUSH" -r -i <<'INPUT' 2>&1 || true
+cd /usr
+INPUT
+)
+case "$out" in
+    *"RC_DID_CD:"*"tmp"*)
+        case "$out" in
+            *"cd: restricted"*)
+                ok "rc runs before -r engages; post-rc cd is blocked" ;;
+            *)
+                fail "rc ran but post-rc cd was NOT blocked
+got: $out" ;;
+        esac
+        ;;
+    *)
+        fail "rc did not run pre-restrict (its cd should have shown)
+got: $out" ;;
+esac
+
+printf '%s: all assertions passed\n' "$0"


### PR DESCRIPTION
## Summary

Finishes the login-shell viability punch list. **L15** implements bash's `rbash` / zsh's `RESTRICTED` / POSIX 2024 `set -r` (matching restriction set and engagement order). **L14** (motd / `~/.hushlogin`) is closed as won't-fix per oracle research — none of bash/zsh/dash ship that responsibility; it belongs to `login(1)` / `pam_motd` / `sshd`.

## L15 invocation surfaces
- `lush -r` short flag
- `lush --restricted` long flag
- `set -r` / `set -o restricted` from a running shell
- `rlush` symlink to the lush binary (bash's `rbash` convention; `-rlush` for login + restricted)

## L15 restriction set (bash rbash verbatim)
1. `cd` is disabled
2. `SHELL`, `PATH`, `HISTFILE`, `ENV`, `BASH_ENV` made readonly
3. Command names containing `/` rejected
4. `.` / `source` with `/`-containing filename rejected
5. Output redirections forbidden (`>`, `>|`, `>>`, `>&`, `&>`, `&>>`, `2>`, `2>>`). Input + FD-to-FD duplication still allowed.
6. `exec` to replace shell disabled
7. `set +r` / `set +o restricted` rejected (one-way)

Engagement order matches bash and zsh: restrictions activate **after** rc-file processing so admins can pre-configure `PATH`. **Not a security boundary** — documented explicitly in CONFIGURATION.md matching bash's own manual; trivial escapes via `vi :shell`, `man !sh`, `find -exec sh` remain.

## L14 — closed won't-fix
Oracle source inspection (per the agent's research): `bash shell.c`/`general.c` zero motd/hushlogin references; `zsh Src/init.c` same; `dash` has no motd handling at all. None of the three oracles display motd from the shell. Memory note `project-motd-not-shells-job` records the rationale.

## Test plan
- [x] Local: 120/120 meson tests pass (was 119; +1 new restricted-shell integration test with 20 assertions)
- [x] Werror-clean
- [x] All restrictions verified manually + via fixture: cd, `/`-cmd, output redirection (>, >>, 2>), input redirection still works, exec rejected, source with `/` rejected, all five protected vars readonly, set +r / set +o restricted rejected, `--restricted` long flag, rc runs before restrictions engage, unrestricted shell unaffected
- [x] CI: Linux build + tests (the cross-platform gate)