### PR TITLE
compdef LLE bridge: invoke bound functions on TAB

### DIFF
--- a/include/compdef_source.h
+++ b/include/compdef_source.h
@@ -1,0 +1,36 @@
+/**
+ * @file compdef_source.h
+ * @brief Registration of the compdef-binding LLE completion source.
+ *
+ * compdef_source_init() registers a custom completion source with the
+ * LLE source manager. The source's is_applicable callback consults the
+ * compdef bindings table (compdef_lookup); when a binding exists for
+ * the current word context's command_name, the source's generate
+ * callback sets executor->active_comp_result, invokes the bound shell
+ * function in-process via executor_run_function (which sets up
+ * positional params $1=cmd, $2=current_word, $3=previous_word),
+ * restores active_comp_result, and returns. Candidates are
+ * accumulated into the result via compadd, which appends through
+ * completion_bridge_add while the function runs.
+ *
+ * Call once at shell startup AFTER lle_editor_create has run so the
+ * source manager exists, AND AFTER init_compdef_bindings so the
+ * bindings table is ready.
+ *
+ * @author Michael Berry <trismegustis@gmail.com>
+ * @copyright Copyright (C) 2021-2026 Michael Berry
+ */
+
+#ifndef LUSH_COMPDEF_SOURCE_H
+#define LUSH_COMPDEF_SOURCE_H
+
+/**
+ * @brief Register the compdef completion source with the LLE engine.
+ *
+ * Idempotent. Safe to call multiple times; the underlying
+ * lle_completion_register_source is responsible for rejecting duplicate
+ * registrations of the same source name.
+ */
+void compdef_source_init(void);
+
+#endif /* LUSH_COMPDEF_SOURCE_H */

--- a/include/executor.h
+++ b/include/executor.h
@@ -658,6 +658,30 @@ int executor_call_hook(executor_t *executor, const char *hook_name,
                        const char *arg);
 
 /**
+ * @brief Invoke a user-defined shell function in-process with positional args.
+ *
+ * Thin public wrapper around the internal execute_function_call. Looks up
+ * `fn_name` in the function table, pushes a function scope, binds
+ * argv[1..argc-1] as $1..$N within that scope, runs the body, and pops
+ * the scope on return. argv[0] is conventionally the function name.
+ *
+ * Used by the compdef LLE completion source to invoke a compdef-bound
+ * shell function while executor->active_comp_result is set so the
+ * function's `compadd` calls populate the active accumulator.
+ *
+ * @param executor Executor context (must be non-NULL).
+ * @param fn_name Function name to look up.
+ * @param argc Argument count.
+ * @param argv Argument vector; argv[0] is the function name.
+ * @return Function exit status, or non-zero on lookup / scope failure.
+ *         Returns 0 silently if no function named fn_name is defined,
+ *         matching the autoload-style philosophy of compdef: a binding
+ *         to an undefined function is not itself an error.
+ */
+int executor_run_function(executor_t *executor, const char *fn_name, int argc,
+                          char **argv);
+
+/**
  * @brief Call precmd hook (before prompt display)
  *
  * @param executor Executor context

--- a/meson.build
+++ b/meson.build
@@ -190,6 +190,7 @@ src = ['src/arithmetic.c',
        'src/brace_match.c',
        'src/identifier.c',
        'src/completion_bridge.c',
+       'src/compdef_source.c',
        'src/posix_history.c',
        'src/posix_opts.c',
        'src/redirection.c',
@@ -2273,6 +2274,25 @@ if fs.exists('tests/unit/test_compdef.c')
                             include_directories: [inc, include_directories('tests')],
                             dependencies: [lle_dep, libm])
   test('Compdef + Compadd', test_compdef,
+       suite: 'unit',
+       timeout: 30)
+endif
+
+# Compdef LLE source tests
+if fs.exists('tests/unit/test_compdef_source.c')
+  test_compdef_source_sources = []
+  foreach s : src
+    if not s.endswith('lush.c')
+      test_compdef_source_sources += s
+    endif
+  endforeach
+  test_compdef_source = executable('test_compdef_source',
+                                    'tests/unit/test_compdef_source.c',
+                                    'tests/unit/test_executor_stubs.c',
+                                    test_compdef_source_sources + lle_shell_sources,
+                                    include_directories: [inc, include_directories('tests')],
+                                    dependencies: [lle_dep, libm])
+  test('Compdef LLE Source', test_compdef_source,
        suite: 'unit',
        timeout: 30)
 endif

--- a/src/compdef_source.c
+++ b/src/compdef_source.c
@@ -1,0 +1,110 @@
+/**
+ * @file compdef_source.c
+ * @brief LLE completion source that fires compdef-bound functions on TAB.
+ *
+ * Registers a custom completion source via lle_completion_register_source.
+ * On each TAB:
+ *   - is_applicable() returns true iff compdef_lookup(command_name) yields
+ *     a function name (i.e. the user has run `compdef FN CMD` for the
+ *     command at the cursor).
+ *   - generate() saves the executor's prior active_comp_result, sets it
+ *     to the result the engine is filling, builds argv (function name,
+ *     command name, current-word prefix, previous word), invokes the
+ *     function in-process via executor_run_function, and restores the
+ *     prior active_comp_result. The function emits candidates by
+ *     calling `compadd`, which appends through completion_bridge_add
+ *     into the active accumulator.
+ *
+ * Lives on the shell side (src/, not src/lle/) because the generate
+ * callback calls executor_run_function and reads/writes
+ * executor->active_comp_result. The source is registered with liblle by
+ * function pointer; no weak/strong bridge symbols are required because
+ * the pointer itself transfers control across the boundary.
+ *
+ * @author Michael Berry <trismegustis@gmail.com>
+ * @copyright Copyright (C) 2021-2026 Michael Berry
+ */
+
+#include "compdef_source.h"
+
+#include "compdef.h"
+#include "executor.h"
+#include "lle/completion/custom_source.h"
+#include "lle/completion/word_context.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+extern executor_t *current_executor;
+
+bool compdef_source_applicable(void *user_data,
+                               const lle_word_context_t *context) {
+    (void)user_data;
+    if (!context || !context->command_name) {
+        return false;
+    }
+    return compdef_lookup(context->command_name) != NULL;
+}
+
+lle_result_t compdef_source_generate(void *user_data,
+                                     const lle_word_context_t *context,
+                                     lle_completion_result_t *result) {
+    (void)user_data;
+    if (!context || !result) {
+        return LLE_SUCCESS;
+    }
+    if (!current_executor) {
+        return LLE_SUCCESS;
+    }
+    const char *fn = compdef_lookup(context->command_name);
+    if (!fn) {
+        return LLE_SUCCESS;
+    }
+
+    /// argv layout follows bash-completion convention:
+    ///   $1 = command name being completed
+    ///   $2 = current word prefix (what the user has typed for the word
+    ///        the cursor is on; we use dequoted_filename_prefix when it
+    ///        is set, falling back to the empty string)
+    ///   $3 = previous fully-completed word (or empty at command position)
+    char *cmd = (char *)context->command_name;
+    char *cur = (char *)(context->dequoted_filename_prefix
+                             ? context->dequoted_filename_prefix
+                             : "");
+    char *prev = "";
+    if (context->arguments && context->argument_count > 0 &&
+        context->arguments[context->argument_count - 1]) {
+        prev = context->arguments[context->argument_count - 1];
+    }
+    char *argv[] = {(char *)fn, cmd, cur, prev};
+    int argc = 4;
+
+    /// Snapshot the executor pointer BEFORE running the function:
+    /// execute_builtin_command (inside the function body's compadd
+    /// call) sets `current_executor` to its executor argument and then
+    /// clears it back to NULL on return, so after executor_run_function
+    /// returns the global is NULL even though our stack-local executor
+    /// is still valid. Use the stack-local for the active_comp_result
+    /// push/pop so the restore doesn't dereference NULL.
+    executor_t *exec = current_executor;
+    void *prior = exec->active_comp_result;
+    exec->active_comp_result = result;
+    (void)executor_run_function(exec, fn, argc, argv);
+    exec->active_comp_result = prior;
+    return LLE_SUCCESS;
+}
+
+void compdef_source_init(void) {
+    lle_custom_completion_source_t source = {
+        .name = "compdef",
+        .description = "compdef-bound user functions",
+        .priority = 750, /// above generic file/command (default 500),
+                         /// below built-in arg-specs (which know their
+                         /// command shape exactly)
+        .generate = compdef_source_generate,
+        .is_applicable = compdef_source_applicable,
+        .cleanup = NULL,
+        .user_data = NULL,
+    };
+    (void)lle_completion_register_source(&source);
+}

--- a/src/executor.c
+++ b/src/executor.c
@@ -18583,6 +18583,28 @@ int executor_call_hook(executor_t *executor, const char *hook_name,
     return result;
 }
 
+int executor_run_function(executor_t *executor, const char *fn_name, int argc,
+                          char **argv) {
+    if (!executor || !fn_name || argc < 1 || !argv) {
+        return 0;
+    }
+    /// Autoload-style semantics: an undefined function silently
+    /// produces no effect, matching how compdef bindings reference
+    /// function names that may be loaded later (or never).
+    if (!find_function(executor, fn_name)) {
+        return 0;
+    }
+    int result = execute_function_call(executor, fn_name, argv, argc,
+                                       SOURCE_LOC_UNKNOWN);
+    /// Mirror executor_call_hook's translation of the internal
+    /// return-signal range so a `return N` from the function surfaces
+    /// the user's intended exit code, not the encoded signal.
+    if (result >= 200 && result <= 455) {
+        result = result - 200;
+    }
+    return result;
+}
+
 /**
  * @brief Call precmd hook (before prompt display)
  *

--- a/src/init.c
+++ b/src/init.c
@@ -21,6 +21,7 @@
 #include "builtins.h"
 #include "compat.h"
 #include "compdef.h"
+#include "compdef_source.h"
 #include "config.h"
 #include "dirstack.h"
 #include "errors.h"
@@ -936,6 +937,13 @@ int init(int argc, char **argv, FILE **in) {
 
     /// Initialize compdef bindings table
     init_compdef_bindings();
+
+    /// Register the compdef LLE completion source. Requires the LLE
+    /// source manager to exist (created by lle_shell_integration_init
+    /// above). When LLE initialization failed earlier the registration
+    /// call is a no-op inside liblle; we still call it unconditionally
+    /// to keep the init sequence linear.
+    compdef_source_init();
 
     /// Initialize command hash table
     init_command_hash();

--- a/tests/unit/test_compdef_source.c
+++ b/tests/unit/test_compdef_source.c
@@ -1,0 +1,262 @@
+/**
+ * @file test_compdef_source.c
+ * @brief Tests for the LLE compdef-binding completion source.
+ *
+ * Covers:
+ *   - compdef_source_applicable: false with no executor, false with no
+ *     binding, true with a binding for the current command_name
+ *   - compdef_source_generate: silent no-op when no executor / no
+ *     binding / undefined function; honors push/pop discipline of
+ *     active_comp_result; invokes a real shell function and surfaces
+ *     the candidates emitted by compadd
+ *
+ * Tests construct a real executor and define real shell functions via
+ * executor_execute_command_line so the function-invocation path is
+ * exercised end-to-end. The active_comp_result accumulator is a real
+ * lle_completion_result_t built with the standard LLE memory pool
+ * sentinel ((lle_memory_pool_t *)1) per the project pattern.
+ *
+ * @author Michael Berry <trismegustis@gmail.com>
+ * @copyright Copyright (C) 2021-2026 Michael Berry
+ */
+
+#include "compdef.h"
+#include "executor.h"
+#include "lle/completion/completion_types.h"
+#include "lle/completion/word_context.h"
+#include "test_framework.h"
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern void init_symtable(void);
+
+#undef ASSERT
+#define ASSERT(cond, msg) ASSERT_TRUE(cond, msg)
+
+/* compdef_source.c exposes these via external linkage; declared here
+ * directly rather than added to compdef_source.h to keep the public
+ * header narrow (the production caller only ever uses
+ * compdef_source_init). */
+bool compdef_source_applicable(void *user_data,
+                               const struct lle_word_context *context);
+lle_result_t compdef_source_generate(void *user_data,
+                                     const struct lle_word_context *context,
+                                     lle_completion_result_t *result);
+
+static lle_memory_pool_t *test_pool = (lle_memory_pool_t *)1;
+static executor_t *test_exec = NULL;
+static lle_completion_result_t *test_result = NULL;
+
+static void setup_env(void) {
+    init_compdef_bindings();
+    test_exec = executor_new();
+    current_executor = test_exec;
+    lle_completion_result_create(test_pool, 16, &test_result);
+}
+
+static void teardown_env(void) {
+    if (test_result) {
+        lle_completion_result_free(test_result);
+        test_result = NULL;
+    }
+    current_executor = NULL;
+    if (test_exec) {
+        executor_free(test_exec);
+        test_exec = NULL;
+    }
+    free_compdef_bindings();
+}
+
+static void make_context(lle_word_context_t *ctx, const char *cmd,
+                         const char *cur_prefix) {
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->command_name = (char *)cmd;
+    ctx->dequoted_filename_prefix = (char *)cur_prefix;
+    ctx->arg_index = 1;
+}
+
+static int find_candidate(const char *text) {
+    if (!test_result) {
+        return -1;
+    }
+    for (size_t i = 0; i < test_result->count; i++) {
+        if (test_result->items[i].text &&
+            strcmp(test_result->items[i].text, text) == 0) {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
+/* ============================================================================
+ * compdef_source_applicable
+ * ============================================================================
+ */
+
+TEST(applicable_returns_false_with_null_context) {
+    setup_env();
+    ASSERT_FALSE(compdef_source_applicable(NULL, NULL),
+                 "NULL context is never applicable");
+    teardown_env();
+}
+
+TEST(applicable_returns_false_with_null_command_name) {
+    setup_env();
+    lle_word_context_t ctx;
+    make_context(&ctx, NULL, NULL);
+    ASSERT_FALSE(compdef_source_applicable(NULL, &ctx),
+                 "context without a command_name is not applicable");
+    teardown_env();
+}
+
+TEST(applicable_returns_false_when_no_binding) {
+    setup_env();
+    lle_word_context_t ctx;
+    make_context(&ctx, "uncoveted", "");
+    ASSERT_FALSE(compdef_source_applicable(NULL, &ctx),
+                 "command with no compdef binding is not applicable");
+    teardown_env();
+}
+
+TEST(applicable_returns_true_when_binding_exists) {
+    setup_env();
+    compdef_set("git", "_git");
+    lle_word_context_t ctx;
+    make_context(&ctx, "git", "che");
+    ASSERT_TRUE(compdef_source_applicable(NULL, &ctx),
+                "command with a compdef binding is applicable");
+    teardown_env();
+}
+
+/* ============================================================================
+ * compdef_source_generate
+ * ============================================================================
+ */
+
+TEST(generate_no_executor_returns_success_silently) {
+    setup_env();
+    executor_t *saved = current_executor;
+    current_executor = NULL;
+    lle_word_context_t ctx;
+    make_context(&ctx, "git", "");
+    lle_result_t r = compdef_source_generate(NULL, &ctx, test_result);
+    ASSERT_TRUE(r == LLE_SUCCESS,
+                "generate with no current_executor returns LLE_SUCCESS");
+    ASSERT_EQ(test_result->count, 0u, "no candidates accumulated");
+    current_executor = saved;
+    teardown_env();
+}
+
+TEST(generate_no_binding_returns_success_silently) {
+    setup_env();
+    lle_word_context_t ctx;
+    make_context(&ctx, "git", "");
+    lle_result_t r = compdef_source_generate(NULL, &ctx, test_result);
+    ASSERT_TRUE(r == LLE_SUCCESS,
+                "generate with no binding returns LLE_SUCCESS");
+    ASSERT_EQ(test_result->count, 0u, "no candidates accumulated");
+    teardown_env();
+}
+
+TEST(generate_undefined_function_returns_success_silently) {
+    setup_env();
+    /// Binding exists but the function has never been defined. This
+    /// is the autoload-style use case: register early, define later.
+    compdef_set("git", "_git_never_defined");
+    lle_word_context_t ctx;
+    make_context(&ctx, "git", "");
+    lle_result_t r = compdef_source_generate(NULL, &ctx, test_result);
+    ASSERT_TRUE(r == LLE_SUCCESS,
+                "generate with undefined function returns LLE_SUCCESS");
+    ASSERT_EQ(test_result->count, 0u, "no candidates accumulated");
+    teardown_env();
+}
+
+TEST(generate_runs_function_and_surfaces_positional_candidates) {
+    setup_env();
+    executor_execute_command_line(
+        test_exec, "_subs() { compadd checkout branch merge; }", 1);
+    compdef_set("git", "_subs");
+
+    lle_word_context_t ctx;
+    make_context(&ctx, "git", "");
+    lle_result_t r = compdef_source_generate(NULL, &ctx, test_result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "generate returns LLE_SUCCESS");
+    ASSERT_EQ(test_result->count, 3u, "three candidates accumulated");
+    ASSERT_TRUE(find_candidate("checkout") >= 0, "checkout candidate present");
+    ASSERT_TRUE(find_candidate("branch") >= 0, "branch candidate present");
+    ASSERT_TRUE(find_candidate("merge") >= 0, "merge candidate present");
+    teardown_env();
+}
+
+TEST(generate_passes_command_and_prefix_via_positional_params) {
+    setup_env();
+    /// The function emits its received positional params as candidates;
+    /// reading them back through the accumulator verifies the argv
+    /// layout (argv[1]=cmd, argv[2]=cur, argv[3]=prev) flows through
+    /// executor_run_function correctly.
+    executor_execute_command_line(test_exec,
+                                  "_echo_args() { compadd \"$1\" \"$2\"; }", 1);
+    compdef_set("git", "_echo_args");
+
+    lle_word_context_t ctx;
+    make_context(&ctx, "git", "che");
+    lle_result_t r = compdef_source_generate(NULL, &ctx, test_result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "generate returns LLE_SUCCESS");
+    ASSERT_EQ(test_result->count, 2u, "two candidates accumulated");
+    ASSERT_TRUE(find_candidate("git") >= 0, "$1 carried the command name");
+    ASSERT_TRUE(find_candidate("che") >= 0, "$2 carried the current prefix");
+    teardown_env();
+}
+
+TEST(generate_restores_active_comp_result) {
+    setup_env();
+    executor_execute_command_line(test_exec, "_noop() { compadd x; }", 1);
+    compdef_set("git", "_noop");
+
+    /// Place a sentinel value in active_comp_result before invocation;
+    /// generate must overwrite during the call and restore on exit.
+    void *sentinel = (void *)0xDEADBEEFul;
+    test_exec->active_comp_result = sentinel;
+
+    lle_word_context_t ctx;
+    make_context(&ctx, "git", "");
+    (void)compdef_source_generate(NULL, &ctx, test_result);
+    ASSERT_TRUE(test_exec->active_comp_result == sentinel,
+                "active_comp_result restored to prior value after the call");
+
+    test_exec->active_comp_result = NULL;
+    teardown_env();
+}
+
+int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
+
+    /// The global symbol table backs executor_new(); without it,
+    /// executor_new returns NULL and the function-invocation tests
+    /// can't proceed. Mirror test_executor.c's main(), which calls
+    /// init_symtable() once before running tests.
+    init_symtable();
+
+    printf("Running compdef-source tests\n");
+    printf("============================\n");
+
+    printf("\nApplicable:\n");
+    RUN_TEST(applicable_returns_false_with_null_context);
+    RUN_TEST(applicable_returns_false_with_null_command_name);
+    RUN_TEST(applicable_returns_false_when_no_binding);
+    RUN_TEST(applicable_returns_true_when_binding_exists);
+
+    printf("\nGenerate:\n");
+    RUN_TEST(generate_no_executor_returns_success_silently);
+    RUN_TEST(generate_no_binding_returns_success_silently);
+    RUN_TEST(generate_undefined_function_returns_success_silently);
+    RUN_TEST(generate_runs_function_and_surfaces_positional_candidates);
+    RUN_TEST(generate_passes_command_and_prefix_via_positional_params);
+    RUN_TEST(generate_restores_active_comp_result);
+
+    return TEST_RESULT();
+}


### PR DESCRIPTION
## Summary

Completes the compdef arc started in #223. Registers a custom LLE
completion source that fires when the user TABs on a command bound via
\`compdef FN CMD\`; the source invokes FN in-process and surfaces the
candidates FN emits via \`compadd\`.

End-to-end pipeline now works:

\`\`\`
_subs() { compadd checkout branch merge; }
compdef _subs git
# user types: git <TAB>
# -> _subs runs, compadd appends, candidates surface
\`\`\`

## Design notes

- **No bridge symbols required.** \`lle_completion_register_source\` takes
  function pointers; the pointer itself transfers control back to
  shell-side code each time liblle dispatches.
- **\`executor_run_function\`** is a new public wrapper around the
  existing static \`execute_function_call\`, with autoload-style
  semantics (undefined function name yields rc=0 silently, not an
  error) to match compdef's register-now-define-later model.
- **Stack-local executor snapshot** in the generate callback works
  around the fact that \`execute_builtin_command\` clears
  \`current_executor\` to NULL on return; restoring \`active_comp_result\`
  on the stack local avoids a NULL-deref.

## Test plan

- [x] 10 new unit tests in \`tests/unit/test_compdef_source.c\` covering
  is_applicable + generate, including autoload (undefined-function) and
  active_comp_result push/pop discipline
- [x] \`meson test -C build\`: 122/122 pass on macOS
- [x] Ubuntu 24.04 clean compile, 0 warnings; test_compdef_source 10/10
- [x] Runtime smoke: \`_subs() { compadd checkout merge; }; compdef _subs git\` runs cleanly

Follows #223 foundation. Tracking: #222 (cmd %map language decision) remains open and orthogonal.