### PR TITLE
lle async_worker: LLE_ASYNC_NOOP type + use it for wiring test

### DIFF
--- a/include/lle/async_worker.h
+++ b/include/lle/async_worker.h
@@ -82,7 +82,16 @@ extern "C" {
  */
 typedef enum lle_async_request_type {
     LLE_ASYNC_GIT_STATUS, ///< Get git repository status
-    LLE_ASYNC_CUSTOM      ///< Custom request with user-provided handler
+    LLE_ASYNC_CUSTOM,     ///< Custom request with user-provided handler
+    LLE_ASYNC_NOOP        ///< Immediate-success no-op. Worker dequeues, sets
+                          ///< response.result = LLE_SUCCESS, fires the
+                          ///< completion callback, frees the request. No
+                          ///< filesystem, no subprocess, no payload. Use
+                          ///< for: worker warm-up after start, smoke-
+                          ///< probing that the queue and callback path
+                          ///< are alive, unit tests that need to verify
+                          ///< completion wiring without the timing
+                          ///< dependency of a real workload.
 } lle_async_request_type_t;
 
 /**

--- a/src/lle/core/async_worker.c
+++ b/src/lle/core/async_worker.c
@@ -338,6 +338,13 @@ static void *lle_async_worker_thread(void *arg) {
             response.result = LLE_ERROR_FEATURE_NOT_AVAILABLE;
             break;
 
+        case LLE_ASYNC_NOOP:
+            /// Immediate-success no-op. The worker proves it dequeued
+            /// the request and that the completion-notify path fires;
+            /// no external work is performed.
+            response.result = LLE_SUCCESS;
+            break;
+
         default:
             response.result = LLE_ERROR_INVALID_PARAMETER;
             break;

--- a/tests/lle/unit/test_async_worker.c
+++ b/tests/lle/unit/test_async_worker.c
@@ -215,23 +215,31 @@ TEST(callback_invoked_on_completion) {
     lle_async_worker_init(&worker, test_completion_callback, NULL);
     lle_async_worker_start(worker);
 
-    /// Get current directory for the request
-    char cwd[PATH_MAX];
-    ASSERT_NOT_NULL(getcwd(cwd, sizeof(cwd)), "getcwd for test request");
-
-    lle_async_request_t *req = lle_async_request_create(LLE_ASYNC_GIT_STATUS);
-    snprintf(req->cwd, sizeof(req->cwd), "%s", cwd);
+    /// Use LLE_ASYNC_NOOP so the wiring (worker thread dequeue ->
+    /// type-dispatch -> completion-callback fire) is tested without
+    /// any subprocess / filesystem dependency. The git-status request
+    /// path is independently covered by git_status_detects_repo /
+    /// git_status_non_repo below; conflating wiring with workload
+    /// timing made this test race against Docker-on-macOS fork/exec
+    /// overhead (~4.5s for the four sequential git subprocess
+    /// launches) and intermittently fail at the 5000ms callback wait.
+    lle_async_request_t *req = lle_async_request_create(LLE_ASYNC_NOOP);
+    ASSERT_NOT_NULL(req, "request_create should succeed for NOOP");
 
     lle_result_t result = lle_async_worker_submit(worker, req);
     ASSERT_EQ(result, LLE_SUCCESS, "Submit should succeed");
 
-    /// Wait for callback
+    /// NOOP completes in microseconds; 5000ms is generous headroom
+    /// for the worker-thread schedule plus the pthread_cond_wait
+    /// round-trip in the test, with no jitter coming from external
+    /// work.
     bool received = wait_for_response(5000);
     ASSERT_TRUE(received, "Should receive response within timeout");
 
     pthread_mutex_lock(&callback_mutex);
     ASSERT_EQ(callback_count, 1, "Callback should be called once");
-    ASSERT_EQ(last_response.result, LLE_SUCCESS, "Result should be success");
+    ASSERT_EQ(last_response.result, LLE_SUCCESS,
+              "NOOP response should be LLE_SUCCESS");
     pthread_mutex_unlock(&callback_mutex);
 
     lle_async_worker_shutdown(worker);


### PR DESCRIPTION
## Summary

Replaces the only flaky test in the suite (\`callback_invoked_on_completion\` in test_async_worker.c) with a proper structural fix rather than a bandaid timeout bump or skipped assertion.

## Root cause

The test was using \`LLE_ASYNC_GIT_STATUS\` to drive the worker, asserting the completion callback fired within 5000ms. Under Docker-on-macOS the four sequential git subprocess launches take ~4.5s wall-clock due to host/VM filesystem bridge overhead — within 500ms of the test timeout, intermittently lost to scheduling jitter. The test had been conflating two concerns:

1. **Worker-thread wiring** (submit → dequeue → dispatch → callback fire). This is what the test's name promises.
2. **git_status returns LLE_SUCCESS**. Independently covered by \`git_status_detects_repo\` and \`git_status_non_repo\`.

## Fix

Adds \`LLE_ASYNC_NOOP\` to the request-type enum — an immediate-success no-op that the worker dispatches without any external work. Documented purpose: worker warm-up after start, smoke-probing that the queue + callback path are alive, unit tests that need the wiring without external timing. Not a test-only knob — legitimate client value as a health check.

The wiring test switches from GIT_STATUS to NOOP. All five original assertions remain — none weakened. The \`result == LLE_SUCCESS\` assertion is now actually guaranteed by the dispatcher rather than maybe-true-if-host-fork-exec-is-fast.

## Test plan

- [x] macOS native: 15/15 \`test_async_worker\`, full suite 123/123, 0 warnings
- [x] Ubuntu 24.04 under Docker (the failing environment): \`test_async_worker\` 3-for-3 isolated runs green, full suite 123/123 ✓
- [x] No assertions removed or weakened — the test now actually tests what its name claims