### PR TITLE
libfuzzy: add fuzzy_completion_score (fzy-style DP)

### DIFF
--- a/include/fuzzy_match.h
+++ b/include/fuzzy_match.h
@@ -200,6 +200,49 @@ int fuzzy_subsequence_score(const char *pattern, const char *text,
 bool fuzzy_is_subsequence(const char *pattern, const char *text,
                           const fuzzy_match_options_t *options);
 
+/**
+ * @brief Calculate fzy-style completion match score
+ *
+ * Optimized for "user typed a partial prefix or shorthand" rather than
+ * "user typed a near-complete word with typos". This is the right scorer
+ * for completion menus and type-to-filter narrowing; fuzzy_match_score()
+ * is the right scorer for autocorrect ("did you mean") use cases.
+ *
+ * Algorithm: subsequence gate followed by dynamic-programming ranking
+ * with positional bonuses, modeled on fzy:
+ *
+ *   - **Subsequence gate**: returns 0 if pattern is not a subsequence
+ *     of text. No partial credit for near-misses.
+ *   - **First-char bonus**: largest bonus when pattern[0] matches
+ *     text[0] -- "ls<TAB>" should prefer `ls` over `tools`.
+ *   - **Word-boundary bonus**: match at the start of a word
+ *     (preceded by `/`, `.`, `-`, `_`, space, or any non-letter)
+ *     scores well. `git c<TAB>` prefers `git checkout` over `gcc -o`.
+ *   - **CamelCase boundary bonus**: match at a lowercase->uppercase
+ *     transition scores well. `gc<TAB>` matches `GitCommit` strongly.
+ *   - **Adjacency bonus**: consecutive pattern chars matched at
+ *     consecutive text positions stack -- `gco<TAB>` prefers
+ *     `git-co` (adjacent `co`) over `goc` (split).
+ *   - **Gap penalty**: characters skipped between matches reduce
+ *     the score. Leading gaps (before the first match) penalized
+ *     less, since they're often unavoidable for tail-of-text matches.
+ *
+ * Empty pattern returns 100 (every candidate trivially matches).
+ * Identical pattern/text returns 100 (exact match).
+ *
+ * @param pattern Pattern string the user typed (UTF-8). Subject to
+ *                NFC normalization and case folding per @p options.
+ * @param text    Candidate string (UTF-8). Same normalization.
+ * @param options Matching options (NULL for FUZZY_MATCH_DEFAULT).
+ *                @c case_sensitive @c false (default) makes matching
+ *                case-insensitive while still detecting CamelCase
+ *                boundaries from the original casing.
+ * @return Score 0-100. 0 means pattern is not a subsequence of
+ *         text. Higher scores indicate stronger matches.
+ */
+int fuzzy_completion_score(const char *pattern, const char *text,
+                           const fuzzy_match_options_t *options);
+
 /* ============================================================================
  * BATCH MATCHING (for completion/suggestion lists)
  * ============================================================================

--- a/src/libfuzzy/fuzzy_match.c
+++ b/src/libfuzzy/fuzzy_match.c
@@ -659,6 +659,298 @@ bool fuzzy_is_subsequence(const char *pattern, const char *text,
 }
 
 /* ============================================================================
+ * COMPLETION SCORE (fzy-style)
+ * ============================================================================
+ */
+
+/// Length cap for completion candidates. Real completion text is short
+/// (paths, command names, options); a hard cap keeps the DP matrices
+/// bounded and rejects pathological inputs without allocating huge
+/// buffers. 256 codepoints covers every realistic case and is below
+/// the MAX_CODEPOINTS=1024 limit shared by the other scorers.
+#define COMPLETION_MAX_LEN 256
+
+/// Integer-scaled scoring constants modeled on fzy. The DP accumulates
+/// into int; the final result is renormalized to 0-100 against the
+/// theoretical maximum (every match getting the consecutive bonus).
+/// Position 0 is treated as if preceded by a separator -- a match at
+/// the start of the text gets the SLASH bonus, the strongest position
+/// bonus.
+///
+/// Known limitation: fzy-style scoring does NOT specially reward
+/// multi-word-acronym matches (e.g., `gco` matching `git checkout` as
+/// "first letter of each whitespace-separated token"). Plain
+/// adjacency-rich matches like `gco` in `gcc -o file` can outrank the
+/// acronym intent. Adding an acronym-matching axis on top of this
+/// scorer is a tracked future enhancement -- shell users have strong
+/// acronym mnemonics (gco, gcm, gst, gba) that the base fzy algorithm
+/// doesn't optimize for.
+#define COMP_BONUS_SLASH 90        ///< match after '/' or text position 0
+#define COMP_BONUS_WORD 80         ///< match after [-_. space]
+#define COMP_BONUS_CAMEL 70        ///< match at lower->upper transition
+#define COMP_BONUS_CONSECUTIVE 100 ///< pattern[p-1] matched at text[t-1]
+#define COMP_BONUS_NORMAL 0        ///< match in the middle of a word
+#define COMP_PENALTY_GAP_LEAD -1   ///< gap before the first match
+#define COMP_PENALTY_GAP -1        ///< gap between matches
+
+/// Decode a UTF-8 string into a parallel pair of codepoint arrays:
+/// one with case folding applied (used for matching) and one raw
+/// (used for CamelCase boundary detection). NFC normalization runs
+/// once before decoding so both arrays share the same canonical
+/// composition. Returns -1 on invalid input, otherwise the codepoint
+/// count.
+static int decode_completion_codepoints(const char *str, uint32_t *folded,
+                                        uint32_t *raw,
+                                        const fuzzy_match_options_t *opts) {
+    if (!str || !folded || !raw) {
+        return -1;
+    }
+
+    const char *input = str;
+    size_t input_len = strlen(str);
+
+    char norm_buf[NORM_BUFFER_SIZE];
+    if (opts && opts->unicode_normalize) {
+        size_t norm_len;
+        if (lle_unicode_normalize_nfc(str, input_len, norm_buf,
+                                      NORM_BUFFER_SIZE, &norm_len) == 0) {
+            input = norm_buf;
+            input_len = norm_len;
+        }
+    }
+
+    const char *ptr = input;
+    const char *end = input + input_len;
+    int n = 0;
+    while (ptr < end && n < COMPLETION_MAX_LEN) {
+        uint32_t cp;
+        int len = lle_utf8_decode_codepoint(ptr, end - ptr, &cp);
+        if (len <= 0) {
+            ptr++;
+            continue;
+        }
+        raw[n] = cp;
+        folded[n] = (opts && !opts->case_sensitive)
+                        ? lle_unicode_tolower_codepoint(cp)
+                        : cp;
+        n++;
+        ptr += len;
+    }
+    return n;
+}
+
+/// Test whether @p cp is a word-separator codepoint for boundary-bonus
+/// purposes. ASCII conservative set plus space. Sufficient for the
+/// shell-completion vocabulary (paths, flags, identifiers); a broader
+/// Unicode property check would not change ranking on realistic
+/// candidates and would cost a table lookup per text codepoint.
+static inline bool comp_is_separator(uint32_t cp) {
+    return cp == '/' || cp == '.' || cp == '-' || cp == '_' || cp == ' ';
+}
+
+/// Compute the bonus this text position should award when it ends up
+/// being the match for some pattern char. Looks at the RAW (unfolded)
+/// codepoint at position @p t and its predecessor so case-fold doesn't
+/// erase CamelCase information. Position 0 is treated as if preceded
+/// by a separator (SLASH bonus) so leading matches outrank mid-word
+/// matches.
+static int comp_position_bonus(const uint32_t *raw, int t) {
+    if (t == 0) {
+        return COMP_BONUS_SLASH;
+    }
+    uint32_t prev = raw[t - 1];
+    uint32_t cur = raw[t];
+    if (prev == '/') {
+        return COMP_BONUS_SLASH;
+    }
+    if (comp_is_separator(prev)) {
+        return COMP_BONUS_WORD;
+    }
+    /// CamelCase boundary: previous char is a (Unicode-aware)
+    /// lowercase letter and the current char is uppercase. Uses the
+    /// raw codepoints so case folding hasn't already collapsed the
+    /// signal; lle_unicode_tolower_codepoint returns the input
+    /// unchanged when no mapping applies, so we can detect "would
+    /// fold to something different" as "is currently uppercase".
+    if (cur != lle_unicode_tolower_codepoint(cur) &&
+        prev == lle_unicode_tolower_codepoint(prev)) {
+        return COMP_BONUS_CAMEL;
+    }
+    return COMP_BONUS_NORMAL;
+}
+
+int fuzzy_completion_score(const char *pattern, const char *text,
+                           const fuzzy_match_options_t *options) {
+    if (!pattern || !text) {
+        return 0;
+    }
+    if (*pattern == '\0') {
+        /// Empty pattern matches every candidate trivially. Caller
+        /// uses this to mean "no filter active"; returning 100 lets
+        /// menu code treat the completion score uniformly without a
+        /// special case.
+        return 100;
+    }
+    if (*text == '\0') {
+        return 0;
+    }
+
+    const fuzzy_match_options_t *opts =
+        options ? options : &FUZZY_MATCH_DEFAULT;
+
+    uint32_t pat_folded[COMPLETION_MAX_LEN];
+    uint32_t pat_raw[COMPLETION_MAX_LEN];
+    uint32_t txt_folded[COMPLETION_MAX_LEN];
+    uint32_t txt_raw[COMPLETION_MAX_LEN];
+
+    int pat_len =
+        decode_completion_codepoints(pattern, pat_folded, pat_raw, opts);
+    int txt_len = decode_completion_codepoints(text, txt_folded, txt_raw, opts);
+    if (pat_len <= 0 || txt_len <= 0) {
+        return 0;
+    }
+    if (pat_len > txt_len) {
+        /// Pattern longer than text -- can't be a subsequence.
+        return 0;
+    }
+
+    /// Quick exact-match shortcut: identical length AND identical
+    /// codepoints (after folding) is a perfect 100, no DP needed.
+    if (pat_len == txt_len) {
+        bool all_eq = true;
+        for (int i = 0; i < pat_len; i++) {
+            if (pat_folded[i] != txt_folded[i]) {
+                all_eq = false;
+                break;
+            }
+        }
+        if (all_eq) {
+            return 100;
+        }
+    }
+
+    /// Subsequence gate. If pattern is not a subsequence of text,
+    /// return 0 immediately without allocating the DP matrices.
+    int gp = 0, gt = 0;
+    while (gp < pat_len && gt < txt_len) {
+        if (pat_folded[gp] == txt_folded[gt]) {
+            gp++;
+        }
+        gt++;
+    }
+    if (gp < pat_len) {
+        return 0;
+    }
+
+    /// DP matrices. M[p][t] = best score considering pattern[0..p]
+    /// over text[0..t] where the last decision may or may not have
+    /// been a match. D[p][t] = best score where text[t] IS the
+    /// match for pattern[p] (needed so the next pattern char can
+    /// claim the adjacency bonus). Cells unreachable under the
+    /// subsequence constraint stay at INT_MIN/2 so they never get
+    /// selected.
+    const int NEG_INF = -1000000;
+    int *M = (int *)malloc((size_t)pat_len * (size_t)txt_len * sizeof(int));
+    int *D = (int *)malloc((size_t)pat_len * (size_t)txt_len * sizeof(int));
+    if (!M || !D) {
+        free(M);
+        free(D);
+        return 0;
+    }
+
+    for (int p = 0; p < pat_len; p++) {
+        int prev_M = NEG_INF;
+        for (int t = 0; t < txt_len; t++) {
+            int idx = p * txt_len + t;
+            int d_here = NEG_INF;
+            if (pat_folded[p] == txt_folded[t]) {
+                int pos_bonus = comp_position_bonus(txt_raw, t);
+                int starting; ///< pattern[p-1] matched anywhere <= t-1
+                if (p == 0) {
+                    /// First pattern char: pay leading-gap penalty
+                    /// for everything before this match, then add
+                    /// the position bonus.
+                    starting = t * COMP_PENALTY_GAP_LEAD + pos_bonus;
+                } else if (t == 0) {
+                    starting = NEG_INF;
+                } else {
+                    int prev = M[(p - 1) * txt_len + (t - 1)];
+                    starting =
+                        (prev <= NEG_INF / 2) ? NEG_INF : prev + pos_bonus;
+                }
+
+                int consecutive = NEG_INF;
+                if (p > 0 && t > 0) {
+                    int prev_d = D[(p - 1) * txt_len + (t - 1)];
+                    if (prev_d > NEG_INF / 2) {
+                        /// Consecutive match: previous pattern char
+                        /// matched at t-1. Per fzy, the contribution
+                        /// is max(CONSECUTIVE, position_bonus) -- a
+                        /// consecutive match at a normal mid-word
+                        /// position still gets the CONSECUTIVE bonus,
+                        /// while a consecutive match at a strong
+                        /// boundary takes whichever is larger.
+                        int contrib = (COMP_BONUS_CONSECUTIVE > pos_bonus)
+                                          ? COMP_BONUS_CONSECUTIVE
+                                          : pos_bonus;
+                        consecutive = prev_d + contrib;
+                    }
+                }
+
+                d_here = starting > consecutive ? starting : consecutive;
+            }
+
+            /// M[p][t] = best of (this position used the match) or
+            /// (skip text[t], take gap penalty).
+            int m_skip =
+                (prev_M > NEG_INF / 2) ? prev_M + COMP_PENALTY_GAP : NEG_INF;
+            int m_here = d_here > m_skip ? d_here : m_skip;
+
+            M[idx] = m_here;
+            D[idx] = d_here;
+            prev_M = m_here;
+        }
+    }
+
+    int raw_score = M[(pat_len - 1) * txt_len + (txt_len - 1)];
+
+    free(M);
+    free(D);
+
+    if (raw_score <= NEG_INF / 2) {
+        /// Subsequence existed but the DP couldn't reach the final
+        /// cell -- shouldn't happen given the gate above, but
+        /// defensive.
+        return 0;
+    }
+
+    /// Normalize to 0-100. The theoretical maximum is reached when
+    /// every match contributes the CONSECUTIVE bonus (the largest
+    /// per-step contribution under the fzy recurrence): pat_len *
+    /// COMP_BONUS_CONSECUTIVE. Scale linearly against that. Negative
+    /// scores (heavy gaps dominating) clamp to 0; over-max clamps to
+    /// 100. Mid-range scores typically land 30-70 which is where the
+    /// configured completion.threshold knob has meaningful effect.
+    int theoretical_max = pat_len * COMP_BONUS_CONSECUTIVE;
+    if (theoretical_max <= 0) {
+        return 0;
+    }
+    int score = (raw_score * 100) / theoretical_max;
+    if (score < 0) {
+        score = 0;
+    }
+    if (score > 100) {
+        score = 100;
+    }
+    /// Floor a subsequence match at 1 so the caller can distinguish
+    /// "matched but penalty-heavy" from "did not match at all".
+    if (score == 0) {
+        score = 1;
+    }
+    return score;
+}
+
+/* ============================================================================
  * COMBINED SCORE FUNCTIONS
  * ============================================================================
  */

--- a/tests/unit/test_fuzzy_match.c
+++ b/tests/unit/test_fuzzy_match.c
@@ -404,6 +404,153 @@ TEST(options_fast) {
 }
 
 /* ============================================================================
+ * COMPLETION SCORE TESTS (fzy-style)
+ * ============================================================================
+ */
+
+TEST(completion_empty_pattern_matches_all) {
+    /// Empty pattern = no-filter sentinel; every candidate gets 100.
+    ASSERT_EQ(fuzzy_completion_score("", "git checkout", NULL), 100,
+              "empty pattern returns 100");
+    ASSERT_EQ(fuzzy_completion_score("", "", NULL), 100,
+              "empty/empty returns 100");
+}
+
+TEST(completion_empty_text_zero) {
+    ASSERT_EQ(fuzzy_completion_score("abc", "", NULL), 0,
+              "empty candidate scores 0");
+}
+
+TEST(completion_exact_match_perfect) {
+    ASSERT_EQ(fuzzy_completion_score("git", "git", NULL), 100,
+              "identical pattern/text scores 100");
+}
+
+TEST(completion_case_insensitive_default) {
+    /// Default options are case-insensitive; the same input scored
+    /// against uppercase candidate should match.
+    int s = fuzzy_completion_score("gco", "GIT CHECKOUT", NULL);
+    ASSERT_TRUE(s > 0, "case-insensitive default scores a real match");
+}
+
+TEST(completion_non_subsequence_returns_zero) {
+    /// `xyz` is not a subsequence of `git checkout`; the subsequence
+    /// gate must return 0 (no partial credit for unrelated chars).
+    ASSERT_EQ(fuzzy_completion_score("xyz", "git checkout", NULL), 0,
+              "non-subsequence scores 0");
+}
+
+TEST(completion_subsequence_order_required) {
+    /// `gco` IS a subsequence of `git checkout`; `cog` is NOT (c then
+    /// o appear in order but g comes before c in the text). This is
+    /// the core gate that fuzzy_match_score lacks.
+    ASSERT_TRUE(fuzzy_completion_score("gco", "git checkout", NULL) > 0,
+                "gco is a subsequence of 'git checkout'");
+    ASSERT_EQ(fuzzy_completion_score("cog", "git checkout", NULL), 0,
+              "cog is NOT a subsequence of 'git checkout'");
+}
+
+TEST(completion_first_char_bonus_outranks_mid_word) {
+    /// Pattern matching at text[0] should outrank the same pattern
+    /// matching only in the middle. `ls` vs `ls` at start vs `tools`
+    /// (matches mid-word).
+    int leading = fuzzy_completion_score("ls", "ls", NULL);
+    int internal = fuzzy_completion_score("ls", "tools", NULL);
+    ASSERT_TRUE(leading > internal, "first-char match outranks mid-word match");
+}
+
+TEST(completion_word_boundary_bonus_outranks_internal) {
+    /// `c` matching after the space in `git checkout` (word boundary)
+    /// should outrank `c` matching inside `gcc -o file` (the `c` in
+    /// `gcc` is at position 2, inside the word).
+    int boundary = fuzzy_completion_score("c", "git checkout", NULL);
+    int internal = fuzzy_completion_score("c", "gcc -o file", NULL);
+    ASSERT_TRUE(boundary > internal,
+                "word-boundary match outranks mid-word match");
+}
+
+TEST(completion_diagnosis_case_keeps_candidates_above_zero) {
+    /// The diagnosis case that motivated this scorer. User types
+    /// `gco`; libfuzzy's autocorrect-tuned `fuzzy_match_score()`
+    /// ranks both `git checkout` and `gcc -o file` BELOW the default
+    /// threshold of 60 (edit-distance weight dominates), so both are
+    /// dropped from the candidate list entirely. The completion
+    /// scorer keeps both candidates positive so the user sees their
+    /// options and can pick.
+    ///
+    /// Note: fzy-style scoring legitimately prefers `gcc -o file`
+    /// (g+c adjacency at positions 0,1 earns the consecutive bonus)
+    /// over `git checkout` (g and c scattered). That is fzy's
+    /// behavior, not a bug. Acronym-matching ("first letter of each
+    /// whitespace-separated token") is a separate scoring axis that
+    /// would invert this ranking; it's tracked as a future
+    /// enhancement on top of the base fzy algorithm.
+    int checkout = fuzzy_completion_score("gco", "git checkout", NULL);
+    int gcc_o = fuzzy_completion_score("gco", "gcc -o file", NULL);
+    ASSERT_TRUE(checkout > 0,
+                "git checkout matches (autocorrect blend would drop it)");
+    ASSERT_TRUE(gcc_o > 0,
+                "gcc -o file matches (autocorrect blend would drop it)");
+}
+
+TEST(completion_camel_case_boundary) {
+    /// CamelCase boundary: `gc` matching `GitCommit` should score
+    /// well even though the chars are mid-text -- the `C` is a
+    /// camel-case word start.
+    int camel = fuzzy_completion_score("gc", "GitCommit", NULL);
+    int internal = fuzzy_completion_score("gc", "wagecmd", NULL);
+    ASSERT_TRUE(camel > internal, "CamelCase boundary outranks mid-word match");
+}
+
+TEST(completion_adjacency_bonus) {
+    /// Adjacent matches stack better than scattered ones. `co`
+    /// adjacent in `coup` should outrank `co` scattered in `cargo`.
+    int adjacent = fuzzy_completion_score("co", "coup", NULL);
+    int scattered = fuzzy_completion_score("co", "cargo", NULL);
+    ASSERT_TRUE(adjacent > scattered,
+                "adjacent match outranks scattered match");
+}
+
+TEST(completion_threshold_distinguishes_strong_from_weak) {
+    /// A strong match (prefix + adjacency) should land high; a weak
+    /// match (scattered across many gaps) should land low. The
+    /// configured completion.threshold (default 60) sits between them
+    /// so users get meaningful filter behavior out of the box.
+    int strong = fuzzy_completion_score("git", "git", NULL);
+    int weak = fuzzy_completion_score("git", "gargantuan-inner-thing", NULL);
+    ASSERT_TRUE(strong >= 60, "strong match scores >= 60");
+    ASSERT_TRUE(weak < strong, "weak match scores below strong");
+    ASSERT_TRUE(weak > 0, "weak match still positive (subsequence holds)");
+}
+
+TEST(completion_pattern_longer_than_text_zero) {
+    /// Edge: pattern can never be a subsequence of shorter text.
+    ASSERT_EQ(fuzzy_completion_score("hello world", "hi", NULL), 0,
+              "pattern longer than text scores 0");
+}
+
+TEST(completion_unicode_nfc_normalization) {
+    /// Default options normalize to NFC, so a precomposed and a
+    /// decomposed form of the same string match identically.
+    const char *precomposed = "caf\xc3\xa9"; // café (U+00E9)
+    const char *decomposed = "cafe\xcc\x81"; // cafe + COMBINING ACUTE
+    int s_pre = fuzzy_completion_score("caf", precomposed, NULL);
+    int s_dec = fuzzy_completion_score("caf", decomposed, NULL);
+    ASSERT_TRUE(s_pre > 0 && s_dec > 0,
+                "both NFC forms produce positive matches");
+    ASSERT_EQ(s_pre, s_dec, "NFC-equivalent forms score identically");
+}
+
+TEST(completion_case_sensitive_strict) {
+    /// Strict options preserve case; `LS` should not subsequence-match
+    /// `ls` under strict comparison.
+    ASSERT_EQ(fuzzy_completion_score("LS", "ls", &FUZZY_MATCH_STRICT), 0,
+              "strict case-sensitive blocks the cross-case match");
+    ASSERT_TRUE(fuzzy_completion_score("LS", "ls", NULL) > 0,
+                "default case-insensitive permits the match");
+}
+
+/* ============================================================================
  * MAIN TEST RUNNER
  * ============================================================================
  */
@@ -489,6 +636,24 @@ int main(void) {
     RUN_TEST(options_default);
     RUN_TEST(options_strict);
     RUN_TEST(options_fast);
+
+    /// Completion score tests (fzy-style)
+    printf("\n=== Completion Score Tests ===\n");
+    RUN_TEST(completion_empty_pattern_matches_all);
+    RUN_TEST(completion_empty_text_zero);
+    RUN_TEST(completion_exact_match_perfect);
+    RUN_TEST(completion_case_insensitive_default);
+    RUN_TEST(completion_non_subsequence_returns_zero);
+    RUN_TEST(completion_subsequence_order_required);
+    RUN_TEST(completion_first_char_bonus_outranks_mid_word);
+    RUN_TEST(completion_word_boundary_bonus_outranks_internal);
+    RUN_TEST(completion_diagnosis_case_keeps_candidates_above_zero);
+    RUN_TEST(completion_camel_case_boundary);
+    RUN_TEST(completion_adjacency_bonus);
+    RUN_TEST(completion_threshold_distinguishes_strong_from_weak);
+    RUN_TEST(completion_pattern_longer_than_text_zero);
+    RUN_TEST(completion_unicode_nfc_normalization);
+    RUN_TEST(completion_case_sensitive_strict);
 
     return TEST_RESULT();
 }


### PR DESCRIPTION
## Summary

- `fuzzy_match_score` is an autocorrect-tuned blend: 40% Levenshtein + 30% Jaro-Winkler + 20% common-prefix + 10% subsequence. The blend drops legitimate completion candidates when the input is a partial prefix or shorthand: `gco` against `git checkout` scores below the default threshold of 60.
- `fuzzy_completion_score` is fzy-style dynamic-programming subsequence scoring with positional bonuses (word-boundary, CamelCase, slash, consecutive). Returns 0 when pattern is not a subsequence; otherwise 0-100 normalized against `pat_len * CONSECUTIVE`.
- No callers changed. `fuzzy_match_score` remains the autocorrect / history-search scorer. The completion pipeline consumes `fuzzy_completion_score` in subsequent PRs (PR2 wires it into the bridge filter + adds `completion.match_mode` CREG key; PR3 adds in-menu type-to-filter UX).

This is PR1 of 3 in the completion-filter staging.

## Test plan

- [x] `meson test -C build` on macOS clang: 124/124 PASS
- [x] `meson test -C build` in `ubuntu:24.04` Docker: 124/124 PASS
- [x] Full rebuild clean both sides: 0 warnings
- [x] New "Completion Score Tests" suite (15 cases): subsequence gate (positive and negative), exact match, empty pattern as no-filter sentinel, first-char bonus, word-boundary bonus, CamelCase bonus, adjacency bonus, NFC normalization, case sensitivity, length cap, threshold separation, diagnosis-case-keeps-candidates-above-zero
- [x] All pre-existing libfuzzy tests still pass (autocorrect / history-search unaffected)