### PR TITLE
compdef LLE bridge: end-to-end integration test + executor-pointer fix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2297,6 +2297,25 @@ if fs.exists('tests/unit/test_compdef_source.c')
        timeout: 30)
 endif
 
+# Compdef end-to-end integration test through full source-manager dispatch
+if fs.exists('tests/integration/test_compdef_e2e.c')
+  test_compdef_e2e_sources = []
+  foreach s : src
+    if not s.endswith('lush.c')
+      test_compdef_e2e_sources += s
+    endif
+  endforeach
+  test_compdef_e2e = executable('test_compdef_e2e',
+                                 'tests/integration/test_compdef_e2e.c',
+                                 'tests/integration/test_compdef_e2e_stubs.c',
+                                 test_compdef_e2e_sources + lle_shell_sources,
+                                 include_directories: [inc, include_directories('tests')],
+                                 dependencies: [lle_dep, libm])
+  test('Compdef End-to-End', test_compdef_e2e,
+       suite: 'integration',
+       timeout: 30)
+endif
+
 # Redirection Tests
 if fs.exists('tests/unit/test_redirection.c')
   test_redirection_sources = []

--- a/src/compdef_source.c
+++ b/src/compdef_source.c
@@ -35,7 +35,12 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-extern executor_t *current_executor;
+/// get_global_executor returns the session-lifetime executor that
+/// outlives any single command invocation. Using current_executor
+/// here would be wrong: execute_builtin_command sets current_executor
+/// at entry and clears it on exit, so it is NULL between commands --
+/// exactly when LLE TAB completion fires.
+extern executor_t *get_global_executor(void);
 
 bool compdef_source_applicable(void *user_data,
                                const lle_word_context_t *context) {
@@ -53,7 +58,8 @@ lle_result_t compdef_source_generate(void *user_data,
     if (!context || !result) {
         return LLE_SUCCESS;
     }
-    if (!current_executor) {
+    executor_t *exec = get_global_executor();
+    if (!exec) {
         return LLE_SUCCESS;
     }
     const char *fn = compdef_lookup(context->command_name);
@@ -79,14 +85,11 @@ lle_result_t compdef_source_generate(void *user_data,
     char *argv[] = {(char *)fn, cmd, cur, prev};
     int argc = 4;
 
-    /// Snapshot the executor pointer BEFORE running the function:
-    /// execute_builtin_command (inside the function body's compadd
-    /// call) sets `current_executor` to its executor argument and then
-    /// clears it back to NULL on return, so after executor_run_function
-    /// returns the global is NULL even though our stack-local executor
-    /// is still valid. Use the stack-local for the active_comp_result
-    /// push/pop so the restore doesn't dereference NULL.
-    executor_t *exec = current_executor;
+    /// Save + restore the session executor's active_comp_result on
+    /// the exec pointer (not on current_executor, which the inner
+    /// compadd's execute_builtin_command path clears to NULL on
+    /// return, so the restore would dereference NULL on a global
+    /// read).
     void *prior = exec->active_comp_result;
     exec->active_comp_result = result;
     (void)executor_run_function(exec, fn, argc, argv);

--- a/tests/integration/test_compdef_e2e.c
+++ b/tests/integration/test_compdef_e2e.c
@@ -1,0 +1,222 @@
+/**
+ * @file test_compdef_e2e.c
+ * @brief End-to-end integration: source-manager dispatch -> compdef-bound
+ *        function -> compadd -> candidate surfaces in the LLE result.
+ *
+ * Tests the full completion pipeline that gets driven on TAB:
+ *
+ *   lle_completion_system_generate(system, "git che", cursor, &result)
+ *     -> lle_word_context_analyze       (figures out command_name, prefix)
+ *     -> lle_source_manager_query       (fans out across registered sources)
+ *     -> compdef source's is_applicable (checks compdef_lookup)
+ *     -> compdef source's generate      (sets active_comp_result, runs fn)
+ *     -> bin_compadd                    (appends via completion_bridge_add)
+ *     -> lle_completion_result_add_with_description
+ *
+ * Distinct from tests/unit/test_compdef_source.c, which exercises the
+ * source's generate callback directly without going through the
+ * source-manager dispatch. This file proves the dispatch wiring is
+ * intact: compdef_source_init really did register with the global
+ * custom registry, and a freshly-created completion system picks it
+ * up via its custom meta-source.
+ *
+ * @author Michael Berry <trismegustis@gmail.com>
+ * @copyright Copyright (C) 2021-2026 Michael Berry
+ */
+
+#include "compdef.h"
+#include "compdef_source.h"
+#include "executor.h"
+#include "lle/completion/completion_system.h"
+#include "lle/completion/completion_types.h"
+#include "lle/completion/custom_source.h"
+#include "lle/memory_management.h"
+#include "lush_memory_pool.h"
+#include "test_framework.h"
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern void init_symtable(void);
+
+#undef ASSERT
+#define ASSERT(cond, msg) ASSERT_TRUE(cond, msg)
+
+/// The completion system's post-dispatch steps (menu_state_create, etc.)
+/// exercise more pool surface than the unit-test sentinel can handle, so
+/// this integration test wraps a real lush_memory_pool with the LLE
+/// pool type the editor uses in production.
+static lle_memory_pool_t *test_pool = NULL;
+static executor_t *test_exec = NULL;
+static lle_completion_system_t *test_system = NULL;
+
+/// Defined in test_compdef_e2e_stubs.c. Set once at global_setup so
+/// get_global_executor() returns it for the whole test run.
+extern executor_t *test_integration_executor;
+
+static void global_setup(void) {
+    /// Heavy LLE infrastructure (memory pools, completion system,
+    /// custom-source registry) is created once for the whole binary
+    /// run rather than per-test. Per-test churn on these was
+    /// unstable; production lush also creates them once at startup.
+    lush_pool_init(NULL);
+    lle_memory_pool_create_from_lush(&test_pool, global_memory_pool,
+                                     LLE_POOL_BUFFER);
+    lle_completion_system_create(test_pool, &test_system);
+    lle_custom_source_init(test_system->source_manager, test_pool);
+    compdef_source_init();
+    init_compdef_bindings();
+    test_exec = executor_new();
+    test_integration_executor = test_exec;
+    current_executor = test_exec;
+}
+
+static void global_teardown(void) {
+    lle_custom_source_shutdown();
+    if (test_system) {
+        lle_completion_system_destroy(test_system);
+        test_system = NULL;
+    }
+    if (test_pool) {
+        lle_memory_pool_destroy(test_pool);
+        test_pool = NULL;
+    }
+    current_executor = NULL;
+    test_integration_executor = NULL;
+    if (test_exec) {
+        executor_free(test_exec);
+        test_exec = NULL;
+    }
+    free_compdef_bindings();
+}
+
+/// Per-test reset: clear bindings and any user-defined functions on
+/// the executor so each test starts with a known-empty state without
+/// rebuilding the heavy infrastructure.
+static void per_test_reset(void) {
+    /// Wipe bindings table contents by destroying + re-creating.
+    free_compdef_bindings();
+    init_compdef_bindings();
+    /// Drop any functions defined in a prior test so the next
+    /// executor_execute_command_line gets a clean slate.
+    executor_execute_command_line(
+        test_exec, "unset -f _subs _echo1 _never_defined 2>/dev/null; :", 1);
+}
+
+static int find_candidate(lle_completion_result_t *result, const char *text) {
+    if (!result) {
+        return -1;
+    }
+    for (size_t i = 0; i < result->count; i++) {
+        if (result->items[i].text && strcmp(result->items[i].text, text) == 0) {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
+/* ============================================================================
+ * Tests
+ * ============================================================================
+ */
+
+TEST(system_dispatch_fires_compdef_source) {
+    per_test_reset();
+    executor_execute_command_line(
+        test_exec, "_subs() { compadd checkout branch merge; }", 1);
+    compdef_set("git", "_subs");
+
+    lle_completion_result_t *result = NULL;
+    /// "git " — cursor at position 4 (just past the space), starting
+    /// the next word. command_name = "git", prefix empty. compdef
+    /// fires, _subs emits three candidates, all should land in the
+    /// result because the empty prefix matches everything.
+    lle_result_t r =
+        lle_completion_system_generate(test_system, "git ", 4, &result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "system_generate succeeded");
+    ASSERT_NOT_NULL(result, "result is allocated");
+    ASSERT_TRUE(find_candidate(result, "checkout") >= 0,
+                "checkout surfaced through full dispatch");
+    ASSERT_TRUE(find_candidate(result, "branch") >= 0,
+                "branch surfaced through full dispatch");
+    ASSERT_TRUE(find_candidate(result, "merge") >= 0,
+                "merge surfaced through full dispatch");
+}
+
+TEST(system_dispatch_skips_compdef_when_no_binding) {
+    per_test_reset();
+    /// No compdef binding for "uncoveted". The compdef source's
+    /// is_applicable returns false; generate is never called. Other
+    /// built-in sources may still surface candidates (files, etc.) so
+    /// we only assert that none of the candidates _subs would have
+    /// emitted are present.
+    executor_execute_command_line(
+        test_exec, "_subs() { compadd checkout branch merge; }", 1);
+
+    lle_completion_result_t *result = NULL;
+    lle_result_t r =
+        lle_completion_system_generate(test_system, "uncoveted ", 10, &result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "system_generate succeeded");
+    ASSERT_TRUE(find_candidate(result, "checkout") < 0,
+                "compdef source did not fire");
+    ASSERT_TRUE(find_candidate(result, "branch") < 0,
+                "compdef source did not fire");
+}
+
+TEST(system_dispatch_with_compdef_to_undefined_function) {
+    per_test_reset();
+    /// Binding to a function that has never been defined. The
+    /// compdef source returns SUCCESS with 0 candidates rather than
+    /// erroring; built-in sources still fire and the result is well
+    /// formed.
+    compdef_set("git", "_never_defined");
+
+    lle_completion_result_t *result = NULL;
+    lle_result_t r =
+        lle_completion_system_generate(test_system, "git ", 4, &result);
+    ASSERT_TRUE(r == LLE_SUCCESS,
+                "system_generate succeeded even though the bound function "
+                "is not defined");
+    ASSERT_TRUE(find_candidate(result, "checkout") < 0,
+                "no compdef-emitted candidate is present");
+}
+
+TEST(system_dispatch_passes_command_name_to_function) {
+    per_test_reset();
+    /// The function emits its $1 (command name) as a candidate. Going
+    /// through the full system_generate -> word_context_analyze path
+    /// proves the command_name field is being populated correctly
+    /// from the buffer text (not by our unit-test scaffolding).
+    executor_execute_command_line(test_exec, "_echo1() { compadd \"$1\"; }", 1);
+    compdef_set("mycmd", "_echo1");
+
+    lle_completion_result_t *result = NULL;
+    lle_result_t r =
+        lle_completion_system_generate(test_system, "mycmd ", 6, &result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "system_generate succeeded");
+    ASSERT_TRUE(find_candidate(result, "mycmd") >= 0,
+                "command name flowed through to $1 inside the function");
+}
+
+int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
+
+    /// executor_new() requires the global symtable manager to be
+    /// initialized; mirror tests/unit/test_executor.c's main pattern.
+    init_symtable();
+    global_setup();
+
+    printf("Running compdef E2E integration tests\n");
+    printf("=====================================\n");
+    printf("\nFull-pipeline dispatch:\n");
+    RUN_TEST(system_dispatch_fires_compdef_source);
+    RUN_TEST(system_dispatch_skips_compdef_when_no_binding);
+    RUN_TEST(system_dispatch_with_compdef_to_undefined_function);
+    RUN_TEST(system_dispatch_passes_command_name_to_function);
+
+    int rc = TEST_RESULT();
+    global_teardown();
+    return rc;
+}

--- a/tests/integration/test_compdef_e2e_stubs.c
+++ b/tests/integration/test_compdef_e2e_stubs.c
@@ -1,0 +1,36 @@
+/**
+ * @file test_compdef_e2e_stubs.c
+ * @brief Stubs for the compdef E2E integration test.
+ *
+ * Distinct from tests/unit/test_executor_stubs.c. That file makes
+ * get_global_executor() return `current_executor`, which is fine for
+ * unit tests that set current_executor right before each call. The
+ * integration test invokes paths (executor_execute_command_line,
+ * compdef-bound function bodies) whose internal builtin dispatch
+ * sets+clears current_executor as a side effect, so by the time
+ * lle_completion_system_generate runs the compdef source the global
+ * is NULL.
+ *
+ * Production lush has a separate session-long pointer in lush.c
+ * (`global_executor`) that get_global_executor returns; the
+ * integration test mirrors that ownership shape via a dedicated
+ * test_integration_executor pointer that the test sets once at
+ * global_setup() and clears at global_teardown().
+ *
+ * @author Michael Berry <trismegustis@gmail.com>
+ * @copyright Copyright (C) 2021-2026 Michael Berry
+ */
+
+#include "executor.h"
+
+executor_t *test_integration_executor = NULL;
+
+executor_t *get_global_executor(void) { return test_integration_executor; }
+
+int parse_and_execute(const char *input, size_t starting_line) {
+    if (!input || !test_integration_executor) {
+        return 1;
+    }
+    return executor_execute_command_line(test_integration_executor, input,
+                                         starting_line);
+}


### PR DESCRIPTION
## Summary

Two things in one PR because the second was discovered in service of the first:

1. **Integration test** through the full \`lle_completion_system_generate\` pipeline — exercises source-manager dispatch + word-context analysis + the compdef custom source's is_applicable / generate callbacks end-to-end, not just the source's callbacks in isolation like the unit tests do.

2. **Production fix in \`src/compdef_source.c\`:** the generate callback was reading \`current_executor\` (the per-builtin-call transient that \`execute_builtin_command\` clears to NULL on exit). Outside command execution — exactly when TAB fires — that's NULL, so compdef would have never invoked the bound function in real interactive use. Switched to \`get_global_executor()\` (the session-lifetime pointer used by the existing hook-invocation path). Pure caller-side bug; the function-invocation infrastructure was already correct.

The integration test surfaced the bug because it drives the full pipeline through the production paths instead of stubbing executor state.

## Test plan

- [x] \`meson test -C build\`: 123/123 pass on macOS
- [x] 4 new integration tests in \`tests/integration/test_compdef_e2e.c\` (source fires on binding, skips on no binding, undefined-function yields zero candidates, $1=cmd flows correctly via word_context dispatch)
- [x] Ubuntu 24.04 clean compile (0 warnings); all 3 compdef test binaries pass (test_compdef 24/24, test_compdef_source 10/10, test_compdef_e2e 4/4)
- [x] Existing unit tests still pass — they use the unit-test stubs path; integration test has its own stubs that mirror \`lush.c\`'s long-lived executor pointer

## Follow-up

PTY-driven real-world TAB test (typing into an interactive lush session, capturing the rendered candidate menu) is the next deliverable on the compdef arc. Separate PR.