### PR TITLE
compdef: filter compadd candidates against typed prefix

### DIFF
--- a/include/completion_bridge.h
+++ b/include/completion_bridge.h
@@ -46,11 +46,17 @@ bool completion_bridge_active(struct executor *e);
  * to check completion_bridge_active() first and surface a builtin
  * error). The candidate / description strings are copied internally.
  *
+ * When executor->active_comp_prefix is non-empty, candidates that do
+ * not NFC-prefix-match the prefix are silently skipped and the call
+ * returns 0 (a deliberately filtered candidate is not a failure). The
+ * filter uses lle_unicode_is_prefix_z so normalization-form
+ * differences in either side do not mismatch.
+ *
  * @param e Executor whose active_comp_result is the target.
  * @param candidate Candidate text. Must be non-NULL, non-empty.
  * @param description Description text. NULL for no description.
- * @return 0 on success, -1 on failure (no active result, OOM, or
- *         invalid input).
+ * @return 0 on success or prefix-filtered skip, -1 on failure (no
+ *         active result, OOM, or invalid input).
  */
 int completion_bridge_add(struct executor *e, const char *candidate,
                           const char *description);

--- a/include/executor.h
+++ b/include/executor.h
@@ -146,14 +146,25 @@ typedef struct executor {
      * currently executing. */
     source_location_t active_loc;
 
-    /* Active completion-result accumulator. NULL outside a
-     * completion-function call. Populated by the LLE completion-source
-     * bridge before invoking a compdef-bound user function and cleared
-     * after. The compadd builtin appends candidates here; it errors
-     * when this field is NULL. Treated as opaque on the shell side
-     * (real type is lle_completion_result_t, owned by liblle); the
-     * shell-LLE bridge in completion_bridge.h provides typed access. */
+    /// Active completion-result accumulator. NULL outside a
+    /// completion-function call. Populated by the LLE completion-source
+    /// bridge before invoking a compdef-bound user function and cleared
+    /// after. The compadd builtin appends candidates here; it errors
+    /// when this field is NULL. Treated as opaque on the shell side
+    /// (real type is lle_completion_result_t, owned by liblle); the
+    /// shell-LLE bridge in completion_bridge.h provides typed access.
     void *active_comp_result;
+
+    /// Current-word prefix that compdef-emitted candidates must match.
+    /// Set by the LLE completion source from
+    /// lle_word_context_t.dequoted_filename_prefix right before invoking
+    /// the bound function and cleared on return. NULL or "" means no
+    /// filtering (every candidate is accepted). completion_bridge_add
+    /// uses lle_unicode_is_prefix_z (NFC-aware) so callers don't have to
+    /// filter manually inside their bound function -- a single emit-path
+    /// filter in the bridge covers every compadd code path (positional,
+    /// -a, -k).
+    const char *active_comp_prefix;
 
     /// Process substitution fd tracking (for cleanup after command execution)
     int procsub_fds[32];    ///< File descriptors from process substitutions

--- a/src/compdef_source.c
+++ b/src/compdef_source.c
@@ -89,11 +89,18 @@ lle_result_t compdef_source_generate(void *user_data,
     /// the exec pointer (not on current_executor, which the inner
     /// compadd's execute_builtin_command path clears to NULL on
     /// return, so the restore would dereference NULL on a global
-    /// read).
-    void *prior = exec->active_comp_result;
+    /// read). active_comp_prefix is paired with active_comp_result so
+    /// completion_bridge_add can filter candidates that don't match
+    /// what the user has typed for the current word -- a single
+    /// emit-path filter that covers compadd's positional / -a / -k
+    /// arms without any per-call work inside the bound function.
+    void *prior_result = exec->active_comp_result;
+    const char *prior_prefix = exec->active_comp_prefix;
     exec->active_comp_result = result;
+    exec->active_comp_prefix = cur;
     (void)executor_run_function(exec, fn, argc, argv);
-    exec->active_comp_result = prior;
+    exec->active_comp_result = prior_result;
+    exec->active_comp_prefix = prior_prefix;
     return LLE_SUCCESS;
 }
 

--- a/src/completion_bridge.c
+++ b/src/completion_bridge.c
@@ -12,6 +12,7 @@
 
 #include "executor.h"
 #include "lle/completion/completion_types.h"
+#include "lle/unicode_compare.h"
 
 bool completion_bridge_active(struct executor *e) {
     return e != NULL && e->active_comp_result != NULL;
@@ -21,6 +22,16 @@ int completion_bridge_add(struct executor *e, const char *candidate,
                           const char *description) {
     if (!e || !e->active_comp_result || !candidate || candidate[0] == '\0') {
         return -1;
+    }
+    /// Skip candidates that don't NFC-prefix-match the current word.
+    /// Empty / NULL prefix accepts everything (the first TAB at a word
+    /// boundary). Filtering here means every compadd code path
+    /// (positional, -a, -k) and any future emit path benefits without
+    /// per-site duplication, and the user's bound function can emit
+    /// its entire candidate set blindly.
+    if (e->active_comp_prefix && e->active_comp_prefix[0] != '\0' &&
+        !lle_unicode_is_prefix_z(e->active_comp_prefix, candidate, NULL)) {
+        return 0;
     }
     lle_completion_result_t *r =
         (lle_completion_result_t *)e->active_comp_result;

--- a/src/executor.c
+++ b/src/executor.c
@@ -366,6 +366,7 @@ executor_t *executor_new(void) {
     }
     executor->active_loc = SOURCE_LOC_UNKNOWN;
     executor->active_comp_result = NULL;
+    executor->active_comp_prefix = NULL;
 
     /// Initialize process substitution fd tracking
     executor->procsub_fd_count = 0;
@@ -437,6 +438,7 @@ executor_t *executor_new_with_symtable(symtable_manager_t *symtable) {
     }
     executor->active_loc = SOURCE_LOC_UNKNOWN;
     executor->active_comp_result = NULL;
+    executor->active_comp_prefix = NULL;
 
     /// Initialize process substitution fd tracking
     executor->procsub_fd_count = 0;

--- a/tests/integration/test_compdef_e2e.c
+++ b/tests/integration/test_compdef_e2e.c
@@ -182,6 +182,39 @@ TEST(system_dispatch_with_compdef_to_undefined_function) {
                 "no compdef-emitted candidate is present");
 }
 
+TEST(system_dispatch_filters_candidates_by_typed_prefix) {
+    per_test_reset();
+    /// Function emits its full candidate set blindly; the bridge
+    /// filters down to the single one that matches the typed prefix.
+    /// This is the user-facing fix: `git c<TAB>` shows only checkout,
+    /// not all six git subcommands.
+    executor_execute_command_line(
+        test_exec,
+        "_subs() { compadd checkout branch merge clone commit pull; }", 1);
+    compdef_set("git", "_subs");
+
+    lle_completion_result_t *result = NULL;
+    /// Buffer "git c", cursor at position 5: command_name = "git",
+    /// dequoted_filename_prefix = "c". Only candidates starting with
+    /// "c" should survive the bridge filter.
+    lle_result_t r =
+        lle_completion_system_generate(test_system, "git c", 5, &result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "system_generate succeeded");
+    ASSERT_NOT_NULL(result, "result is allocated");
+    ASSERT_TRUE(find_candidate(result, "checkout") >= 0,
+                "checkout survived the c-prefix filter");
+    ASSERT_TRUE(find_candidate(result, "clone") >= 0,
+                "clone survived the c-prefix filter");
+    ASSERT_TRUE(find_candidate(result, "commit") >= 0,
+                "commit survived the c-prefix filter");
+    ASSERT_TRUE(find_candidate(result, "branch") < 0,
+                "branch filtered out by c-prefix");
+    ASSERT_TRUE(find_candidate(result, "merge") < 0,
+                "merge filtered out by c-prefix");
+    ASSERT_TRUE(find_candidate(result, "pull") < 0,
+                "pull filtered out by c-prefix");
+}
+
 TEST(system_dispatch_passes_command_name_to_function) {
     per_test_reset();
     /// The function emits its $1 (command name) as a candidate. Going
@@ -214,6 +247,7 @@ int main(int argc, char **argv) {
     RUN_TEST(system_dispatch_fires_compdef_source);
     RUN_TEST(system_dispatch_skips_compdef_when_no_binding);
     RUN_TEST(system_dispatch_with_compdef_to_undefined_function);
+    RUN_TEST(system_dispatch_filters_candidates_by_typed_prefix);
     RUN_TEST(system_dispatch_passes_command_name_to_function);
 
     int rc = TEST_RESULT();

--- a/tests/integration/test_pty_compdef.c
+++ b/tests/integration/test_pty_compdef.c
@@ -110,7 +110,41 @@ int main(int argc, char **argv_main) {
             s.out_len, s.output);
     }
 
-    /// Cancel the partial line (Ctrl-C) then exit cleanly.
+    /// Cancel the partial line (Ctrl-C) then re-run the test with a
+    /// typed prefix that should narrow the candidate set. Only
+    /// "checkout" starts with "c"; "branch" and "merge" must be
+    /// filtered out by the bridge so they don't appear in the menu.
+    pty_send(&s, "\x03");
+    pty_drain(&s, 100);
+
+    s.out_len = 0;
+    s.output[0] = '\0';
+    pty_send(&s, "git c\t");
+    pty_drain(&s, 500);
+
+    if (!strstr(s.output, "checkout")) {
+        fprintf(stderr,
+                "test_pty_compdef: 'checkout' missing under c-prefix\n");
+        failures++;
+    }
+    if (strstr(s.output, "branch")) {
+        fprintf(stderr,
+                "test_pty_compdef: 'branch' leaked through c-prefix filter\n");
+        failures++;
+    }
+    if (strstr(s.output, "merge")) {
+        fprintf(stderr,
+                "test_pty_compdef: 'merge' leaked through c-prefix filter\n");
+        failures++;
+    }
+
+    if (failures) {
+        fprintf(stderr,
+                "test_pty_compdef: prefix-filter captured output (%zu bytes):"
+                "\n---\n%s\n---\n",
+                s.out_len, s.output);
+    }
+
     pty_send(&s, "\x03");
     pty_drain(&s, 100);
     pty_send(&s, "exit\r");

--- a/tests/unit/test_compdef_source.c
+++ b/tests/unit/test_compdef_source.c
@@ -191,23 +191,124 @@ TEST(generate_runs_function_and_surfaces_positional_candidates) {
     teardown_env();
 }
 
-TEST(generate_passes_command_and_prefix_via_positional_params) {
+TEST(generate_passes_command_name_via_dollar_one) {
     setup_env();
-    /// The function emits its received positional params as candidates;
-    /// reading them back through the accumulator verifies the argv
-    /// layout (argv[1]=cmd, argv[2]=cur, argv[3]=prev) flows through
-    /// executor_run_function correctly.
-    executor_execute_command_line(test_exec,
-                                  "_echo_args() { compadd \"$1\" \"$2\"; }", 1);
-    compdef_set("git", "_echo_args");
+    /// Verifies argv[1] (the command name) flows through
+    /// executor_run_function to "$1" inside the bound function.
+    /// Empty prefix bypasses the bridge filter so the test isolates
+    /// argv forwarding.
+    executor_execute_command_line(test_exec, "_echo_cmd() { compadd \"$1\"; }",
+                                  1);
+    compdef_set("git", "_echo_cmd");
+
+    lle_word_context_t ctx;
+    make_context(&ctx, "git", "");
+    lle_result_t r = compdef_source_generate(NULL, &ctx, test_result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "generate returns LLE_SUCCESS");
+    ASSERT_EQ(test_result->count, 1u, "one candidate accumulated");
+    ASSERT_TRUE(find_candidate("git") >= 0, "$1 carried the command name");
+    teardown_env();
+}
+
+TEST(generate_passes_current_prefix_via_dollar_two) {
+    setup_env();
+    /// Verifies argv[2] (the current-word prefix) flows through to
+    /// "$2". The function emits "${2}_suffix" so the candidate
+    /// naturally starts with the prefix and survives the bridge
+    /// filter; if "$2" were not the typed prefix, the resulting
+    /// candidate would not begin with "che" and would be filtered
+    /// out, producing a count of zero.
+    executor_execute_command_line(
+        test_exec, "_echo_prefix() { compadd \"${2}_suffix\"; }", 1);
+    compdef_set("git", "_echo_prefix");
 
     lle_word_context_t ctx;
     make_context(&ctx, "git", "che");
     lle_result_t r = compdef_source_generate(NULL, &ctx, test_result);
     ASSERT_TRUE(r == LLE_SUCCESS, "generate returns LLE_SUCCESS");
-    ASSERT_EQ(test_result->count, 2u, "two candidates accumulated");
-    ASSERT_TRUE(find_candidate("git") >= 0, "$1 carried the command name");
-    ASSERT_TRUE(find_candidate("che") >= 0, "$2 carried the current prefix");
+    ASSERT_EQ(test_result->count, 1u, "one candidate accumulated");
+    ASSERT_TRUE(find_candidate("che_suffix") >= 0,
+                "$2 carried the current prefix to the function");
+    teardown_env();
+}
+
+TEST(generate_filters_candidates_against_active_prefix) {
+    setup_env();
+    /// The user's bound function emits its entire candidate set blindly
+    /// (no manual prefix filter). The bridge filters down to only those
+    /// that NFC-prefix-match the current word -- prefix "c" keeps
+    /// "checkout"; "branch" and "merge" are silently skipped. This is
+    /// the user-facing fix for `git c<TAB>` showing all candidates
+    /// instead of narrowing to commit/checkout/clone.
+    executor_execute_command_line(
+        test_exec, "_subs() { compadd checkout branch merge; }", 1);
+    compdef_set("git", "_subs");
+
+    lle_word_context_t ctx;
+    make_context(&ctx, "git", "c");
+    lle_result_t r = compdef_source_generate(NULL, &ctx, test_result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "generate returns LLE_SUCCESS");
+    ASSERT_EQ(test_result->count, 1u,
+              "only the prefix-matching candidate kept");
+    ASSERT_TRUE(find_candidate("checkout") >= 0, "checkout matched prefix 'c'");
+    ASSERT_TRUE(find_candidate("branch") < 0, "branch filtered out");
+    ASSERT_TRUE(find_candidate("merge") < 0, "merge filtered out");
+    teardown_env();
+}
+
+TEST(generate_filter_skips_all_when_no_candidate_matches) {
+    setup_env();
+    /// A prefix that no candidate shares produces an empty result --
+    /// no spurious match, no candidate inserted as inline preview.
+    executor_execute_command_line(
+        test_exec, "_subs() { compadd checkout branch merge; }", 1);
+    compdef_set("git", "_subs");
+
+    lle_word_context_t ctx;
+    make_context(&ctx, "git", "xyz");
+    lle_result_t r = compdef_source_generate(NULL, &ctx, test_result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "generate returns LLE_SUCCESS");
+    ASSERT_EQ(test_result->count, 0u,
+              "no candidates matched the non-matching prefix");
+    teardown_env();
+}
+
+TEST(generate_filter_inactive_with_empty_prefix) {
+    setup_env();
+    /// Empty / NULL prefix accepts every candidate (matches the
+    /// first-TAB-at-word-boundary case where the user has typed
+    /// nothing yet for the current word).
+    executor_execute_command_line(
+        test_exec, "_subs() { compadd checkout branch merge; }", 1);
+    compdef_set("git", "_subs");
+
+    lle_word_context_t ctx;
+    make_context(&ctx, "git", "");
+    lle_result_t r = compdef_source_generate(NULL, &ctx, test_result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "generate returns LLE_SUCCESS");
+    ASSERT_EQ(test_result->count, 3u,
+              "every candidate kept when the prefix is empty");
+    teardown_env();
+}
+
+TEST(generate_filter_restores_prior_prefix) {
+    setup_env();
+    /// active_comp_prefix must be saved + restored just like
+    /// active_comp_result so nested completion contexts (a function
+    /// that itself triggers completion lookups) don't leak the inner
+    /// prefix to the outer scope.
+    executor_execute_command_line(test_exec, "_noop() { compadd x; }", 1);
+    compdef_set("git", "_noop");
+    const char *sentinel = "outer-prefix";
+    test_exec->active_comp_prefix = sentinel;
+
+    lle_word_context_t ctx;
+    make_context(&ctx, "git", "inner");
+    (void)compdef_source_generate(NULL, &ctx, test_result);
+    ASSERT_TRUE(test_exec->active_comp_prefix == sentinel,
+                "active_comp_prefix restored to prior value after the call");
+
+    test_exec->active_comp_prefix = NULL;
     teardown_env();
 }
 
@@ -255,7 +356,12 @@ int main(int argc, char **argv) {
     RUN_TEST(generate_no_binding_returns_success_silently);
     RUN_TEST(generate_undefined_function_returns_success_silently);
     RUN_TEST(generate_runs_function_and_surfaces_positional_candidates);
-    RUN_TEST(generate_passes_command_and_prefix_via_positional_params);
+    RUN_TEST(generate_passes_command_name_via_dollar_one);
+    RUN_TEST(generate_passes_current_prefix_via_dollar_two);
+    RUN_TEST(generate_filters_candidates_against_active_prefix);
+    RUN_TEST(generate_filter_skips_all_when_no_candidate_matches);
+    RUN_TEST(generate_filter_inactive_with_empty_prefix);
+    RUN_TEST(generate_filter_restores_prior_prefix);
     RUN_TEST(generate_restores_active_comp_result);
 
     return TEST_RESULT();


### PR DESCRIPTION
## Summary

- `git c<TAB>` showed all six candidates emitted by the bound function instead of narrowing to those starting with "c". The bridge appended every candidate unconditionally.
- Other completion sources in `src/lle/completion/completion_sources.c` filter through `lle_unicode_is_prefix` against `context->dequoted_filename_prefix`; compdef-emitted candidates bypassed that path.
- Fixed at the bridge layer (single emit-path filter covers compadd's positional / `-a` / `-k` arms). User's bound function emits its full candidate set blindly; the bridge drops candidates whose NFC form does not have the typed prefix.

Code changes:
- `include/executor.h` adds `const char *active_comp_prefix` paired with `active_comp_result`; opaque on the shell side.
- `src/compdef_source.c` save+restores the prefix alongside the result pointer, populated from `context->dequoted_filename_prefix`.
- `src/completion_bridge.c` filters via `lle_unicode_is_prefix_z`. Empty / NULL prefix accepts everything (first-TAB-at-word-boundary).
- Tests: split the existing `$1`/`$2`-forwarding test into two focused cases (one per positional). Added five new prefix-filter cases at the unit level, one at E2E, one at PTY.

## Test plan

- [x] `meson test -C build` on macOS clang: 124/124 PASS
- [x] `meson test -C build` in `ubuntu:24.04` Docker (per `[[project-linux-build-reproduction]]`): 124/124 PASS
- [x] Full rebuild clean both sides: 0 warnings
- [x] Compdef suites: `Compdef + Compadd` / `Compdef LLE Source` / `Compdef End-to-End` / `PTY compdef TAB completion` all PASS

Expected post-merge behavior:
- `git c<TAB>` -> menu shows `checkout` (and any other c-prefixed candidates)
- `git p<TAB>` -> menu shows `push`, `pull`
- `git xyz<TAB>` -> 0 candidates, no spurious inline insertion
- `git <TAB>` (empty prefix) -> all candidates surface, as before