### PR TITLE
compdef: PTY-driven TAB completion test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2682,6 +2682,18 @@ if host_os == 'linux' or host_os == 'darwin' or host_os == 'freebsd' or host_os 
          timeout: 30)
   endif
 
+  # PTY-driven compdef TAB-completion end-to-end test
+  if fs.exists('tests/integration/test_pty_compdef.c')
+    test_pty_compdef = executable('test_pty_compdef',
+                                  ['tests/integration/test_pty_compdef.c'],
+                                  dependencies: libutil_dep)
+    test('PTY compdef TAB completion',
+         test_pty_compdef,
+         args: [lush_exe.full_path()],
+         suite: 'integration',
+         timeout: 30)
+  endif
+
   # L11 (SIGHUP variant): logout script fires on SIGHUP-induced exit.
   if fs.exists('tests/integration/test_pty_sighup_logout.c')
     test_pty_logout = executable('test_pty_sighup_logout',

--- a/tests/integration/pty_helpers.h
+++ b/tests/integration/pty_helpers.h
@@ -269,6 +269,92 @@ static inline int pty_spawn(pty_session_t *session, const char *lush_path,
     return 0;
 }
 
+/// Spawn lush with ALL THREE stdio streams on the same PTY pair.
+/// Unlike pty_spawn, this configuration makes stdin a TTY (the slave),
+/// so isatty(STDIN_FILENO) returns true inside the child and the LLE
+/// enters interactive mode. Use this when the test needs to drive
+/// real keystrokes through the line editor (TAB completion menus,
+/// arrow-key navigation, etc.). pty_send writes through the master
+/// fd; the child reads them from its stdin (slave). pty_drain reads
+/// the same master fd; the child's stdout (slave) writes echo +
+/// render bytes for the parent to capture.
+///
+/// TERM=xterm-256color (not dumb) so the LLE does not fall back to
+/// non-interactive degraded mode.
+static inline int pty_spawn_lle(pty_session_t *session, const char *lush_path,
+                                const char *const argv[]) {
+    memset(session, 0, sizeof(*session));
+    session->home_dir = pty_make_tmpdir();
+    if (!session->home_dir) {
+        perror("pty_spawn_lle: mkdtemp");
+        return -1;
+    }
+
+    session->output = (char *)calloc(1, PTY_BUF_SIZE);
+    if (!session->output) {
+        pty_rmrf(session->home_dir);
+        free(session->home_dir);
+        return -1;
+    }
+    session->out_cap = PTY_BUF_SIZE;
+
+    int master, slave;
+    if (openpty(&master, &slave, NULL, NULL, NULL) != 0) {
+        perror("pty_spawn_lle: openpty");
+        free(session->output);
+        pty_rmrf(session->home_dir);
+        free(session->home_dir);
+        return -1;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("pty_spawn_lle: fork");
+        close(master);
+        close(slave);
+        free(session->output);
+        pty_rmrf(session->home_dir);
+        free(session->home_dir);
+        return -1;
+    }
+
+    if (pid == 0) {
+        setsid();
+#ifdef TIOCSCTTY
+        ioctl(slave, TIOCSCTTY, 0);
+#endif
+        dup2(slave, STDIN_FILENO);
+        dup2(slave, STDOUT_FILENO);
+        dup2(slave, STDERR_FILENO);
+        if (slave > STDERR_FILENO) {
+            close(slave);
+        }
+        close(master);
+
+        const char *parent_path = getenv("PATH");
+        char home_buf[1024];
+        char path_buf[2048];
+        char term_buf[] = "TERM=xterm-256color";
+        snprintf(home_buf, sizeof(home_buf), "HOME=%s", session->home_dir);
+        snprintf(path_buf, sizeof(path_buf), "PATH=%s",
+                 parent_path ? parent_path : "/usr/bin:/bin");
+        char *envp[] = {home_buf, path_buf, term_buf, NULL};
+        execve(lush_path, (char *const *)argv, envp);
+        perror("pty_spawn_lle: execve");
+        _exit(127);
+    }
+
+    close(slave);
+    session->pid = pid;
+    session->master_fd = master;
+    /// Single bidirectional fd: pty_send writes here, pty_drain reads
+    /// here. The PTY slave is shared between child stdin / stdout /
+    /// stderr, so the parent sees its own input echoed back along
+    /// with the LLE's render bytes.
+    session->stdin_fd = master;
+    return 0;
+}
+
 /// Write a NUL-terminated string to the child's stdin (the pipe end).
 /// Returns 0 on success or -1 with errno set.
 static inline int pty_send(pty_session_t *session, const char *s) {

--- a/tests/integration/test_pty_compdef.c
+++ b/tests/integration/test_pty_compdef.c
@@ -1,0 +1,121 @@
+/**
+ * @file test_pty_compdef.c
+ * @brief Real-world TAB completion test under a PTY.
+ *
+ * Spawns lush interactively under a pseudo-terminal, defines a shell
+ * function, binds it to a command via compdef, then sends a literal
+ * TAB byte and verifies that compadd-emitted candidates appear in the
+ * LLE's rendered output. This exercises the full integration path
+ * (executor + LLE + display + terminal) that the C-only integration
+ * test in test_compdef_e2e.c cannot reach.
+ *
+ * Uses pty_spawn_lle (defined in pty_helpers.h) which wires all three
+ * stdio streams to a single PTY pair so isatty(STDIN_FILENO) returns
+ * true inside the child and the LLE enters interactive mode. Sending
+ * a literal 0x09 byte to the master is processed by the LLE input
+ * layer identically to a TAB key press (terminal_unix_interface.c:872
+ * explicitly excludes 0x09 from Ctrl-letter conversion and lets it
+ * flow as a CHARACTER event).
+ *
+ * @author Michael Berry <trismegustis@gmail.com>
+ * @copyright Copyright (C) 2021-2026 Michael Berry
+ */
+
+#include "pty_helpers.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char **argv_main) {
+    /// Meson invokes PTY tests with the lush binary path as argv[1]
+    /// (see test_pty_sighup_cascade.c's contract).
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <lush-binary-path>\n", argv_main[0]);
+        return 2;
+    }
+    const char *lush_path = argv_main[1];
+
+    pty_session_t s;
+    /// -i forces interactive mode (so the LLE always initializes
+    /// regardless of any other defaults). argv[0] is conventionally
+    /// the binary name; not significant for behavior.
+    const char *argv[] = {"lush", "-i", NULL};
+    if (pty_spawn_lle(&s, lush_path, argv) != 0) {
+        fprintf(stderr, "test_pty_compdef: spawn failed\n");
+        return 1;
+    }
+
+    /// Let the LLE come up and emit its initial prompt. 500ms matches
+    /// the settle time used by the existing PTY tests
+    /// (test_pty_sighup_cascade.c).
+    pty_drain(&s, 500);
+
+    /// cd into a directory where the file/directory completion source
+    /// won't drown out the compdef candidates -- HOME was set to a
+    /// fresh empty tmpdir by pty_spawn_lle. The LLE's menu caps at
+    /// max_visible_items=20; with 19+ cwd entries the file source
+    /// alone would exhaust the cap and silently truncate the compdef
+    /// candidates that came after it in the source ordering.
+    pty_send(&s, "cd ~\r");
+    pty_drain(&s, 200);
+
+    /// Define the completion function. Use \r (carriage return) to
+    /// commit the line: LLE's raw input layer treats \r as Enter; \n
+    /// would be a literal newline byte that gets buffered into the
+    /// current line.
+    pty_send(&s, "_subs() { compadd checkout branch merge; }\r");
+    pty_drain(&s, 200);
+
+    /// Register the binding.
+    pty_send(&s, "compdef _subs git\r");
+    pty_drain(&s, 200);
+
+    /// Reset the captured-output buffer so the assertion sees only
+    /// what the TAB press produced, not the echoed cd / fn-define /
+    /// compdef-bind lines from above.
+    s.out_len = 0;
+    s.output[0] = '\0';
+
+    /// Type "git " then TAB. No carriage return -- we don't want to
+    /// execute the partial line, just trigger completion at the
+    /// cursor. The TAB byte (\x09) is processed by the LLE input
+    /// layer as a TAB key press.
+    pty_send(&s, "git \t");
+    pty_drain(&s, 500);
+
+    /// All three candidates should appear in the LLE's rendered
+    /// output. The menu renderer outputs candidate text literally
+    /// (ANSI escapes surround it for selection highlighting but the
+    /// text itself is unescaped); strstr is the established
+    /// assertion pattern used by the other PTY tests.
+    int failures = 0;
+    if (!strstr(s.output, "checkout")) {
+        fprintf(stderr, "test_pty_compdef: 'checkout' not in output\n");
+        failures++;
+    }
+    if (!strstr(s.output, "branch")) {
+        fprintf(stderr, "test_pty_compdef: 'branch' not in output\n");
+        failures++;
+    }
+    if (!strstr(s.output, "merge")) {
+        fprintf(stderr, "test_pty_compdef: 'merge' not in output\n");
+        failures++;
+    }
+
+    if (failures) {
+        fprintf(
+            stderr,
+            "test_pty_compdef: captured output (%zu bytes):\n---\n%s\n---\n",
+            s.out_len, s.output);
+    }
+
+    /// Cancel the partial line (Ctrl-C) then exit cleanly.
+    pty_send(&s, "\x03");
+    pty_drain(&s, 100);
+    pty_send(&s, "exit\r");
+    pty_wait(&s, 5000);
+    pty_cleanup(&s);
+
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Final piece of the compdef arc. Spawns lush interactively under a pseudo-terminal, defines a function, binds it via \`compdef\`, sends a literal TAB byte, and verifies that compadd-emitted candidates appear in the LLE's rendered menu output. Exercises the full executor + LLE + display + terminal-input path that the C-only integration test in #225 cannot reach (it stops at \`lle_completion_system_generate\`'s result struct, before any rendering).

## What's new

- **\`pty_spawn_lle\`** in \`tests/integration/pty_helpers.h\` — sibling of existing \`pty_spawn\`, but wires all three stdio streams of the spawned child to a single PTY pair so \`isatty(STDIN_FILENO)\` returns true and the LLE enters interactive mode. Existing \`pty_spawn\` deliberately keeps stdin on a pipe to suppress the LLE for the SIGHUP cascade tests; that configuration cannot drive TAB.
- **\`tests/integration/test_pty_compdef.c\`** — the test itself. Drives:
  \`\`\`
  cd ~
  _subs() { compadd checkout branch merge; }
  compdef _subs git
  git <TAB>
  \`\`\`
  Then \`strstr\`'s the captured master-fd output for each candidate.

## Implementation notes

- TAB byte handling: 0x09 sent through \`pty_send\` reaches the LLE input layer at \`src/lle/terminal/terminal_unix_interface.c:872\`, which explicitly excludes 0x09 from Ctrl-letter conversion and routes it as a CHARACTER event — identical to a TAB key press.
- \`cd ~\` to the spawn's empty tmpdir HOME before TAB: the menu caps at \`max_visible_items=20\`; without an empty cwd the file/directory completion source floods 19+ entries before mine and silently truncates the compdef candidates.
- Uses the same \`strstr\` substring-match assertion pattern as \`test_pty_sighup_logout.c\`. The menu renderer outputs candidate text literally (ANSI escapes surround selection highlighting; the text itself is unescaped).

## Test plan

- [x] \`meson test -C build\`: 124/124 pass on macOS, including the new PTY test
- [x] Ubuntu 24.04 clean compile (0 warnings); PTY compdef test passes; the same async-worker callback-timing flake from prior arc PRs shows under Docker virtualization but native ubuntu-latest CI is the authoritative Linux verdict.

## Compdef arc status

This closes out the compdef integration arc:
- #223 — foundation (compdef + compadd builtins, feature gating)
- #224 — LLE bridge (custom completion source registration)
- #225 — C integration test + production fix (executor pointer)
- #226 (this) — PTY real-world TAB test