### PR TITLE
tests/real_world: ingest 10 bash-completion scripts (+10 corpus)

### DIFF
--- a/tests/real_world/corpus/bash/bash-completion/SOURCES.md
+++ b/tests/real_world/corpus/bash/bash-completion/SOURCES.md
@@ -19,3 +19,13 @@ Generated and maintained by tests/real_world/_harness/ingest.sh.
 | rcs.bash | https://github.com/scop/bash-completion/blob/9b3c713/completions-core/rcs.bash | 9b3c713 |
 | hping2.bash | https://github.com/scop/bash-completion/blob/9b3c713/completions-core/hping2.bash | 9b3c713 |
 | gkrellm.bash | https://github.com/scop/bash-completion/blob/9b3c713/completions-core/gkrellm.bash | 9b3c713 |
+| look.bash | https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/look.bash | ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b |
+| newgrp.bash | https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/newgrp.bash | ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b |
+| eject.bash | https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/eject.bash | ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b |
+| umount.bash | https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/umount.bash | ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b |
+| rmmod.bash | https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/rmmod.bash | ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b |
+| hwclock.bash | https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/hwclock.bash | ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b |
+| insmod.bash | https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/insmod.bash | ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b |
+| acpi.bash | https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-core/acpi.bash | ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b |
+| a2x.bash | https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-core/a2x.bash | ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b |
+| aspell.bash | https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-core/aspell.bash | ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b |

--- a/tests/real_world/corpus/bash/bash-completion/a2x.bash
+++ b/tests/real_world/corpus/bash/bash-completion/a2x.bash
@@ -1,0 +1,51 @@
+# ============================================================================
+# Corpus entry (ingested via tests/real_world/_harness)
+# ============================================================================
+# SOURCE:           https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-core/a2x.bash
+# UPSTREAM-COMMIT:  ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b
+# UPSTREAM-SET:     bash-completion
+# LICENSE:          GPL-2.0-or-later
+# BUCKET:           bash
+# ADAPTED:          2026-05-31
+# ============================================================================
+# a2x(1) completion                                        -*- shell-script -*-
+
+_comp_cmd_a2x()
+{
+    local cur prev words cword was_split comp_args
+    _comp_initialize -s -- "$@" || return
+
+    local noargopts='!(-*|*[aDd]*)'
+    # shellcheck disable=SC2254
+    case $prev in
+        --attribute | --asciidoc-opts | --dblatex-opts | --fop-opts | --help | \
+            --version | --xsltproc-opts | -${noargopts}[ah])
+            return
+            ;;
+        --destination-dir | --icons-dir | -${noargopts}D)
+            _comp_compgen_filedir -d
+            return
+            ;;
+        --doctype | -${noargopts}d)
+            _comp_compgen -x asciidoc doctype
+            return
+            ;;
+        --stylesheet)
+            _comp_compgen_filedir css
+            return
+            ;;
+    esac
+
+    [[ $was_split ]] && return
+
+    if [[ $cur == -* ]]; then
+        _comp_compgen_help
+        [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
+        return
+    fi
+
+    _comp_compgen_filedir
+} &&
+    complete -F _comp_cmd_a2x a2x
+
+# ex: filetype=sh

--- a/tests/real_world/corpus/bash/bash-completion/acpi.bash
+++ b/tests/real_world/corpus/bash/bash-completion/acpi.bash
@@ -1,0 +1,34 @@
+# ============================================================================
+# Corpus entry (ingested via tests/real_world/_harness)
+# ============================================================================
+# SOURCE:           https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-core/acpi.bash
+# UPSTREAM-COMMIT:  ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b
+# UPSTREAM-SET:     bash-completion
+# LICENSE:          GPL-2.0-or-later
+# BUCKET:           bash
+# ADAPTED:          2026-05-31
+# ============================================================================
+# acpi(1) completion                                       -*- shell-script -*-
+
+_comp_cmd_acpi()
+{
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
+
+    local noargopts='!(-*|*[d]*)'
+    # shellcheck disable=SC2254
+    case $prev in
+        --help | --version | -${noargopts}[hv])
+            return
+            ;;
+        --directory | -${noargopts}d)
+            _comp_compgen_filedir -d
+            return
+            ;;
+    esac
+
+    _comp_compgen_help
+} &&
+    complete -F _comp_cmd_acpi acpi
+
+# ex: filetype=sh

--- a/tests/real_world/corpus/bash/bash-completion/aspell.bash
+++ b/tests/real_world/corpus/bash/bash-completion/aspell.bash
@@ -1,0 +1,99 @@
+# ============================================================================
+# Corpus entry (ingested via tests/real_world/_harness)
+# ============================================================================
+# SOURCE:           https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-core/aspell.bash
+# UPSTREAM-COMMIT:  ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b
+# UPSTREAM-SET:     bash-completion
+# LICENSE:          GPL-2.0-or-later
+# BUCKET:           bash
+# ADAPTED:          2026-05-31
+# ============================================================================
+# bash completion for aspell                               -*- shell-script -*-
+
+_comp_cmd_aspell__dictionary()
+{
+    local datadir aspell=$1
+    datadir=$("$aspell" config data-dir 2>/dev/null || echo /usr/lib/aspell)
+    # First, get aliases (dicts dump does not list them)
+    if _comp_expand_glob COMPREPLY '"$datadir"/*.alias'; then
+        COMPREPLY=("${COMPREPLY[@]%.alias}")
+        COMPREPLY=("${COMPREPLY[@]#$datadir/}")
+    fi
+    # Then, add the canonical dicts
+    _comp_split -a COMPREPLY "$("$aspell" dicts 2>/dev/null)"
+    ((${#COMPREPLY[@]})) &&
+        _comp_compgen -- -X '\*' -W '"${COMPREPLY[@]}"'
+}
+
+_comp_cmd_aspell()
+{
+    local cur prev words cword was_split comp_args
+    _comp_initialize -s -- "$@" || return
+
+    case $prev in
+        -c | -p | check | --conf | --personal | --repl | --per-conf)
+            _comp_compgen_filedir
+            return
+            ;;
+        --conf-dir | --data-dir | --dict-dir | --home-dir | --local-data-dir | --prefix)
+            _comp_compgen_filedir -d
+            return
+            ;;
+        dump | create | merge)
+            _comp_compgen -- -W 'master personal repl'
+            return
+            ;;
+        --mode)
+            _comp_compgen_split -- "$("$1" modes 2>/dev/null |
+                _comp_awk '{ print $1 }')"
+            return
+            ;;
+        --sug-mode)
+            _comp_compgen -- -W 'ultra fast normal bad-speller'
+            return
+            ;;
+        --keymapping)
+            _comp_compgen -- -W 'aspell ispell'
+            return
+            ;;
+        -d | --master)
+            _comp_cmd_aspell__dictionary "$1"
+            return
+            ;;
+        --add-filter | --rem-filter)
+            _comp_compgen_split -- "$("$1" filters 2>/dev/null |
+                _comp_awk '{ print $1 }')"
+            return
+            ;;
+    esac
+
+    [[ $was_split ]] && return
+
+    if [[ $cur == -* ]]; then
+        _comp_compgen -- -W '--conf= --conf-dir= --data-dir= --dict-dir=
+            --encoding= --add-filter= --rem-filter= --mode= --add-extra-dicts=
+            --rem-extra-dicts= --home-dir= --ignore= --ignore-accents
+            --dont-ignore-accents --ignore-case --dont-ignore-case
+            --ignore-repl --dont-ignore-repl --jargon --keyboard= --lang=
+            --language-tag --local-data-dir= --master= --module
+            --add-module-search-order --rem-module-search-order --per-conf=
+            --personal= --prefix= --repl= --run-together --dont-run-together
+            --run-together-limit= --run-together-min= --save-repl
+            --dont-save-repl --set-prefix --dont-set-prefix --size= --spelling
+            --strip-accents --dont-strip-accents --sug-mode=
+            --add-word-list-path --rem-word-list-path --backup --dont-backup
+            --reverse --dont-reverse --time --dont-time --keymapping=
+            --add-email-quote= --rem-email-quote= --email-margin=
+            --add-tex-command= --rem-tex-command= --tex-check-comments
+            --dont-tex-check-comments --add-tex-extension --rem-tex-extension
+            --add-sgml-check= --rem-sgml-check= --add-sgml-extension
+            --rem-sgml-extension'
+        [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
+    else
+        _comp_compgen -- -W 'usage help check pipe list config soundslike
+            filter version dump create merge'
+    fi
+} &&
+    complete -F _comp_cmd_aspell aspell
+
+# ex: filetype=sh

--- a/tests/real_world/corpus/bash/bash-completion/eject.bash
+++ b/tests/real_world/corpus/bash/bash-completion/eject.bash
@@ -1,0 +1,43 @@
+# ============================================================================
+# Corpus entry (ingested via tests/real_world/_harness)
+# ============================================================================
+# SOURCE:           https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/eject.bash
+# UPSTREAM-COMMIT:  ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b
+# UPSTREAM-SET:     bash-completion
+# LICENSE:          GPL-2.0-or-later
+# BUCKET:           bash
+# ADAPTED:          2026-05-31
+# ============================================================================
+# bash completion for eject(1)                             -*- shell-script -*-
+
+# Use of this file is deprecated on Linux.  Upstream completion is
+# available in util-linux >= 2.23, use that instead.
+
+_comp_cmd_eject()
+{
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
+
+    case $prev in
+        -h | --help | -V | --version | -c | --changerslot | -x | --cdspeed)
+            return
+            ;;
+        -a | --auto | -i | --manualeject)
+            _comp_compgen -- -W 'on off'
+            return
+            ;;
+    esac
+
+    if [[ $cur == -* ]]; then
+        _comp_compgen_help
+        return
+    elif [[ $prev == @(-d|--default) ]]; then
+        return
+    fi
+
+    _comp_compgen_cd_devices
+    _comp_compgen -a dvd_devices
+} &&
+    complete -F _comp_cmd_eject eject
+
+# ex: filetype=sh

--- a/tests/real_world/corpus/bash/bash-completion/hwclock.bash
+++ b/tests/real_world/corpus/bash/bash-completion/hwclock.bash
@@ -1,0 +1,36 @@
+# ============================================================================
+# Corpus entry (ingested via tests/real_world/_harness)
+# ============================================================================
+# SOURCE:           https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/hwclock.bash
+# UPSTREAM-COMMIT:  ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b
+# UPSTREAM-SET:     bash-completion
+# LICENSE:          GPL-2.0-or-later
+# BUCKET:           bash
+# ADAPTED:          2026-05-31
+# ============================================================================
+# hwclock(8) completion                                    -*- shell-script -*-
+
+# Use of this file is deprecated.  Upstream completion is available in
+# util-linux >= 2.23, use that instead.
+
+_comp_cmd_hwclock()
+{
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
+
+    case $prev in
+        -h | --help | -V | --version | --date | --epoch)
+            return
+            ;;
+        -f | --rtc | --adjfile)
+            _comp_compgen_filedir
+            return
+            ;;
+    esac
+
+    local PATH=$PATH:/sbin
+    _comp_compgen_help
+} &&
+    complete -F _comp_cmd_hwclock hwclock
+
+# ex: filetype=sh

--- a/tests/real_world/corpus/bash/bash-completion/insmod.bash
+++ b/tests/real_world/corpus/bash/bash-completion/insmod.bash
@@ -1,0 +1,31 @@
+# ============================================================================
+# Corpus entry (ingested via tests/real_world/_harness)
+# ============================================================================
+# SOURCE:           https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/insmod.bash
+# UPSTREAM-COMMIT:  ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b
+# UPSTREAM-SET:     bash-completion
+# LICENSE:          GPL-2.0-or-later
+# BUCKET:           bash
+# ADAPTED:          2026-05-31
+# ============================================================================
+# Linux insmod(8) completion                               -*- shell-script -*-
+
+# Use of this file is deprecated.
+# Upstream completion is available in kmod >= 34, use that instead.
+
+_comp_cmd_insmod()
+{
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
+
+    # do filename completion for first argument
+    if ((cword == 1)); then
+        _comp_compgen_filedir '@(?(k)o?(.[gx]z|.zst))'
+    else # do module parameter completion
+        _comp_compgen_split -- "$(PATH="$PATH:/sbin" modinfo \
+            -p "${words[1]}" 2>/dev/null | cut -d: -f1)"
+    fi
+} &&
+    complete -F _comp_cmd_insmod insmod insmod.static
+
+# ex: filetype=sh

--- a/tests/real_world/corpus/bash/bash-completion/look.bash
+++ b/tests/real_world/corpus/bash/bash-completion/look.bash
@@ -1,0 +1,27 @@
+# ============================================================================
+# Corpus entry (ingested via tests/real_world/_harness)
+# ============================================================================
+# SOURCE:           https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/look.bash
+# UPSTREAM-COMMIT:  ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b
+# UPSTREAM-SET:     bash-completion
+# LICENSE:          GPL-2.0-or-later
+# BUCKET:           bash
+# ADAPTED:          2026-05-31
+# ============================================================================
+# look(1) completion                                       -*- shell-script -*-
+
+# Use of this file is deprecated on Linux.  Upstream completion is
+# available in util-linux >= 2.23, use that instead.
+
+_comp_cmd_look()
+{
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
+
+    if ((cword == 1)); then
+        _comp_compgen_split -- "$(look "$cur" 2>/dev/null)"
+    fi
+} &&
+    complete -F _comp_cmd_look -o default look
+
+# ex: filetype=sh

--- a/tests/real_world/corpus/bash/bash-completion/newgrp.bash
+++ b/tests/real_world/corpus/bash/bash-completion/newgrp.bash
@@ -1,0 +1,29 @@
+# ============================================================================
+# Corpus entry (ingested via tests/real_world/_harness)
+# ============================================================================
+# SOURCE:           https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/newgrp.bash
+# UPSTREAM-COMMIT:  ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b
+# UPSTREAM-SET:     bash-completion
+# LICENSE:          GPL-2.0-or-later
+# BUCKET:           bash
+# ADAPTED:          2026-05-31
+# ============================================================================
+# newgrp(1) completion                                     -*- shell-script -*-
+
+# Use of this file is deprecated on Linux.  Upstream completion is
+# available in util-linux >= 2.23, use that instead.
+
+_comp_cmd_newgrp()
+{
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
+
+    if [[ $cur == "-" ]]; then
+        COMPREPLY=(-)
+    else
+        _comp_compgen_allowed_groups
+    fi
+} &&
+    complete -F _comp_cmd_newgrp newgrp
+
+# ex: filetype=sh

--- a/tests/real_world/corpus/bash/bash-completion/rmmod.bash
+++ b/tests/real_world/corpus/bash/bash-completion/rmmod.bash
@@ -1,0 +1,37 @@
+# ============================================================================
+# Corpus entry (ingested via tests/real_world/_harness)
+# ============================================================================
+# SOURCE:           https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/rmmod.bash
+# UPSTREAM-COMMIT:  ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b
+# UPSTREAM-SET:     bash-completion
+# LICENSE:          GPL-2.0-or-later
+# BUCKET:           bash
+# ADAPTED:          2026-05-31
+# ============================================================================
+# Linux rmmod(8) completion.                               -*- shell-script -*-
+# This completes on a list of all currently installed kernel modules.
+
+# Use of this file is deprecated.
+# Upstream completion is available in kmod >= 34, use that instead.
+
+_comp_cmd_rmmod()
+{
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
+
+    case $prev in
+        -h | --help | -V | --version)
+            return
+            ;;
+    esac
+
+    if [[ $cur == -* ]]; then
+        _comp_compgen_help
+        return
+    fi
+
+    _comp_compgen_inserted_kernel_modules
+} &&
+    complete -F _comp_cmd_rmmod rmmod
+
+# ex: filetype=sh

--- a/tests/real_world/corpus/bash/bash-completion/umount.bash
+++ b/tests/real_world/corpus/bash/bash-completion/umount.bash
@@ -1,0 +1,33 @@
+# ============================================================================
+# Corpus entry (ingested via tests/real_world/_harness)
+# ============================================================================
+# SOURCE:           https://github.com/scop/bash-completion/blob/ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b/completions-fallback/umount.bash
+# UPSTREAM-COMMIT:  ef936aaf7b8968be0bdf71027d07e1c15bbe8a4b
+# UPSTREAM-SET:     bash-completion
+# LICENSE:          GPL-2.0-or-later
+# BUCKET:           bash
+# ADAPTED:          2026-05-31
+# ============================================================================
+# umount(8) completion                                     -*- shell-script -*-
+
+# Use of this file is deprecated on Linux.  Upstream completion is
+# available in util-linux >= 2.28, use that instead.
+
+if [[ $OSTYPE == *linux* ]]; then
+    . "${BASH_SOURCE%.bash}.linux.bash"
+    return
+fi
+
+# umount(8) completion. This relies on the mount point being the third
+# space-delimited field in the output of mount(8)
+#
+_comp_cmd_umount()
+{
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
+
+    _comp_compgen_split -l -- "$(mount | cut -d" " -f 3)"
+} &&
+    complete -F _comp_cmd_umount -o dirnames umount
+
+# ex: filetype=sh


### PR DESCRIPTION
## Summary
First corpus-expansion batch of the post-login-shell-audit arc. The ingest harness in `tests/real_world/_harness/` had been built for exactly this but only used twice before; this PR picks the expansion back up.

Ingested from [scop/bash-completion@ef936aa](https://github.com/scop/bash-completion/tree/ef936aa) (GPL-2.0-or-later):

- **completions-fallback/** (small util completions, 17-33 lines): `look`, `newgrp`, `eject`, `umount`, `rmmod`, `hwclock`, `insmod`
- **completions-core/** (medium completions, 24-89 lines): `acpi`, `a2x`, `aspell`

Each passed scan, hermeticize, header-template, and the oracle determinism check. Pre-flight parity verified byte-identical stdout between bash and lush. One candidate (`arch.bash`) was skipped — both shells fail on the same missing helper but with different error-block formatting; that's an error-shape divergence not a behavioral one.

## Scorecard delta
- Was: 59 scripts, 100% pass, 0 divergences
- Now: 68 scripts, 100% pass, 0 divergences

Target remains 400+ across all four buckets (posix/bash/zsh/lush). No source code changes — corpus-only expansion.

## Test plan
- [x] Local: `meson test "real-world scorecard"` passes (68/68)
- [x] Each script passes the harness's oracle dry-run (determinism check)
- [x] CI: scorecard test runs on Linux + macOS