### PR TITLE
executor: strip @/% sigils in typed-fn call args (Fixes #207)

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -18964,15 +18964,22 @@ static int eval_fn_call_argument(executor_t *executor, node_t *arg,
         return out->scalar_value ? 0 : 1;
     }
 
-    /// NODE_VAR carries a bare $name (or ${name}) reference. Strip the
-    /// leading '$' / '${...}' to get the variable name and look it up
-    /// kind-aware via symtable_lookup. A list or map binding crosses
-    /// the call boundary as-is, preserving its kind tag for the
-    /// parameter-bind step rather than being flattened to a string.
+    /// NODE_VAR carries a variable reference -- either a bare $name
+    /// / ${name} or a kind-sigil form @name / %name (when
+    /// FEATURE_KIND_SIGILS is on; see docs/features/typed-functions.md
+    /// for the call-site sigil discipline). Strip whichever prefix is
+    /// present and look the underlying name up kind-aware. The
+    /// returned view preserves the symtable's actual kind tag, so a
+    /// list or map binding crosses the call boundary as-is rather
+    /// than being flattened to a string. Issue #207: failing to
+    /// strip @/% meant `elements(@arr)` looked up the literal name
+    /// `@arr`, missed, and reported the arg as an empty scalar --
+    /// triggering an E1133 against the declared list kind on the
+    /// docs' own example.
     if (arg->type == NODE_VAR) {
         const char *var_name = text;
         char name_buf[256];
-        if (var_name[0] == '$') {
+        if (var_name[0] == '$' || var_name[0] == '@' || var_name[0] == '%') {
             var_name++;
         }
         if (var_name[0] == '{') {

--- a/tests/real_world/curated/lush/404_typed_function_basics.sh
+++ b/tests/real_world/curated/lush/404_typed_function_basics.sh
@@ -36,18 +36,35 @@ fn from_typed(n: scalar) -> scalar {
 let chained = from_typed("7")
 echo "chained: $chained"
 
-# Kind-mismatch detection: passing the literal "5" (scalar) to a
-# function expecting scalar succeeds; this just exercises the
-# call-site type check on a happy path. The negative case
-# (passing a list where scalar is expected) is exercised by
-# the kind-sigil test below.
+# Kind-mismatch detection on the happy path: scalar in, scalar out.
 fn echo_n(n: scalar) -> scalar {
     return "$n"
 }
 let e = echo_n("hello")
 echo "echo-n: $e"
 
-# TODO: list-kinded args via the @sigil are documented in
-# docs/features/typed-functions.md but currently report E1133 even
-# on the doc's own example `elements(@arr)`. Excluded from this
-# fixture pending the parity fix; tracked as issue #207.
+# List-kinded args via the @sigil. The call-site sigil resolves the
+# named binding kind-aware, preserving the list kind across the call
+# boundary so the typed-function body sees `values` as a list.
+fn count_items(values: list) -> scalar {
+    return "${#values[@]}"
+}
+arr=(apple banana cherry date)
+let n = count_items(@arr)
+echo "count-items: $n"
+
+fn first_item(values: list) -> scalar {
+    return "${values[0]}"
+}
+let f = first_item(@arr)
+echo "first-item: $f"
+
+# Map-kinded args via the %sigil.
+fn map_size(m: map) -> scalar {
+    return "${#m[@]}"
+}
+declare -A config
+config[shell]="lush"
+config[mode]="polyglot"
+let sz = map_size(%config)
+echo "map-size: $sz"


### PR DESCRIPTION
## Summary
Trivial one-line fix to `eval_fn_call_argument` in `src/executor.c`. The prefix-strip for NODE_VAR text only stripped `$`; extending it to accept `@` (list sigil) and `%` (map sigil) makes the typed-functions docs' own example work as documented.

## Repro (was failing, now passes)
\`\`\`lush
fn elements(values: list) -> scalar {
    return "\${#values[@]}"
}
arr=(a b c d)
let n = elements(@arr)
echo "n: \$n"   # was: error[E1133]; now: 4
\`\`\`

## Test plan
- [x] Local: 120/120 meson tests pass
- [x] Scorecard: 129/129 / 100% / 0 unexpected (unchanged — this was a docs-example failure not a corpus divergence)
- [x] `tests/real_world/curated/lush/404_typed_function_basics.sh` updated: the TODO comment marking list-arg as broken is gone; three positive-case tests now exercise `@`/`%` sigils end-to-end
- [x] Both `@arr` (list) and `%map` (associative) verified

Fixes #207