### PR TITLE
LLE completion: match_mode CREG ENUM + single filter predicate

### DIFF
--- a/include/completion_filter.h
+++ b/include/completion_filter.h
@@ -1,0 +1,48 @@
+/**
+ * @file completion_filter.h
+ * @brief Shell-side predicate for completion candidate filtering.
+ *
+ * Looks up the active match mode, case sensitivity, and fuzzy
+ * threshold from the central config registry and dispatches to the
+ * configured predicate:
+ *
+ *   - completion.match_mode = prefix
+ *     -> lle_unicode_is_prefix_z (NFC-aware prefix)
+ *   - completion.match_mode = substring
+ *     -> lle_unicode_contains_z (NFC-aware substring)
+ *   - completion.match_mode = fuzzy
+ *     -> fuzzy_completion_score; admitted when score >=
+ *        completion.threshold
+ *
+ * Consumed in two places so the bridge pre-emit filter (compdef
+ * candidate emission) and the in-menu type-to-filter pass share the
+ * exact same predicate -- the UX never diverges between "type then
+ * TAB" and "TAB then narrow."
+ *
+ * @author Michael Berry <trismegustis@gmail.com>
+ * @copyright Copyright (C) 2021-2026 Michael Berry
+ */
+
+#ifndef LUSH_COMPLETION_FILTER_H
+#define LUSH_COMPLETION_FILTER_H
+
+#include <stdbool.h>
+
+/**
+ * @brief Test whether a candidate passes the active completion filter.
+ *
+ * Empty or NULL @p prefix accepts every candidate (no filter active).
+ * NULL or empty @p candidate is rejected.
+ *
+ * The threshold is honored only when the active mode is fuzzy; in
+ * prefix and substring modes the predicate is binary.
+ *
+ * @param prefix    Current word prefix typed by the user (UTF-8). May
+ *                  be NULL or empty.
+ * @param candidate Candidate string under test (UTF-8). Must be
+ *                  non-NULL, non-empty.
+ * @return true if the candidate is admitted by the configured filter.
+ */
+bool completion_filter_admits(const char *prefix, const char *candidate);
+
+#endif /* LUSH_COMPLETION_FILTER_H */

--- a/include/config.h
+++ b/include/config.h
@@ -129,6 +129,29 @@ typedef enum {
 } lle_dedup_strategy_t;
 
 /**
+ * @brief Completion match mode
+ *
+ * Selects the predicate used to filter completion candidates against
+ * the typed word prefix. Applies uniformly to the bridge pre-emit
+ * filter and (subsequent commit) the in-menu type-to-filter:
+ *
+ *  - PREFIX: NFC-aware prefix match via lle_unicode_is_prefix_z.
+ *    Most predictable; matches bash / zsh consensus.
+ *  - SUBSTRING: NFC-aware substring containment via
+ *    lle_unicode_contains_z. Matches a typed pattern anywhere in
+ *    the candidate.
+ *  - FUZZY: fzy-style subsequence scoring via fuzzy_completion_score,
+ *    gated by completion.threshold. Most forgiving.
+ *
+ * Per-mode defaults: prefix for posix / bash / zsh; fuzzy for lush.
+ */
+typedef enum {
+    COMPLETION_MATCH_PREFIX,    ///< NFC prefix match (default outside lush)
+    COMPLETION_MATCH_SUBSTRING, ///< NFC substring containment
+    COMPLETION_MATCH_FUZZY      ///< fzy-style scoring (default in lush)
+} completion_match_mode_t;
+
+/**
  * @brief Configuration context structure
  *
  * Tracks the current parsing context during configuration file processing.
@@ -186,9 +209,9 @@ typedef struct {
     bool lle_readline_compatible_mode; ///< Readline compatibility mode
 
     /// Completion settings
-    bool completion_enabled;        ///< Enable tab completion
-    bool fuzzy_completion;          ///< Enable fuzzy matching
-    int completion_threshold;       ///< Minimum match score
+    bool completion_enabled;                       ///< Enable tab completion
+    completion_match_mode_t completion_match_mode; ///< Match predicate
+    int completion_threshold;                      ///< Minimum match score
     bool completion_case_sensitive; ///< Case-sensitive completion
     bool completion_show_all;       ///< Show all completions
     bool hints_enabled;             ///< Enable inline hints
@@ -507,6 +530,14 @@ bool config_validate_ambiguous_width(const char *value);
  * @return true if valid arrow mode, false otherwise
  */
 bool config_validate_lle_arrow_mode(const char *value);
+
+/**
+ * @brief Validate a completion match mode value
+ *
+ * @param value Match mode string to validate ("prefix", "substring", "fuzzy")
+ * @return true if valid match mode, false otherwise
+ */
+bool config_validate_completion_match_mode(const char *value);
 
 /**
  * @brief Validate an LLE storage mode value

--- a/include/lle/unicode_compare.h
+++ b/include/lle/unicode_compare.h
@@ -210,4 +210,40 @@ bool lle_unicode_is_prefix(const char *prefix, size_t prefix_len,
 bool lle_unicode_is_prefix_z(const char *prefix, const char *str,
                              const lle_unicode_compare_options_t *options);
 
+/**
+ * @brief Check if one UTF-8 string contains another as a substring
+ *
+ * Performs Unicode-normalized substring search using NFC normalization.
+ * Handles precomposed vs decomposed forms, optional case folding, and
+ * grapheme boundaries the same way as lle_unicode_is_prefix.
+ *
+ * Empty needle returns true (every string contains the empty string).
+ * Empty haystack returns false unless the needle is also empty.
+ *
+ * @param needle     Substring to search for (UTF-8)
+ * @param needle_len Length of needle in bytes
+ * @param haystack   String to search within (UTF-8)
+ * @param haystack_len Length of haystack in bytes
+ * @param options    Comparison options (NULL for defaults with normalization)
+ * @return true if a starting position in haystack matches needle codepoint-
+ *         by-codepoint under the configured options
+ */
+bool lle_unicode_contains(const char *needle, size_t needle_len,
+                          const char *haystack, size_t haystack_len,
+                          const lle_unicode_compare_options_t *options);
+
+/**
+ * @brief Check if one null-terminated UTF-8 string contains another
+ *
+ * Convenience wrapper around lle_unicode_contains() for null-terminated
+ * inputs.
+ *
+ * @param needle   Substring to search for (UTF-8, null-terminated)
+ * @param haystack String to search within (UTF-8, null-terminated)
+ * @param options  Comparison options (NULL for defaults)
+ * @return true if needle is a Unicode-normalized substring of haystack
+ */
+bool lle_unicode_contains_z(const char *needle, const char *haystack,
+                            const lle_unicode_compare_options_t *options);
+
 #endif /// LLE_UNICODE_COMPARE_H

--- a/meson.build
+++ b/meson.build
@@ -190,6 +190,7 @@ src = ['src/arithmetic.c',
        'src/brace_match.c',
        'src/identifier.c',
        'src/completion_bridge.c',
+       'src/completion_filter.c',
        'src/compdef_source.c',
        'src/posix_history.c',
        'src/posix_opts.c',
@@ -2274,6 +2275,25 @@ if fs.exists('tests/unit/test_compdef.c')
                             include_directories: [inc, include_directories('tests')],
                             dependencies: [lle_dep, libm])
   test('Compdef + Compadd', test_compdef,
+       suite: 'unit',
+       timeout: 30)
+endif
+
+# Completion filter predicate tests (prefix / substring / fuzzy modes)
+if fs.exists('tests/unit/test_completion_filter.c')
+  test_completion_filter_sources = []
+  foreach s : src
+    if not s.endswith('lush.c')
+      test_completion_filter_sources += s
+    endif
+  endforeach
+  test_completion_filter = executable('test_completion_filter',
+                                       'tests/unit/test_completion_filter.c',
+                                       'tests/unit/test_executor_stubs.c',
+                                       test_completion_filter_sources + lle_shell_sources,
+                                       include_directories: [inc, include_directories('tests')],
+                                       dependencies: [lle_dep, libm])
+  test('Completion Filter', test_completion_filter,
        suite: 'unit',
        timeout: 30)
 endif

--- a/src/builtins/display/lle_completion.c
+++ b/src/builtins/display/lle_completion.c
@@ -12,10 +12,13 @@
 
 #include "builtins.h"
 #include "builtins/display.h"
+#include "config.h"
 #include "config_registry.h"
 #include "lle/completion/completion_state.h"
 #include "lle/completion/completion_system.h"
 #include "lle/completion/custom_source.h"
+
+extern config_values_t config;
 
 int display_lle_completion(int argc, char **argv) {
     /// LLE completion subsystem. The umbrella command groups
@@ -160,17 +163,60 @@ int display_lle_completion(int argc, char **argv) {
             return 1;
         }
 
+    } else if (strcmp(comp_subcmd, "match_mode") == 0) {
+        /// completion.match_mode: filter predicate used by the
+        /// bridge pre-emit filter and (subsequent commit) the
+        /// in-menu type-to-filter. Values: prefix | substring |
+        /// fuzzy. Per-mode default: lush=fuzzy, others=prefix.
+        if (argc < 3) {
+            const char *display = "prefix";
+            switch (config.completion_match_mode) {
+            case COMPLETION_MATCH_SUBSTRING:
+                display = "substring";
+                break;
+            case COMPLETION_MATCH_FUZZY:
+                display = "fuzzy";
+                break;
+            case COMPLETION_MATCH_PREFIX:
+            default:
+                display = "prefix";
+                break;
+            }
+            printf("match_mode: %s\n", display);
+            printf("Usage: display lle completion match_mode "
+                   "<prefix|substring|fuzzy>\n");
+            return 0;
+        }
+
+        const char *mode = argv[2];
+        if (strcmp(mode, "prefix") != 0 && strcmp(mode, "substring") != 0 &&
+            strcmp(mode, "fuzzy") != 0) {
+            fprintf(stderr,
+                    "display lle completion match_mode: "
+                    "invalid value '%s' (use prefix|substring|fuzzy)\n",
+                    mode);
+            return 1;
+        }
+        /// config_set_value validates and writes through the
+        /// canonical config_options storage pointer; it also prints
+        /// "Set <key> = <value>" on success, which is the
+        /// project-wide feedback line, so no extra echo here.
+        config_set_value("completion.match_mode", mode);
+        return 0;
+
     } else if (strcmp(comp_subcmd, "help") == 0 ||
                strcmp(comp_subcmd, "--help") == 0) {
         printf("LLE Completion Subsystem\n");
         printf("========================\n\n");
         printf("Usage: display lle completion <subcommand>\n\n");
         printf("Subcommands:\n");
-        printf("  sources [list|reload|help]   - Manage completion "
+        printf("  sources [list|reload|help]              - Manage completion "
                "sources\n");
-        printf("  chain_directories <on|off>   - Re-trigger "
+        printf("  chain_directories <on|off>              - Re-trigger "
                "completion after directory accept\n");
-        printf("  help                         - Show this help "
+        printf("  match_mode <prefix|substring|fuzzy>     - Set the filter "
+               "predicate\n");
+        printf("  help                                    - Show this help "
                "message\n");
         return 0;
 
@@ -178,7 +224,7 @@ int display_lle_completion(int argc, char **argv) {
         fprintf(stderr, "display lle completion: Unknown subcommand '%s'\n",
                 comp_subcmd);
         fprintf(stderr, "Usage: display lle completion "
-                        "<sources|chain_directories|help>\n");
+                        "<sources|chain_directories|match_mode|help>\n");
         return 1;
     }
 }

--- a/src/completion_bridge.c
+++ b/src/completion_bridge.c
@@ -10,9 +10,9 @@
 
 #include "completion_bridge.h"
 
+#include "completion_filter.h"
 #include "executor.h"
 #include "lle/completion/completion_types.h"
-#include "lle/unicode_compare.h"
 
 bool completion_bridge_active(struct executor *e) {
     return e != NULL && e->active_comp_result != NULL;
@@ -23,14 +23,16 @@ int completion_bridge_add(struct executor *e, const char *candidate,
     if (!e || !e->active_comp_result || !candidate || candidate[0] == '\0') {
         return -1;
     }
-    /// Skip candidates that don't NFC-prefix-match the current word.
-    /// Empty / NULL prefix accepts everything (the first TAB at a word
-    /// boundary). Filtering here means every compadd code path
-    /// (positional, -a, -k) and any future emit path benefits without
-    /// per-site duplication, and the user's bound function can emit
-    /// its entire candidate set blindly.
-    if (e->active_comp_prefix && e->active_comp_prefix[0] != '\0' &&
-        !lle_unicode_is_prefix_z(e->active_comp_prefix, candidate, NULL)) {
+    /// Filtering here means every compadd code path (positional,
+    /// -a, -k) and any future emit path benefits without per-site
+    /// duplication; the user's bound function can emit its entire
+    /// candidate set blindly. completion_filter_admits dispatches on
+    /// completion.match_mode (prefix / substring / fuzzy) so the
+    /// active configuration choice applies uniformly across the
+    /// engine; switching modes never produces divergent ranking
+    /// between the pre-emit filter and other consumers.
+    if (e->active_comp_prefix &&
+        !completion_filter_admits(e->active_comp_prefix, candidate)) {
         return 0;
     }
     lle_completion_result_t *r =

--- a/src/completion_filter.c
+++ b/src/completion_filter.c
@@ -1,0 +1,44 @@
+/**
+ * @file completion_filter.c
+ * @brief Implementation of completion_filter_admits.
+ *
+ * See include/completion_filter.h for the contract.
+ *
+ * @author Michael Berry <trismegustis@gmail.com>
+ * @copyright Copyright (C) 2021-2026 Michael Berry
+ */
+
+#include "completion_filter.h"
+
+#include "config.h"
+#include "fuzzy_match.h"
+#include "lle/unicode_compare.h"
+
+/// Project-wide config storage. Defined in src/config.c.
+extern config_values_t config;
+
+bool completion_filter_admits(const char *prefix, const char *candidate) {
+    if (!candidate || candidate[0] == '\0') {
+        return false;
+    }
+    if (!prefix || prefix[0] == '\0') {
+        return true;
+    }
+
+    lle_unicode_compare_options_t cmp_opts = LLE_UNICODE_COMPARE_DEFAULT;
+    cmp_opts.case_insensitive = !config.completion_case_sensitive;
+
+    switch (config.completion_match_mode) {
+    case COMPLETION_MATCH_SUBSTRING:
+        return lle_unicode_contains_z(prefix, candidate, &cmp_opts);
+    case COMPLETION_MATCH_FUZZY: {
+        fuzzy_match_options_t fopts = FUZZY_MATCH_DEFAULT;
+        fopts.case_sensitive = config.completion_case_sensitive;
+        int score = fuzzy_completion_score(prefix, candidate, &fopts);
+        return score >= config.completion_threshold;
+    }
+    case COMPLETION_MATCH_PREFIX:
+    default:
+        return lle_unicode_is_prefix_z(prefix, candidate, &cmp_opts);
+    }
+}

--- a/src/config.c
+++ b/src/config.c
@@ -148,6 +148,16 @@ static const config_enum_mapping_t shell_mode_mappings[] = {
 static const config_enum_def_t shell_mode_enum = {shell_mode_mappings,
                                                   SHELL_MODE_LUSH};
 
+/// Completion Match Mode mappings
+static const config_enum_mapping_t completion_match_mode_mappings[] = {
+    {   "prefix",    COMPLETION_MATCH_PREFIX},
+    {"substring", COMPLETION_MATCH_SUBSTRING},
+    {    "fuzzy",     COMPLETION_MATCH_FUZZY},
+    {       NULL,                          0}  /// Sentinel
+};
+static const config_enum_def_t completion_match_mode_enum = {
+    completion_match_mode_mappings, COMPLETION_MATCH_PREFIX};
+
 /// ============================================================================
 /// CONFIGURATION OPTION DEFINITIONS
 /// ============================================================================
@@ -157,271 +167,272 @@ static config_option_t config_options[] = {
     /// History settings
     {                     "history.enabled",   CONFIG_TYPE_BOOL,CONFIG_SECTION_HISTORY,
      &config.history_enabled,"Enable command history",config_validate_bool,
-     NULL                                                                                                                           },
+     NULL                                                                                                                                    },
     {                        "history.size",    CONFIG_TYPE_INT,    CONFIG_SECTION_HISTORY,
-     &config.history_size,                   "Maximum history entries",             config_validate_int,
-     NULL                                                                                                                           },
+     &config.history_size,                   "Maximum history entries",                   config_validate_int,
+     NULL                                                                                                                                    },
     {                     "history.no_dups",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.history_no_dups,          "Remove duplicate history entries",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {                  "history.timestamps",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.history_timestamps,                 "Add timestamps to history",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {                        "history.file", CONFIG_TYPE_STRING,    CONFIG_SECTION_HISTORY,
-     &config.history_file,                         "History file path",          config_validate_string,                     NULL   },
+     &config.history_file,                         "History file path",                config_validate_string,                        NULL   },
 
     /// LLE History Configuration
     {                  "lle.arrow_key_mode",   CONFIG_TYPE_ENUM,    CONFIG_SECTION_HISTORY,
      &config.lle_arrow_key_mode,                   "Arrow key behavior mode",
-     config_validate_lle_arrow_mode,     &lle_arrow_mode_enum                                                                       },
+     config_validate_lle_arrow_mode,        &lle_arrow_mode_enum                                                                             },
     {     "lle.enable_multiline_navigation",   CONFIG_TYPE_BOOL,
      CONFIG_SECTION_HISTORY,  &config.lle_enable_multiline_navigation,
-     "Enable vertical cursor navigation in multiline",            config_validate_bool,
-     NULL                                                                                                                           },
+     "Enable vertical cursor navigation in multiline",                  config_validate_bool,
+     NULL                                                                                                                                    },
     {         "lle.wrap_history_navigation",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_wrap_history_navigation,         "Wrap around at history boundaries",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {        "lle.save_line_on_history_nav",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_save_line_on_history_nav,
-     "Save current line when navigating history",            config_validate_bool,                     NULL                         },
+     "Save current line when navigating history",                  config_validate_bool,                        NULL                         },
     {    "lle.preserve_multiline_structure",   CONFIG_TYPE_BOOL,
      CONFIG_SECTION_HISTORY, &config.lle_preserve_multiline_structure,
-     "Preserve multiline structure in history",            config_validate_bool,                     NULL                           },
+     "Preserve multiline structure in history",                  config_validate_bool,                        NULL                           },
     {        "lle.enable_multiline_editing",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_enable_multiline_editing,
-     "Enable editing of recalled multiline commands",            config_validate_bool,
-     NULL                                                                                                                           },
+     "Enable editing of recalled multiline commands",                  config_validate_bool,
+     NULL                                                                                                                                    },
     {       "lle.show_multiline_indicators",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_show_multiline_indicators,
-     "Show visual indicators for multiline",            config_validate_bool,                     NULL                              },
+     "Show visual indicators for multiline",                  config_validate_bool,                        NULL                              },
     {       "lle.enable_interactive_search",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_enable_interactive_search,          "Enable Ctrl-R interactive search",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {           "lle.search_fuzzy_matching",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_search_fuzzy_matching,              "Use fuzzy matching in search",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {           "lle.search_case_sensitive",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_search_case_sensitive,             "Case sensitive history search",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {                    "lle.storage_mode",   CONFIG_TYPE_ENUM,    CONFIG_SECTION_HISTORY,
      &config.lle_storage_mode,                      "History storage mode",
-     config_validate_lle_storage_mode,   &lle_storage_mode_enum                                                                     },
+     config_validate_lle_storage_mode,      &lle_storage_mode_enum                                                                           },
     {                    "lle.history_file", CONFIG_TYPE_STRING,    CONFIG_SECTION_HISTORY,
-     &config.lle_history_file,                     "LLE history file path",          config_validate_string,
-     NULL                                                                                                                           },
+     &config.lle_history_file,                     "LLE history file path",                config_validate_string,
+     NULL                                                                                                                                    },
     {              "lle.sync_with_readline",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_sync_with_readline,        "Sync LLE history with GNU Readline",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {          "lle.export_to_bash_history",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_export_to_bash_history,            "Export to .bash_history format",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {        "lle.enable_forensic_tracking",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_enable_forensic_tracking,
-     "Track metadata (timestamps, exit codes, cwd)",            config_validate_bool,
-     NULL                                                                                                                           },
+     "Track metadata (timestamps, exit codes, cwd)",                  config_validate_bool,
+     NULL                                                                                                                                    },
     {            "lle.enable_deduplication",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_enable_deduplication,              "Enable history deduplication",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {                     "lle.dedup_scope",   CONFIG_TYPE_ENUM,    CONFIG_SECTION_HISTORY,
      &config.lle_dedup_scope,                       "Deduplication scope",
-     config_validate_lle_dedup_scope,    &lle_dedup_scope_enum                                                                      },
+     config_validate_lle_dedup_scope,       &lle_dedup_scope_enum                                                                            },
     {                  "lle.dedup_strategy",   CONFIG_TYPE_ENUM,    CONFIG_SECTION_HISTORY,
      &config.lle_dedup_strategy,                    "Deduplication strategy",
-     config_validate_lle_dedup_strategy, &lle_dedup_strategy_enum                                                                   },
+     config_validate_lle_dedup_strategy,    &lle_dedup_strategy_enum                                                                         },
     {                "lle.dedup_navigation",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_dedup_navigation, "Skip duplicates during history navigation",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {         "lle.dedup_navigation_unique",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_dedup_navigation_unique,
-     "Show only unique entries during navigation session",            config_validate_bool,
-     NULL                                                                                                                           },
+     "Show only unique entries during navigation session",                  config_validate_bool,
+     NULL                                                                                                                                    },
     {         "lle.dedup_unicode_normalize",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_dedup_unicode_normalize,
-     "Use Unicode NFC normalization for dedup comparison",            config_validate_bool,
-     NULL                                                                                                                           },
+     "Use Unicode NFC normalization for dedup comparison",                  config_validate_bool,
+     NULL                                                                                                                                    },
     {            "lle.enable_history_cache",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_enable_history_cache,    "Enable history caching for performance",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {                      "lle.cache_size",    CONFIG_TYPE_INT,    CONFIG_SECTION_HISTORY,
-     &config.lle_cache_size,                        "History cache size",             config_validate_int,                     NULL },
+     &config.lle_cache_size,                        "History cache size",                   config_validate_int,                        NULL },
     {        "lle.readline_compatible_mode",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_HISTORY,
      &config.lle_readline_compatible_mode,           "GNU Readline compatibility mode",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
 
     /// Completion settings
     {                  "completion.enabled",   CONFIG_TYPE_BOOL, CONFIG_SECTION_COMPLETION,
-     &config.completion_enabled,                     "Enable tab completion",            config_validate_bool,
-     NULL                                                                                                                           },
-    {                    "completion.fuzzy",   CONFIG_TYPE_BOOL, CONFIG_SECTION_COMPLETION,
-     &config.fuzzy_completion,       "Enable fuzzy matching in completion",
-     config_validate_bool,                     NULL                                                                                 },
+     &config.completion_enabled,                     "Enable tab completion",                  config_validate_bool,
+     NULL                                                                                                                                    },
+    {               "completion.match_mode",   CONFIG_TYPE_ENUM, CONFIG_SECTION_COMPLETION,
+     &config.completion_match_mode,
+     "Completion match predicate "
+     "(prefix / substring / fuzzy)", config_validate_completion_match_mode, &completion_match_mode_enum                                      },
     {                "completion.threshold",    CONFIG_TYPE_INT, CONFIG_SECTION_COMPLETION,
      &config.completion_threshold,          "Fuzzy matching threshold (0-100)",
-     config_validate_int,                     NULL                                                                                  },
+     config_validate_int,                        NULL                                                                                        },
     {           "completion.case_sensitive",   CONFIG_TYPE_BOOL, CONFIG_SECTION_COMPLETION,
      &config.completion_case_sensitive,                 "Case sensitive completion",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {                 "completion.show_all",   CONFIG_TYPE_BOOL, CONFIG_SECTION_COMPLETION,
-     &config.completion_show_all,                      "Show all completions",            config_validate_bool,
-     NULL                                                                                                                           },
+     &config.completion_show_all,                      "Show all completions",                  config_validate_bool,
+     NULL                                                                                                                                    },
     {                    "completion.hints",   CONFIG_TYPE_BOOL, CONFIG_SECTION_COMPLETION,
-     &config.hints_enabled,                        "Enable input hints",            config_validate_bool,                     NULL  },
+     &config.hints_enabled,                        "Enable input hints",                  config_validate_bool,                        NULL  },
 
     /// Prompt settings
     {                    "prompt.use_theme",   CONFIG_TYPE_BOOL,     CONFIG_SECTION_PROMPT,
      &config.use_theme_prompt,
-     "Use theme system for prompts (false = respect user PS1/PS2)",            config_validate_bool,                     NULL       },
+     "Use theme system for prompts (false = respect user PS1/PS2)",                  config_validate_bool,                        NULL       },
     {                        "prompt.theme", CONFIG_TYPE_STRING,     CONFIG_SECTION_PROMPT,
-     &config.prompt_theme,                        "Prompt color theme",          config_validate_string,                     NULL   },
+     &config.prompt_theme,                        "Prompt color theme",                config_validate_string,                        NULL   },
     {                  "prompt.git_enabled",   CONFIG_TYPE_BOOL,     CONFIG_SECTION_PROMPT,
      &config.git_prompt_enabled,                  "Enable git-aware prompts",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {            "prompt.git_cache_timeout",    CONFIG_TYPE_INT,     CONFIG_SECTION_PROMPT,
      &config.git_cache_timeout,       "Git status cache timeout in seconds",
-     config_validate_int,                     NULL                                                                                  },
+     config_validate_int,                        NULL                                                                                        },
     {                       "prompt.format", CONFIG_TYPE_STRING,     CONFIG_SECTION_PROMPT,
      &config.prompt_format,               "Custom prompt format string",
-     config_validate_string,                     NULL                                                                               },
+     config_validate_string,                        NULL                                                                                     },
 
     /// Theme settings
     {                   "prompt.theme_name", CONFIG_TYPE_STRING,     CONFIG_SECTION_PROMPT,
-     &config.theme_name,                         "Active theme name",          config_validate_string,                     NULL     },
+     &config.theme_name,                         "Active theme name",                config_validate_string,                        NULL     },
     {     "prompt.theme_auto_detect_colors",   CONFIG_TYPE_BOOL,     CONFIG_SECTION_PROMPT,
      &config.theme_auto_detect_colors,        "Auto-detect terminal color support",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {         "prompt.theme_fallback_basic",   CONFIG_TYPE_BOOL,     CONFIG_SECTION_PROMPT,
      &config.theme_fallback_basic,        "Fallback to basic colors if needed",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {      "prompt.theme_corporate_company", CONFIG_TYPE_STRING,
      CONFIG_SECTION_PROMPT,          &config.theme_corporate_company,
-     "Corporate company name",          config_validate_string,                     NULL                                            },
+     "Corporate company name",                config_validate_string,                        NULL                                            },
     {   "prompt.theme_corporate_department", CONFIG_TYPE_STRING,
      CONFIG_SECTION_PROMPT,       &config.theme_corporate_department,
-     "Corporate department name",          config_validate_string,                     NULL                                         },
+     "Corporate department name",                config_validate_string,                        NULL                                         },
     {      "prompt.theme_corporate_project", CONFIG_TYPE_STRING,
      CONFIG_SECTION_PROMPT,          &config.theme_corporate_project,
-     "Corporate project name",          config_validate_string,                     NULL                                            },
+     "Corporate project name",                config_validate_string,                        NULL                                            },
     {  "prompt.theme_corporate_environment", CONFIG_TYPE_STRING,
      CONFIG_SECTION_PROMPT,      &config.theme_corporate_environment,
-     "Corporate environment name",          config_validate_string,                     NULL                                        },
+     "Corporate environment name",                config_validate_string,                        NULL                                        },
     {           "prompt.theme_show_company",   CONFIG_TYPE_BOOL,     CONFIG_SECTION_PROMPT,
      &config.theme_show_company,               "Show company name in prompt",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {        "prompt.theme_show_department",   CONFIG_TYPE_BOOL,     CONFIG_SECTION_PROMPT,
      &config.theme_show_department,            "Show department name in prompt",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {      "prompt.theme_show_right_prompt",   CONFIG_TYPE_BOOL,     CONFIG_SECTION_PROMPT,
      &config.theme_show_right_prompt,                  "Enable right-side prompt",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
 
     {      "prompt.theme_enable_animations",   CONFIG_TYPE_BOOL,     CONFIG_SECTION_PROMPT,
      &config.theme_enable_animations,                  "Enable prompt animations",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {           "prompt.theme_enable_icons",   CONFIG_TYPE_BOOL,     CONFIG_SECTION_PROMPT,
-     &config.theme_enable_icons,                      "Enable Unicode icons",            config_validate_bool,
-     NULL                                                                                                                           },
+     &config.theme_enable_icons,                      "Enable Unicode icons",                  config_validate_bool,
+     NULL                                                                                                                                    },
     { "prompt.theme_color_support_override",    CONFIG_TYPE_INT,
      CONFIG_SECTION_PROMPT,     &config.theme_color_support_override,
-     "Override color support detection (0/8/256/16777216)",             config_validate_int,
-     NULL                                                                                                                           },
+     "Override color support detection (0/8/256/16777216)",                   config_validate_int,
+     NULL                                                                                                                                    },
 
     /// Behavior settings
     {                    "behavior.auto_cd",   CONFIG_TYPE_BOOL,   CONFIG_SECTION_BEHAVIOR,
-     &config.auto_cd,                    "Auto-cd to directories",            config_validate_bool,                     NULL        },
+     &config.auto_cd,                    "Auto-cd to directories",                  config_validate_bool,                        NULL        },
     {           "behavior.spell_correction",   CONFIG_TYPE_BOOL,   CONFIG_SECTION_BEHAVIOR,
      &config.spell_correction,           "Enable command spell correction",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {"behavior.autocorrect_max_suggestions",    CONFIG_TYPE_INT,
      CONFIG_SECTION_BEHAVIOR,      &config.autocorrect_max_suggestions,
-     "Maximum auto-correction suggestions (1-5)",             config_validate_int,                     NULL                         },
+     "Maximum auto-correction suggestions (1-5)",                   config_validate_int,                        NULL                         },
     {      "behavior.autocorrect_threshold",    CONFIG_TYPE_INT,   CONFIG_SECTION_BEHAVIOR,
      &config.autocorrect_threshold,
-     "Auto-correction similarity threshold (0-100)",             config_validate_int,                     NULL                      },
+     "Auto-correction similarity threshold (0-100)",                   config_validate_int,                        NULL                      },
     {    "behavior.autocorrect_interactive",   CONFIG_TYPE_BOOL,
      CONFIG_SECTION_BEHAVIOR,          &config.autocorrect_interactive,
-     "Show interactive correction prompts",            config_validate_bool,                     NULL                               },
+     "Show interactive correction prompts",                  config_validate_bool,                        NULL                               },
     {  "behavior.autocorrect_learn_history",   CONFIG_TYPE_BOOL,
      CONFIG_SECTION_BEHAVIOR,        &config.autocorrect_learn_history,
-     "Learn commands from history",            config_validate_bool,                     NULL                                       },
+     "Learn commands from history",                  config_validate_bool,                        NULL                                       },
     {       "behavior.autocorrect_builtins",   CONFIG_TYPE_BOOL,   CONFIG_SECTION_BEHAVIOR,
      &config.autocorrect_builtins,               "Suggest builtin corrections",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {       "behavior.autocorrect_external",   CONFIG_TYPE_BOOL,   CONFIG_SECTION_BEHAVIOR,
      &config.autocorrect_external,      "Suggest external command corrections",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     { "behavior.autocorrect_case_sensitive",   CONFIG_TYPE_BOOL,
      CONFIG_SECTION_BEHAVIOR,       &config.autocorrect_case_sensitive,
-     "Case-sensitive auto-correction",            config_validate_bool,                     NULL                                    },
+     "Case-sensitive auto-correction",                  config_validate_bool,                        NULL                                    },
     {               "behavior.confirm_exit",   CONFIG_TYPE_BOOL,   CONFIG_SECTION_BEHAVIOR,
-     &config.confirm_exit,                    "Confirm before exiting",            config_validate_bool,
-     NULL                                                                                                                           },
+     &config.confirm_exit,                    "Confirm before exiting",                  config_validate_bool,
+     NULL                                                                                                                                    },
     {                  "behavior.tab_width",    CONFIG_TYPE_INT,   CONFIG_SECTION_BEHAVIOR,
-     &config.tab_width,                     "Tab width for display",             config_validate_int,                     NULL      },
+     &config.tab_width,                     "Tab width for display",                   config_validate_int,                        NULL      },
     {             "behavior.no_word_expand",   CONFIG_TYPE_BOOL,   CONFIG_SECTION_BEHAVIOR,
      &config.no_word_expand,       "Disable word expansion and globbing",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {             "behavior.multiline_mode",   CONFIG_TYPE_BOOL,   CONFIG_SECTION_BEHAVIOR,
      &config.multiline_mode,             "Enable multiline editing mode",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {        "behavior.brace_expansion_max",    CONFIG_TYPE_INT,   CONFIG_SECTION_BEHAVIOR,
      &config.brace_expansion_max,
-     "Max brace expansion result count (0 = unbounded)",             config_validate_int,
-     NULL                                                                                                                           },
+     "Max brace expansion result count (0 = unbounded)",                   config_validate_int,
+     NULL                                                                                                                                    },
     {          "behavior.regex_pattern_max",    CONFIG_TYPE_INT,   CONFIG_SECTION_BEHAVIOR,
      &config.regex_pattern_max,
      "Max regex pattern length before rejection (0 = unbounded). Bounds "
      "compile time on pathological patterns fed to platform regcomp from "
-     "[[ =~ ]] and extglob translation paths.",             config_validate_int,                     NULL                           },
+     "[[ =~ ]] and extglob translation paths.",                   config_validate_int,                        NULL                           },
     { "behavior.path_negative_cache_ttl_ms",    CONFIG_TYPE_INT,
      CONFIG_SECTION_BEHAVIOR,       &config.path_negative_cache_ttl_ms,
      "TTL in milliseconds for negative PATH-search cache. Bounds the "
      "syscall cost of repeated lookups of a missing command in tight "
      "loops to O(1) instead of O(PATH_dirs). Short enough that newly "
-     "installed binaries appear quickly. (0 = disabled)",             config_validate_int,                     NULL                 },
+     "installed binaries appear quickly. (0 = disabled)",                   config_validate_int,                        NULL                 },
     {        "behavior.loop_failure_streak",    CONFIG_TYPE_INT,   CONFIG_SECTION_BEHAVIOR,
      &config.loop_failure_streak,
      "Consecutive non-zero body iterations before runaway-loop trip (0 = "
-     "disable)",             config_validate_int,                     NULL                                                          },
+     "disable)",                   config_validate_int,                        NULL                                                          },
     {       "behavior.loop_failure_seconds",    CONFIG_TYPE_INT,   CONFIG_SECTION_BEHAVIOR,
      &config.loop_failure_seconds,
-     "Min wall-clock seconds streak must last before tripping",             config_validate_int,                     NULL           },
+     "Min wall-clock seconds streak must last before tripping",                   config_validate_int,                        NULL           },
 
     /// Color settings
     {               "behavior.color_scheme", CONFIG_TYPE_STRING,   CONFIG_SECTION_BEHAVIOR,
-     &config.color_scheme,                         "Color scheme name",    config_validate_color_scheme,
-     NULL                                                                                                                           },
+     &config.color_scheme,                         "Color scheme name",          config_validate_color_scheme,
+     NULL                                                                                                                                    },
     {             "behavior.colors_enabled",   CONFIG_TYPE_BOOL,   CONFIG_SECTION_BEHAVIOR,
-     &config.colors_enabled,                       "Enable color output",            config_validate_bool,                     NULL },
+     &config.colors_enabled,                       "Enable color output",                  config_validate_bool,                        NULL },
 
     /// Advanced settings
     {             "behavior.verbose_errors",   CONFIG_TYPE_BOOL,   CONFIG_SECTION_BEHAVIOR,
      &config.verbose_errors,               "Show verbose error messages",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {                 "behavior.debug_mode",   CONFIG_TYPE_BOOL,   CONFIG_SECTION_BEHAVIOR,
-     &config.debug_mode,                         "Enable debug mode",            config_validate_bool,                     NULL     },
+     &config.debug_mode,                         "Enable debug mode",                  config_validate_bool,                        NULL     },
 
     /// Network settings
     {              "network.ssh_completion",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_NETWORK,
      &config.ssh_completion_enabled,                "Enable SSH host completion",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {             "network.cloud_discovery",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_NETWORK,
      &config.cloud_discovery_enabled,               "Enable cloud host discovery",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {             "network.cache_ssh_hosts",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_NETWORK,
      &config.cache_ssh_hosts,           "Cache SSH hosts for performance",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {       "network.cache_timeout_minutes",    CONFIG_TYPE_INT,    CONFIG_SECTION_NETWORK,
      &config.cache_timeout_minutes,         "SSH host cache timeout in minutes",
-     config_validate_int,                     NULL                                                                                  },
+     config_validate_int,                        NULL                                                                                        },
     {         "network.show_remote_context",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_NETWORK,
      &config.show_remote_context,             "Show remote context in prompt",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {           "network.auto_detect_cloud",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_NETWORK,
      &config.auto_detect_cloud,             "Auto-detect cloud environment",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {        "network.max_completion_hosts",    CONFIG_TYPE_INT,    CONFIG_SECTION_NETWORK,
      &config.max_completion_hosts,       "Maximum hosts to show in completion",
-     config_validate_int,                     NULL                                                                                  },
+     config_validate_int,                        NULL                                                                                        },
 
     /// Display system settings
     /// v1.3.0: Layered display is now the exclusive system - no configuration
@@ -429,107 +440,107 @@ static config_option_t config_options[] = {
     /// display.system_mode and display.layered_display options removed
     {         "display.syntax_highlighting",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_DISPLAY,
      &config.display_syntax_highlighting,                "Enable syntax highlighting",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {             "display.autosuggestions",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_DISPLAY,
      &config.display_autosuggestions,         "Enable Fish-style autosuggestions",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
     {            "display.transient_prompt",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_DISPLAY,
      &config.display_transient_prompt,
-     "Enable transient prompts (simplify previous prompts in scrollback)",            config_validate_bool,                     NULL},
+     "Enable transient prompts (simplify previous prompts in scrollback)",                  config_validate_bool,                        NULL},
     {            "display.theme_hot_reload",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_DISPLAY,
      &config.display_theme_hot_reload,
-     "Auto-reload theme when its file changes on disk",            config_validate_bool,
-     NULL                                                                                                                           },
+     "Auto-reload theme when its file changes on disk",                  config_validate_bool,
+     NULL                                                                                                                                    },
     {      "display.performance_monitoring",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_DISPLAY,
      &config.display_performance_monitoring,
-     "Enable display performance monitoring",            config_validate_bool,                     NULL                             },
+     "Enable display performance monitoring",                  config_validate_bool,                        NULL                             },
     {          "display.optimization_level",    CONFIG_TYPE_INT,    CONFIG_SECTION_DISPLAY,
      &config.display_optimization_level,          "Display optimization level (0-4)",
-     config_validate_optimization_level,                     NULL                                                                   },
+     config_validate_optimization_level,                        NULL                                                                         },
     {             "display.ambiguous_width", CONFIG_TYPE_STRING,    CONFIG_SECTION_DISPLAY,
      &config.display_ambiguous_width,
      "East Asian Ambiguous-class display width: \"narrow\" (default) or "
-     "\"wide\"", config_validate_ambiguous_width,                     NULL                                                          },
+     "\"wide\"",       config_validate_ambiguous_width,                        NULL                                                          },
     {           "display.lle.pager.enabled",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_DISPLAY,
      &config.display_lle_pager_enabled,
-     "Master switch for the LLE pager (lle_pager_present)",            config_validate_bool,                     NULL               },
+     "Master switch for the LLE pager (lle_pager_present)",                  config_validate_bool,                        NULL               },
     {         "display.lle.pager.min_lines",    CONFIG_TYPE_INT,    CONFIG_SECTION_DISPLAY,
      &config.display_lle_pager_min_lines,
-     "Pager threshold in visual rows (0 = use terminal rows)",             config_validate_int,                     NULL            },
+     "Pager threshold in visual rows (0 = use terminal rows)",                   config_validate_int,                        NULL            },
     {       "display.lle.pager.wrap_search",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_DISPLAY,
      &config.display_lle_pager_wrap_search,
-     "Wrap pager search to top on no-match (less-style)",            config_validate_bool,
-     NULL                                                                                                                           },
+     "Wrap pager search to top on no-match (less-style)",                  config_validate_bool,
+     NULL                                                                                                                                    },
 
     /// v1.3.0: Legacy enhanced display mode option removed
     /// behavior.enhanced_display_mode option removed
 
     /// Script execution control
     {                   "scripts.execution",   CONFIG_TYPE_BOOL,    CONFIG_SECTION_SCRIPTS,
-     &config.script_execution,                   "Enable script execution",            config_validate_bool,
-     NULL                                                                                                                           },
+     &config.script_execution,                   "Enable script execution",                  config_validate_bool,
+     NULL                                                                                                                                    },
 
     /// Shell options integration - all 24 POSIX options with shell.* namespace
     /// These map directly to existing shell_opts flags for perfect
     /// compatibility
     {                       "shell.errexit",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Exit on command failure (set -e)",    config_validate_shell_option,                     NULL                                  },
+     "Exit on command failure (set -e)",          config_validate_shell_option,                        NULL                                  },
     {                        "shell.xtrace",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Trace command execution (set -x)",    config_validate_shell_option,                     NULL                                  },
+     "Trace command execution (set -x)",          config_validate_shell_option,                        NULL                                  },
     {                        "shell.noexec",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Syntax check only (set -n)",    config_validate_shell_option,                     NULL                                        },
+     "Syntax check only (set -n)",          config_validate_shell_option,                        NULL                                        },
     {                       "shell.nounset",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Error on unset variables (set -u)",    config_validate_shell_option,                     NULL                                 },
+     "Error on unset variables (set -u)",          config_validate_shell_option,                        NULL                                 },
     {                       "shell.verbose",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Print input lines (set -v)",    config_validate_shell_option,                     NULL                                        },
+     "Print input lines (set -v)",          config_validate_shell_option,                        NULL                                        },
     {                        "shell.noglob",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Disable pathname expansion (set -f)",    config_validate_shell_option,                     NULL                               },
+     "Disable pathname expansion (set -f)",          config_validate_shell_option,                        NULL                               },
     {                       "shell.hashall",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Command hashing (set -h)",    config_validate_shell_option,                     NULL                                          },
+     "Command hashing (set -h)",          config_validate_shell_option,                        NULL                                          },
     {                       "shell.monitor",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Job control (set -m)",    config_validate_shell_option,                     NULL                                              },
+     "Job control (set -m)",          config_validate_shell_option,                        NULL                                              },
     {                     "shell.allexport",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Auto export variables (set -a)",    config_validate_shell_option,                     NULL                                    },
+     "Auto export variables (set -a)",          config_validate_shell_option,                        NULL                                    },
     {                     "shell.noclobber",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Prevent file overwrite (set -C)",    config_validate_shell_option,                     NULL                                   },
+     "Prevent file overwrite (set -C)",          config_validate_shell_option,                        NULL                                   },
     {                        "shell.onecmd",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Exit after one command (set -t)",    config_validate_shell_option,                     NULL                                   },
+     "Exit after one command (set -t)",          config_validate_shell_option,                        NULL                                   },
     {                        "shell.notify",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Async job notification (set -b)",    config_validate_shell_option,                     NULL                                   },
+     "Async job notification (set -b)",          config_validate_shell_option,                        NULL                                   },
     {                     "shell.ignoreeof",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Prevent exit on EOF (set -o ignoreeof)",    config_validate_shell_option,
-     NULL                                                                                                                           },
+     "Prevent exit on EOF (set -o ignoreeof)",          config_validate_shell_option,
+     NULL                                                                                                                                    },
     {                         "shell.nolog",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Prevent function history logging (set -o nolog)",    config_validate_shell_option,                     NULL                   },
+     "Prevent function history logging (set -o nolog)",          config_validate_shell_option,                        NULL                   },
     {                         "shell.emacs",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Emacs-style editing (set -o emacs)",    config_validate_shell_option,                     NULL                                },
+     "Emacs-style editing (set -o emacs)",          config_validate_shell_option,                        NULL                                },
     {                            "shell.vi",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Vi-style editing (set -o vi)",    config_validate_shell_option,                     NULL                                      },
+     "Vi-style editing (set -o vi)",          config_validate_shell_option,                        NULL                                      },
     {                         "shell.posix",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Strict POSIX compliance (set -o posix)",    config_validate_shell_option,
-     NULL                                                                                                                           },
+     "Strict POSIX compliance (set -o posix)",          config_validate_shell_option,
+     NULL                                                                                                                                    },
     {                      "shell.pipefail",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Pipeline failure detection (set -o pipefail)",    config_validate_shell_option,                     NULL                      },
+     "Pipeline failure detection (set -o pipefail)",          config_validate_shell_option,                        NULL                      },
     {                    "shell.histexpand",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "History expansion (set -o histexpand)",    config_validate_shell_option,
-     NULL                                                                                                                           },
+     "History expansion (set -o histexpand)",          config_validate_shell_option,
+     NULL                                                                                                                                    },
     {                       "shell.history",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Command history recording (set -o history)",    config_validate_shell_option,
-     NULL                                                                                                                           },
+     "Command history recording (set -o history)",          config_validate_shell_option,
+     NULL                                                                                                                                    },
     {          "shell.interactive-comments",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Interactive comments (set -o interactive-comments)",    config_validate_shell_option,                     NULL                },
+     "Interactive comments (set -o interactive-comments)",          config_validate_shell_option,                        NULL                },
     {                      "shell.physical",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Physical directory paths (set -o physical)",    config_validate_shell_option,
-     NULL                                                                                                                           },
+     "Physical directory paths (set -o physical)",          config_validate_shell_option,
+     NULL                                                                                                                                    },
     {                    "shell.privileged",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,                                     NULL,
-     "Restricted shell security (set -o privileged)",    config_validate_shell_option,                     NULL                     },
+     "Restricted shell security (set -o privileged)",          config_validate_shell_option,                        NULL                     },
 
     /// Shell mode settings (Phase 0: Extended Language Support)
     {                          "shell.mode",   CONFIG_TYPE_ENUM,      CONFIG_SECTION_SHELL,                       &config.shell_mode,
-     "Shell compatibility mode (posix, bash, zsh, lush)",      config_validate_shell_mode,         &shell_mode_enum                 },
+     "Shell compatibility mode (posix, bash, zsh, lush)",            config_validate_shell_mode,            &shell_mode_enum                 },
     {                   "shell.mode_strict",   CONFIG_TYPE_BOOL,      CONFIG_SECTION_SHELL,
      &config.shell_mode_strict,             "Disallow runtime mode changes",
-     config_validate_bool,                     NULL                                                                                 },
+     config_validate_bool,                        NULL                                                                                       },
 };
 
 static const int num_config_options =
@@ -845,21 +856,20 @@ static void completion_sync_to_runtime(void) {
         CREG_SUCCESS) {
         config.completion_enabled = bval;
     }
-    if (config_registry_get_boolean("completion.fuzzy", &bval) ==
-        CREG_SUCCESS) {
-        config.fuzzy_completion = bval;
-    }
     if (config_registry_get_boolean("completion.case_sensitive", &bval) ==
         CREG_SUCCESS) {
         config.completion_case_sensitive = bval;
     }
+    /// completion.match_mode is an ENUM whose registry storage points
+    /// directly at config.completion_match_mode (see registration
+    /// block); no manual sync needed -- the registry writes the
+    /// enum value through the storage pointer on load / set.
 }
 
 /// @brief Sync completion config from runtime to registry
 static void completion_sync_from_runtime(void) {
     config_registry_set_boolean("completion.enabled",
                                 config.completion_enabled);
-    config_registry_set_boolean("completion.fuzzy", config.fuzzy_completion);
     config_registry_set_boolean("completion.case_sensitive",
                                 config.completion_case_sensitive);
 }
@@ -937,6 +947,22 @@ static void config_register_per_mode_defaults(void) {
                                      SHELL_MODE_ZSH, &bool_false);
     config_registry_set_mode_default("completion.chain_directories",
                                      SHELL_MODE_POSIX, &bool_false);
+
+    /// completion.match_mode: lush curates fuzzy (fzy-style
+    /// subsequence with positional bonuses, via
+    /// fuzzy_completion_score) as the modern UX default. posix /
+    /// bash / zsh inherit prefix matching to align with the
+    /// bash-readline + zsh-default behavior script authors expect.
+    creg_value_t match_prefix = creg_value_string("prefix");
+    creg_value_t match_fuzzy = creg_value_string("fuzzy");
+    config_registry_set_mode_default("completion.match_mode", SHELL_MODE_LUSH,
+                                     &match_fuzzy);
+    config_registry_set_mode_default("completion.match_mode", SHELL_MODE_BASH,
+                                     &match_prefix);
+    config_registry_set_mode_default("completion.match_mode", SHELL_MODE_ZSH,
+                                     &match_prefix);
+    config_registry_set_mode_default("completion.match_mode", SHELL_MODE_POSIX,
+                                     &match_prefix);
 }
 
 /**
@@ -958,6 +984,18 @@ static bool config_handle_legacy_key(const char *key, const char *value
     /// Legacy editor.use_lle option - LLE is now the only line editor
     if (strcmp(key, "editor.use_lle") == 0) {
         /// Silently ignore - LLE is always enabled
+        return true;
+    }
+
+    /// Legacy completion.fuzzy BOOL replaced by completion.match_mode
+    /// ENUM. Translate truthy -> fuzzy, falsy -> prefix so existing
+    /// rc files keep working without warnings.
+    if (strcmp(key, "completion.fuzzy") == 0) {
+        bool truthy =
+            value && (strcmp(value, "true") == 0 || strcmp(value, "1") == 0 ||
+                      strcmp(value, "on") == 0 || strcmp(value, "yes") == 0);
+        creg_value_t v = creg_value_string(truthy ? "fuzzy" : "prefix");
+        config_registry_set("completion.match_mode", &v);
         return true;
     }
 
@@ -1014,7 +1052,7 @@ static legacy_option_mapping_t legacy_mappings[] = {
 
     /// Completion options
     {          "completion_enabled",                   "completion.enabled"},
-    {            "fuzzy_completion",                     "completion.fuzzy"},
+    {       "completion_match_mode",                "completion.match_mode"},
     {        "completion_threshold",                 "completion.threshold"},
     {   "completion_case_sensitive",            "completion.case_sensitive"},
     {         "completion_show_all",                  "completion.show_all"},
@@ -1800,10 +1838,11 @@ const char *CONFIG_FILE_TEMPLATE =
     "# Enable tab completion\n"
     "completion.enabled = true\n"
     "\n"
-    "# Enable fuzzy matching in completion\n"
-    "completion.fuzzy = true\n"
+    "# Completion match predicate: prefix | substring | fuzzy\n"
+    "# Default: prefix (posix/bash/zsh), fuzzy (lush)\n"
+    "completion.match_mode = prefix\n"
     "\n"
-    "# Fuzzy matching threshold (0-100)\n"
+    "# Fuzzy matching threshold (0-100), applies when match_mode = fuzzy\n"
     "completion.threshold = 60\n"
     "\n"
     "# Case sensitive completion\n"
@@ -2223,7 +2262,7 @@ void config_set_defaults(void) {
 
     /// Completion defaults
     config.completion_enabled = true;
-    config.fuzzy_completion = true;
+    config.completion_match_mode = COMPLETION_MATCH_PREFIX;
     config.completion_threshold = 60;
     config.completion_case_sensitive = false;
     config.completion_show_all = false;
@@ -3204,8 +3243,24 @@ void config_apply_settings(void) {
     /// Basic symbol table settings
     symtable_set_global_int("CONFIG_LOADED", 1);
     symtable_set_global_int("HISTORY_NO_DUPS", config.history_no_dups ? 1 : 0);
-    symtable_set_global_int("FUZZY_COMPLETION",
-                            config.fuzzy_completion ? 1 : 0);
+    /// COMPLETION_MATCH_MODE replaces the legacy FUZZY_COMPLETION
+    /// 0/1 toggle: scripts read a stable string ("prefix" /
+    /// "substring" / "fuzzy") and can branch on the active
+    /// predicate without inspecting the registry directly.
+    const char *match_mode_name = "prefix";
+    switch (config.completion_match_mode) {
+    case COMPLETION_MATCH_SUBSTRING:
+        match_mode_name = "substring";
+        break;
+    case COMPLETION_MATCH_FUZZY:
+        match_mode_name = "fuzzy";
+        break;
+    case COMPLETION_MATCH_PREFIX:
+    default:
+        match_mode_name = "prefix";
+        break;
+    }
+    symtable_set_global("COMPLETION_MATCH_MODE", match_mode_name);
     symtable_set_global_int("COMPLETION_THRESHOLD",
                             config.completion_threshold);
 
@@ -3393,6 +3448,17 @@ bool config_validate_lle_arrow_mode(const char *value) {
             strcmp(value, "classic") == 0 ||
             strcmp(value, "always-history") == 0 ||
             strcmp(value, "multiline-first") == 0);
+}
+
+/**
+ * @brief Validate completion match mode value
+ *
+ * @param value String to validate
+ * @return True if value is a valid completion match mode
+ */
+bool config_validate_completion_match_mode(const char *value) {
+    return (strcmp(value, "prefix") == 0 || strcmp(value, "substring") == 0 ||
+            strcmp(value, "fuzzy") == 0);
 }
 
 /**

--- a/src/lle/unicode/unicode_compare.c
+++ b/src/lle/unicode/unicode_compare.c
@@ -820,6 +820,136 @@ bool lle_unicode_is_prefix_z(const char *prefix, const char *str,
                                  options);
 }
 
+/// Compare a single codepoint pair under the configured options.
+/// Folding via to_lowercase mirrors what lle_unicode_is_prefix uses
+/// on its case-insensitive path, keeping prefix and contains
+/// behaviorally aligned.
+static inline bool cp_equal_under_opts(uint32_t a, uint32_t b,
+                                       bool case_insensitive) {
+    if (a == b) {
+        return true;
+    }
+    if (!case_insensitive) {
+        return false;
+    }
+    return to_lowercase(a) == to_lowercase(b);
+}
+
+bool lle_unicode_contains(const char *needle, size_t needle_len,
+                          const char *haystack, size_t haystack_len,
+                          const lle_unicode_compare_options_t *options) {
+    if (!needle || needle_len == 0) {
+        return true; /// Empty needle matches every haystack
+    }
+    if (!haystack || haystack_len == 0) {
+        return false; /// Non-empty needle cannot be in empty haystack
+    }
+    if (needle_len > haystack_len) {
+        return false; /// Quick rejection on length
+    }
+
+    lle_unicode_compare_options_t opts =
+        options ? *options : LLE_UNICODE_COMPARE_DEFAULT;
+
+    /// Fast path: no normalization, no case folding -> memmem-style
+    /// byte search. Common for the ASCII-only inputs that dominate
+    /// shell completion candidates.
+    if (!opts.normalize && !opts.case_insensitive) {
+        for (size_t i = 0; i + needle_len <= haystack_len; i++) {
+            if (memcmp(haystack + i, needle, needle_len) == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+#define CONTAINS_NORM_BUF_SIZE 4096
+    char norm_needle[CONTAINS_NORM_BUF_SIZE];
+    char norm_hay[CONTAINS_NORM_BUF_SIZE];
+    size_t norm_needle_len, norm_hay_len;
+
+    if (opts.normalize) {
+        if (lle_unicode_normalize_nfc(needle, needle_len, norm_needle,
+                                      CONTAINS_NORM_BUF_SIZE,
+                                      &norm_needle_len) != 0) {
+            return false; /// Normalization failed; conservative reject
+        }
+        if (lle_unicode_normalize_nfc(haystack, haystack_len, norm_hay,
+                                      CONTAINS_NORM_BUF_SIZE,
+                                      &norm_hay_len) != 0) {
+            return false;
+        }
+    } else {
+        if (needle_len >= CONTAINS_NORM_BUF_SIZE ||
+            haystack_len >= CONTAINS_NORM_BUF_SIZE) {
+            return false; /// Strings exceed buffers; conservative reject
+        }
+        memcpy(norm_needle, needle, needle_len);
+        norm_needle[needle_len] = '\0';
+        norm_needle_len = needle_len;
+        memcpy(norm_hay, haystack, haystack_len);
+        norm_hay[haystack_len] = '\0';
+        norm_hay_len = haystack_len;
+    }
+
+    if (norm_needle_len > norm_hay_len) {
+        return false;
+    }
+
+    /// Codepoint-aligned search. Walk haystack one codepoint per
+    /// outer iteration; for each starting position attempt to match
+    /// the needle codepoint-by-codepoint under the configured
+    /// folding. Byte-level memmem would miss case-fold matches and
+    /// could land mid-codepoint, so the explicit decode is required
+    /// when either option diverges from raw bytes.
+    const char *hp = norm_hay;
+    const char *hp_end = norm_hay + norm_hay_len;
+    while (hp < hp_end) {
+        const char *np = norm_needle;
+        const char *np_end = norm_needle + norm_needle_len;
+        const char *sp = hp;
+        bool matched = true;
+        while (np < np_end && sp < hp_end) {
+            uint32_t cp_n, cp_h;
+            int len_n = lle_utf8_decode_codepoint(np, np_end - np, &cp_n);
+            int len_h = lle_utf8_decode_codepoint(sp, hp_end - sp, &cp_h);
+            if (len_n <= 0 || len_h <= 0) {
+                matched = false;
+                break;
+            }
+            if (!cp_equal_under_opts(cp_n, cp_h, opts.case_insensitive)) {
+                matched = false;
+                break;
+            }
+            np += len_n;
+            sp += len_h;
+        }
+        if (matched && np >= np_end) {
+            return true;
+        }
+        /// Advance haystack by one codepoint and retry.
+        uint32_t skip_cp;
+        int skip_len = lle_utf8_decode_codepoint(hp, hp_end - hp, &skip_cp);
+        if (skip_len <= 0) {
+            return false; /// Invalid UTF-8; conservative reject
+        }
+        hp += skip_len;
+    }
+    return false;
+}
+
+bool lle_unicode_contains_z(const char *needle, const char *haystack,
+                            const lle_unicode_compare_options_t *options) {
+    if (!needle) {
+        return true;
+    }
+    if (!haystack) {
+        return false;
+    }
+    return lle_unicode_contains(needle, strlen(needle), haystack,
+                                strlen(haystack), options);
+}
+
 /**
  * @brief Compare two UTF-8 strings with explicit lengths for equality
  * @param str1 First string

--- a/tests/integration/test_compdef_e2e.c
+++ b/tests/integration/test_compdef_e2e.c
@@ -26,6 +26,7 @@
 
 #include "compdef.h"
 #include "compdef_source.h"
+#include "config.h"
 #include "executor.h"
 #include "lle/completion/completion_system.h"
 #include "lle/completion/completion_types.h"
@@ -39,6 +40,7 @@
 #include <string.h>
 
 extern void init_symtable(void);
+extern config_values_t config;
 
 #undef ASSERT
 #define ASSERT(cond, msg) ASSERT_TRUE(cond, msg)
@@ -215,6 +217,68 @@ TEST(system_dispatch_filters_candidates_by_typed_prefix) {
                 "pull filtered out by c-prefix");
 }
 
+TEST(system_dispatch_substring_mode_admits_internal_match) {
+    per_test_reset();
+    /// Substring match_mode admits candidates where the typed
+    /// prefix appears anywhere inside the candidate, not just at
+    /// the start. Buffer "git eck" -> prefix "eck" -> only
+    /// "checkout" contains "eck", so only checkout survives.
+    completion_match_mode_t saved = config.completion_match_mode;
+    config.completion_match_mode = COMPLETION_MATCH_SUBSTRING;
+
+    executor_execute_command_line(
+        test_exec,
+        "_subs() { compadd checkout branch merge clone commit pull; }", 1);
+    compdef_set("git", "_subs");
+
+    lle_completion_result_t *result = NULL;
+    lle_result_t r =
+        lle_completion_system_generate(test_system, "git eck", 7, &result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "system_generate succeeded");
+    ASSERT_NOT_NULL(result, "result is allocated");
+    ASSERT_TRUE(find_candidate(result, "checkout") >= 0,
+                "checkout contains 'eck' as a substring");
+    ASSERT_TRUE(find_candidate(result, "branch") < 0,
+                "branch does not contain 'eck'");
+    ASSERT_TRUE(find_candidate(result, "merge") < 0,
+                "merge does not contain 'eck'");
+
+    config.completion_match_mode = saved;
+}
+
+TEST(system_dispatch_fuzzy_mode_admits_subsequence) {
+    per_test_reset();
+    /// Fuzzy match_mode admits subsequence matches. Buffer
+    /// "git cko" -> prefix "cko" -> "checkout" matches the
+    /// subsequence (c then k then o appear in order).
+    completion_match_mode_t saved_mode = config.completion_match_mode;
+    int saved_threshold = config.completion_threshold;
+    config.completion_match_mode = COMPLETION_MATCH_FUZZY;
+    config.completion_threshold = 1;
+
+    executor_execute_command_line(
+        test_exec,
+        "_subs() { compadd checkout branch merge clone commit pull; }", 1);
+    compdef_set("git", "_subs");
+
+    lle_completion_result_t *result = NULL;
+    lle_result_t r =
+        lle_completion_system_generate(test_system, "git cko", 7, &result);
+    ASSERT_TRUE(r == LLE_SUCCESS, "system_generate succeeded");
+    ASSERT_NOT_NULL(result, "result is allocated");
+    ASSERT_TRUE(find_candidate(result, "checkout") >= 0,
+                "checkout is a subsequence-match for 'cko'");
+    /// `merge` has no 'k' so it can never subsequence-match;
+    /// `branch`'s subsequence is c-?-? but order is wrong (no k).
+    ASSERT_TRUE(find_candidate(result, "merge") < 0,
+                "merge fails the subsequence gate (no k)");
+    ASSERT_TRUE(find_candidate(result, "branch") < 0,
+                "branch fails the subsequence gate (no k in order)");
+
+    config.completion_match_mode = saved_mode;
+    config.completion_threshold = saved_threshold;
+}
+
 TEST(system_dispatch_passes_command_name_to_function) {
     per_test_reset();
     /// The function emits its $1 (command name) as a candidate. Going
@@ -248,6 +312,8 @@ int main(int argc, char **argv) {
     RUN_TEST(system_dispatch_skips_compdef_when_no_binding);
     RUN_TEST(system_dispatch_with_compdef_to_undefined_function);
     RUN_TEST(system_dispatch_filters_candidates_by_typed_prefix);
+    RUN_TEST(system_dispatch_substring_mode_admits_internal_match);
+    RUN_TEST(system_dispatch_fuzzy_mode_admits_subsequence);
     RUN_TEST(system_dispatch_passes_command_name_to_function);
 
     int rc = TEST_RESULT();

--- a/tests/lle/unit/test_unicode_case_compare.c
+++ b/tests/lle/unit/test_unicode_case_compare.c
@@ -269,6 +269,97 @@ static void test_prefix_case_insensitive(void) {
 }
 
 /* ============================================================================
+ * UNICODE SUBSTRING (CONTAINS) MATCHING TESTS
+ * ============================================================================
+ */
+
+static void test_contains_ascii_middle(void) {
+    TEST("ASCII contains - substring in the middle");
+    ASSERT_TRUE(lle_unicode_contains("ell", 3, "hello", 5, NULL),
+                "ell is contained in hello");
+    ASSERT_TRUE(!lle_unicode_contains("xyz", 3, "hello", 5, NULL),
+                "xyz is not contained in hello");
+    PASS();
+}
+
+static void test_contains_ascii_endpoints(void) {
+    TEST("ASCII contains - prefix and suffix substrings");
+    ASSERT_TRUE(lle_unicode_contains("hel", 3, "hello", 5, NULL),
+                "hel matches as prefix substring");
+    ASSERT_TRUE(lle_unicode_contains("llo", 3, "hello", 5, NULL),
+                "llo matches as suffix substring");
+    ASSERT_TRUE(lle_unicode_contains("hello", 5, "hello", 5, NULL),
+                "exact-length match counts as contained");
+    PASS();
+}
+
+static void test_contains_empty_needle(void) {
+    TEST("Contains - empty needle matches everything");
+    ASSERT_TRUE(lle_unicode_contains("", 0, "hello", 5, NULL),
+                "empty needle matches non-empty haystack");
+    ASSERT_TRUE(lle_unicode_contains_z("", "hello", NULL),
+                "empty needle (z) matches non-empty haystack");
+    PASS();
+}
+
+static void test_contains_empty_haystack(void) {
+    TEST("Contains - empty haystack rejects non-empty needle");
+    ASSERT_TRUE(!lle_unicode_contains("a", 1, "", 0, NULL),
+                "non-empty needle cannot be in empty haystack");
+    PASS();
+}
+
+static void test_contains_needle_longer(void) {
+    TEST("Contains - needle longer than haystack");
+    ASSERT_TRUE(!lle_unicode_contains("hello world", 11, "hello", 5, NULL),
+                "longer needle returns false");
+    PASS();
+}
+
+static void test_contains_z_basic(void) {
+    TEST("Null-terminated contains");
+    ASSERT_TRUE(lle_unicode_contains_z("lo wo", "hello world", NULL),
+                "lo wo is contained in hello world (z)");
+    ASSERT_TRUE(!lle_unicode_contains_z("zzz", "hello world", NULL),
+                "zzz is not contained in hello world (z)");
+    PASS();
+}
+
+static void test_contains_case_insensitive(void) {
+    TEST("Case-insensitive contains");
+    lle_unicode_compare_options_t opts = LLE_UNICODE_COMPARE_DEFAULT;
+    opts.case_insensitive = true;
+    ASSERT_TRUE(lle_unicode_contains("ELL", 3, "hello", 5, &opts),
+                "ELL matches hello case-insensitive");
+    ASSERT_TRUE(lle_unicode_contains("ell", 3, "HELLO", 5, &opts),
+                "ell matches HELLO case-insensitive");
+    PASS();
+}
+
+static void test_contains_case_sensitive_strict(void) {
+    TEST("Case-sensitive contains rejects cross-case match");
+    lle_unicode_compare_options_t opts = LLE_UNICODE_COMPARE_DEFAULT;
+    opts.case_insensitive = false;
+    ASSERT_TRUE(!lle_unicode_contains("ELL", 3, "hello", 5, &opts),
+                "ELL does not match hello case-sensitive");
+    PASS();
+}
+
+static void test_contains_nfc_equivalence(void) {
+    TEST("NFC-equivalent forms match under contains");
+    /// Decomposed cafe (cafe + COMBINING ACUTE U+0301) versus
+    /// precomposed cafe (U+00E9). Searching for "afe" in either
+    /// form should succeed once NFC normalization runs.
+    const char *precomposed = "caf\xC3\xA9";
+    const char *decomposed = "cafe\xCC\x81";
+    ASSERT_TRUE(lle_unicode_contains_z("af", precomposed, NULL),
+                "af contained in precomposed cafe");
+    ASSERT_TRUE(lle_unicode_contains_z("af", decomposed, NULL),
+                "af contained in decomposed cafe");
+    PASS();
+}
+
+/* ============================================================================
  * NFC NORMALIZATION TESTS
  * ============================================================================
  */
@@ -447,6 +538,15 @@ int main(void) {
     RUN_TEST(prefix_longer_than_string);
     RUN_TEST(prefix_null_terminated);
     RUN_TEST(prefix_case_insensitive);
+    RUN_TEST(contains_ascii_middle);
+    RUN_TEST(contains_ascii_endpoints);
+    RUN_TEST(contains_empty_needle);
+    RUN_TEST(contains_empty_haystack);
+    RUN_TEST(contains_needle_longer);
+    RUN_TEST(contains_z_basic);
+    RUN_TEST(contains_case_insensitive);
+    RUN_TEST(contains_case_sensitive_strict);
+    RUN_TEST(contains_nfc_equivalence);
 
     printf("NFC Normalization:\n");
     RUN_TEST(nfc_ascii_passthrough);

--- a/tests/unit/test_completion_filter.c
+++ b/tests/unit/test_completion_filter.c
@@ -1,0 +1,239 @@
+/**
+ * @file test_completion_filter.c
+ * @brief Unit tests for completion_filter_admits.
+ *
+ * Exercises the canonical filter predicate across all three
+ * completion.match_mode values. The bridge filter and (subsequent
+ * commit) the in-menu type-to-filter both consume this function;
+ * regressions here are visible as candidate ranking drift in the
+ * completion menu.
+ *
+ * @author Michael Berry <trismegustis@gmail.com>
+ * @copyright Copyright (C) 2021-2026 Michael Berry
+ */
+
+#include "completion_filter.h"
+#include "config.h"
+#include "test_framework.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern config_values_t config;
+extern void init_symtable(void);
+
+#undef ASSERT
+#define ASSERT(cond, msg) ASSERT_TRUE(cond, msg)
+
+/// Snapshot + restore guards so each test gets the configuration it
+/// expects without persisting changes across tests. Match-mode and
+/// case-sensitivity are the two knobs the filter consults; threshold
+/// matters only for fuzzy mode but is restored too for completeness.
+static completion_match_mode_t saved_mode;
+static bool saved_case_sensitive;
+static int saved_threshold;
+
+static void config_snapshot(void) {
+    saved_mode = config.completion_match_mode;
+    saved_case_sensitive = config.completion_case_sensitive;
+    saved_threshold = config.completion_threshold;
+}
+
+static void config_restore(void) {
+    config.completion_match_mode = saved_mode;
+    config.completion_case_sensitive = saved_case_sensitive;
+    config.completion_threshold = saved_threshold;
+}
+
+/* ============================================================================
+ * Empty / null edge cases (mode-independent)
+ * ============================================================================
+ */
+
+TEST(filter_empty_prefix_admits_everything) {
+    config_snapshot();
+    config.completion_match_mode = COMPLETION_MATCH_PREFIX;
+    ASSERT_TRUE(completion_filter_admits("", "anything"),
+                "empty prefix accepts any candidate");
+    ASSERT_TRUE(completion_filter_admits(NULL, "anything"),
+                "NULL prefix accepts any candidate");
+    config_restore();
+}
+
+TEST(filter_null_or_empty_candidate_rejected) {
+    config_snapshot();
+    config.completion_match_mode = COMPLETION_MATCH_PREFIX;
+    ASSERT_FALSE(completion_filter_admits("prefix", NULL),
+                 "NULL candidate is rejected");
+    ASSERT_FALSE(completion_filter_admits("prefix", ""),
+                 "empty candidate is rejected");
+    config_restore();
+}
+
+/* ============================================================================
+ * Prefix mode
+ * ============================================================================
+ */
+
+TEST(filter_prefix_mode_admits_prefix_matches) {
+    config_snapshot();
+    config.completion_match_mode = COMPLETION_MATCH_PREFIX;
+    config.completion_case_sensitive = false;
+    ASSERT_TRUE(completion_filter_admits("git", "git checkout"),
+                "prefix mode admits a prefix match");
+    ASSERT_TRUE(completion_filter_admits("c", "checkout"),
+                "single-char prefix matches");
+    ASSERT_FALSE(completion_filter_admits("checkout", "git checkout"),
+                 "prefix mode rejects substring-only matches");
+    config_restore();
+}
+
+TEST(filter_prefix_mode_case_insensitive_by_default) {
+    config_snapshot();
+    config.completion_match_mode = COMPLETION_MATCH_PREFIX;
+    config.completion_case_sensitive = false;
+    ASSERT_TRUE(completion_filter_admits("GIT", "git checkout"),
+                "case-insensitive prefix mode admits cross-case match");
+    config_restore();
+}
+
+TEST(filter_prefix_mode_case_sensitive_when_configured) {
+    config_snapshot();
+    config.completion_match_mode = COMPLETION_MATCH_PREFIX;
+    config.completion_case_sensitive = true;
+    ASSERT_FALSE(completion_filter_admits("GIT", "git checkout"),
+                 "case-sensitive prefix mode rejects cross-case match");
+    ASSERT_TRUE(completion_filter_admits("git", "git checkout"),
+                "case-sensitive prefix mode still admits exact-case match");
+    config_restore();
+}
+
+/* ============================================================================
+ * Substring mode
+ * ============================================================================
+ */
+
+TEST(filter_substring_mode_admits_internal_match) {
+    config_snapshot();
+    config.completion_match_mode = COMPLETION_MATCH_SUBSTRING;
+    ASSERT_TRUE(completion_filter_admits("check", "git checkout"),
+                "substring mode admits internal match");
+    ASSERT_TRUE(completion_filter_admits("git", "git checkout"),
+                "substring mode admits a prefix match too");
+    ASSERT_TRUE(completion_filter_admits("out", "git checkout"),
+                "substring mode admits a suffix match too");
+    ASSERT_FALSE(completion_filter_admits("xyz", "git checkout"),
+                 "substring mode rejects non-occurrence");
+    config_restore();
+}
+
+TEST(filter_substring_mode_case_insensitive_by_default) {
+    config_snapshot();
+    config.completion_match_mode = COMPLETION_MATCH_SUBSTRING;
+    config.completion_case_sensitive = false;
+    ASSERT_TRUE(completion_filter_admits("CHECK", "git checkout"),
+                "case-insensitive substring admits cross-case match");
+    config_restore();
+}
+
+/* ============================================================================
+ * Fuzzy mode
+ * ============================================================================
+ */
+
+TEST(filter_fuzzy_mode_admits_subsequence) {
+    config_snapshot();
+    config.completion_match_mode = COMPLETION_MATCH_FUZZY;
+    config.completion_threshold = 1; /// floor so any subsequence wins
+    ASSERT_TRUE(completion_filter_admits("gco", "git checkout"),
+                "fuzzy mode admits a subsequence match");
+    ASSERT_TRUE(completion_filter_admits("gco", "gcc -o file"),
+                "fuzzy mode admits any subsequence match, not just one");
+    config_restore();
+}
+
+TEST(filter_fuzzy_mode_rejects_non_subsequence) {
+    config_snapshot();
+    config.completion_match_mode = COMPLETION_MATCH_FUZZY;
+    config.completion_threshold = 1;
+    ASSERT_FALSE(completion_filter_admits("xyz", "git checkout"),
+                 "fuzzy mode rejects non-subsequence (subsequence gate)");
+    config_restore();
+}
+
+TEST(filter_fuzzy_mode_honors_threshold) {
+    config_snapshot();
+    config.completion_match_mode = COMPLETION_MATCH_FUZZY;
+    /// 99 forces only near-exact matches through. The earlier
+    /// completion_score tests show "gco" against "git checkout"
+    /// lands well below 90; threshold 99 must reject.
+    config.completion_threshold = 99;
+    ASSERT_FALSE(completion_filter_admits("gco", "git checkout"),
+                 "threshold 99 gates a mid-strength fuzzy match");
+    /// Exact match should still pass at threshold 99 (score 100).
+    ASSERT_TRUE(completion_filter_admits("git", "git"),
+                "exact match passes any non-100 threshold");
+    config_restore();
+}
+
+/* ============================================================================
+ * Mode independence: changing mode without restart changes behavior
+ * ============================================================================
+ */
+
+TEST(filter_changing_mode_changes_admission) {
+    config_snapshot();
+    config.completion_threshold = 1;
+    config.completion_case_sensitive = false;
+
+    config.completion_match_mode = COMPLETION_MATCH_PREFIX;
+    ASSERT_FALSE(completion_filter_admits("check", "git checkout"),
+                 "prefix mode rejects mid-word match");
+
+    config.completion_match_mode = COMPLETION_MATCH_SUBSTRING;
+    ASSERT_TRUE(completion_filter_admits("check", "git checkout"),
+                "substring mode admits the same input after switch");
+
+    config.completion_match_mode = COMPLETION_MATCH_FUZZY;
+    ASSERT_TRUE(completion_filter_admits("check", "git checkout"),
+                "fuzzy mode admits the same input after switch");
+    config_restore();
+}
+
+int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
+
+    /// The filter reads the central config, which assumes
+    /// config_init has run and the symtable manager is online.
+    init_symtable();
+    config_init();
+
+    printf("Running completion_filter tests\n");
+    printf("===============================\n");
+
+    printf("\nEdge cases:\n");
+    RUN_TEST(filter_empty_prefix_admits_everything);
+    RUN_TEST(filter_null_or_empty_candidate_rejected);
+
+    printf("\nPrefix mode:\n");
+    RUN_TEST(filter_prefix_mode_admits_prefix_matches);
+    RUN_TEST(filter_prefix_mode_case_insensitive_by_default);
+    RUN_TEST(filter_prefix_mode_case_sensitive_when_configured);
+
+    printf("\nSubstring mode:\n");
+    RUN_TEST(filter_substring_mode_admits_internal_match);
+    RUN_TEST(filter_substring_mode_case_insensitive_by_default);
+
+    printf("\nFuzzy mode:\n");
+    RUN_TEST(filter_fuzzy_mode_admits_subsequence);
+    RUN_TEST(filter_fuzzy_mode_rejects_non_subsequence);
+    RUN_TEST(filter_fuzzy_mode_honors_threshold);
+
+    printf("\nMode switching:\n");
+    RUN_TEST(filter_changing_mode_changes_admission);
+
+    return TEST_RESULT();
+}

--- a/tests/unit/test_config.c
+++ b/tests/unit/test_config.c
@@ -170,6 +170,29 @@ TEST(validate_lle_arrow_mode_invalid) {
 }
 
 /* ============================================================================
+ * COMPLETION MATCH MODE VALIDATION TESTS
+ * ============================================================================
+ */
+
+TEST(validate_completion_match_mode_valid) {
+    ASSERT_TRUE(config_validate_completion_match_mode("prefix"),
+                "prefix should be valid");
+    ASSERT_TRUE(config_validate_completion_match_mode("substring"),
+                "substring should be valid");
+    ASSERT_TRUE(config_validate_completion_match_mode("fuzzy"),
+                "fuzzy should be valid");
+}
+
+TEST(validate_completion_match_mode_invalid) {
+    ASSERT_FALSE(config_validate_completion_match_mode("invalid"),
+                 "invalid mode should be rejected");
+    ASSERT_FALSE(config_validate_completion_match_mode(""),
+                 "empty string should be rejected");
+    ASSERT_FALSE(config_validate_completion_match_mode("PREFIX"),
+                 "case-mismatched mode should be rejected");
+}
+
+/* ============================================================================
  * LLE STORAGE MODE VALIDATION TESTS
  * ============================================================================
  */
@@ -669,6 +692,8 @@ int main(void) {
     printf("\n=== LLE Arrow Mode Validation Tests ===\n");
     RUN_TEST(validate_lle_arrow_mode_valid);
     RUN_TEST(validate_lle_arrow_mode_invalid);
+    RUN_TEST(validate_completion_match_mode_valid);
+    RUN_TEST(validate_completion_match_mode_invalid);
 
     /// LLE storage mode validation
     printf("\n=== LLE Storage Mode Validation Tests ===\n");


### PR DESCRIPTION
## Summary

PR2 of the 3-PR type-to-filter UX arc. PR1 (#229) shipped `fuzzy_completion_score` in libfuzzy.

- Promotes the registered-but-never-consumed `completion.fuzzy` BOOL to `completion.match_mode` ENUM (`prefix` / `substring` / `fuzzy`). Per-mode defaults: prefix for posix/bash/zsh, fuzzy for lush.
- Adds `completion_filter_admits()` as the single shell-side predicate that reads `completion.match_mode`, `completion.case_sensitive`, `completion.threshold` and dispatches.
- Wires the predicate into the #228 bridge filter. Switching match_mode at runtime takes immediate effect across every compadd emit path (positional, `-a`, `-k`).
- Adds the NFC-aware substring helper that was missing: `lle_unicode_contains` / `lle_unicode_contains_z` alongside the existing prefix helpers.
- Adds `display lle completion match_mode <prefix|substring|fuzzy>` mirroring `chain_directories`.
- Legacy `completion.fuzzy = true|false` in older rc files translates to `match_mode = fuzzy|prefix`.

## Test plan

- [x] `meson test -C build` on macOS clang: 125/125 PASS
- [x] `meson test -C build` in `ubuntu:24.04` Docker: 125/125 PASS
- [x] Full clean rebuild both sides: 0 warnings
- [x] New `tests/unit/test_completion_filter.c` (11 cases): edges, all three modes, mode switching
- [x] New `tests/lle/unit/test_unicode_case_compare.c` cases (9): contains middle/endpoints, empty/longer-needle edges, case sensitivity, NFC equivalence
- [x] `tests/unit/test_config.c` validator round-trip for `completion.match_mode`
- [x] `tests/integration/test_compdef_e2e.c` substring + fuzzy mode dispatch through full source-manager pipeline
- [x] `display lle completion match_mode` round-trip verified at the shell prompt

Next: PR3 fills the `lle_completion_menu_handle_char()` stub at `completion_menu_logic.c:755-778` and hooks `lle_self_insert` / `lle_backward_delete_char` to narrow the menu in place using this same predicate.