### PR TITLE
LLE completion: in-menu type-to-filter UX

### DIFF
--- a/include/completion_filter.h
+++ b/include/completion_filter.h
@@ -45,4 +45,13 @@
  */
 bool completion_filter_admits(const char *prefix, const char *candidate);
 
+/**
+ * @brief Register the shell-side filter with the LLE menu/bridge.
+ *
+ * Calls lle_completion_set_filter_fn(completion_filter_admits) so the
+ * in-menu type-to-filter path and the compdef bridge invoke the same
+ * predicate. Idempotent; safe to call multiple times during init.
+ */
+void completion_filter_bridge_init(void);
+
 #endif /* LUSH_COMPLETION_FILTER_H */

--- a/include/lle/completion/completion_menu_state.h
+++ b/include/lle/completion/completion_menu_state.h
@@ -32,6 +32,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -61,10 +62,11 @@ typedef struct {
  * @brief Completion menu state
  */
 typedef struct {
-    lle_completion_result_t *result; /**< Completion result (not owned) */
+    lle_completion_result_t
+        *result; /**< Active view (unfiltered or filtered) */
 
     // Navigation state
-    size_t selected_index; /**< Currently selected item (global index) */
+    size_t selected_index; /**< Currently selected item (index into result) */
     size_t first_visible;  /**< First visible item index (for scrolling) */
     size_t visible_count;  /**< Number of visible items */
     size_t target_column;  /**< Sticky column for UP/DOWN navigation */
@@ -86,6 +88,29 @@ typedef struct {
 
     // Memory pool
     lle_memory_pool_t *memory_pool; /**< Memory pool for allocations */
+
+    /**
+     * @name In-menu type-to-filter state
+     *
+     * The unfiltered result is the candidate set the engine produced at
+     * TAB time. When the user types printable characters while the
+     * menu is visible, filter_string accumulates the typed input and
+     * the menu narrows by applying the configured completion predicate
+     * against (original_prefix + filter_string). The narrowed view is
+     * stored in filtered_result; @c result swaps to point at it.
+     * Backspace pops a character and re-applies. When filter_string is
+     * empty @c result points back at @c unfiltered_result.
+     */
+    /**@{*/
+    lle_completion_result_t
+        *unfiltered_result; /**< Original candidate set (not owned) */
+    lle_completion_result_t
+        *filtered_result;   /**< Narrowed view (pool-allocated) */
+    char *filter_string;    /**< Chars typed since menu opened */
+    size_t filter_len;      /**< Length of filter_string in bytes */
+    size_t filter_capacity; /**< Allocated capacity of filter_string */
+    char *original_prefix;  /**< TAB-time word prefix (pool-allocated) */
+    /**@}*/
 } lle_completion_menu_state_t;
 
 // ============================================================================
@@ -105,14 +130,17 @@ lle_completion_menu_config_t lle_completion_menu_default_config(void);
  * @param memory_pool memory pool for allocations
  * @param result completion result (caller retains ownership)
  * @param config menu configuration (NULL for defaults)
+ * @param original_prefix the word prefix at TAB time, used to
+ *        construct the combined prefix during in-menu filtering.
+ *        May be NULL or empty when the menu has no notion of a typed
+ *        prefix; the filter then operates against filter_string alone.
  * @param state output parameter for created state
  * @return LLE_SUCCESS on success, error code on failure
  */
-lle_result_t
-lle_completion_menu_state_create(lle_memory_pool_t *memory_pool,
-                                 lle_completion_result_t *result,
-                                 const lle_completion_menu_config_t *config,
-                                 lle_completion_menu_state_t **state);
+lle_result_t lle_completion_menu_state_create(
+    lle_memory_pool_t *memory_pool, lle_completion_result_t *result,
+    const lle_completion_menu_config_t *config, const char *original_prefix,
+    lle_completion_menu_state_t **state);
 
 /**
  * @brief Free menu state
@@ -225,6 +253,74 @@ lle_completion_menu_update_layout(lle_completion_menu_state_t *state,
  */
 size_t
 lle_completion_menu_get_num_columns(const lle_completion_menu_state_t *state);
+
+// ============================================================================
+// TYPE-TO-FILTER OPERATIONS
+// ============================================================================
+
+/**
+ * @brief Append one Unicode codepoint to the type-to-filter buffer.
+ *
+ * Encodes the codepoint as UTF-8, appends it to filter_string (growing
+ * the capacity as needed), then re-applies the active completion
+ * predicate against unfiltered_result. The narrowed view is stored in
+ * filtered_result and selected_index resets to 0.
+ *
+ * @param state menu state
+ * @param codepoint Unicode codepoint to append. The caller is expected
+ *        to have already verified that this is a printable character;
+ *        non-printables are not validated here.
+ * @return LLE_SUCCESS, LLE_ERROR_INVALID_PARAMETER on NULL state,
+ *         LLE_ERROR_OUT_OF_MEMORY on allocation failure.
+ */
+lle_result_t
+lle_completion_menu_append_filter_char(lle_completion_menu_state_t *state,
+                                       uint32_t codepoint);
+
+/**
+ * @brief Remove the last codepoint from the type-to-filter buffer.
+ *
+ * Walks the filter_string backwards over UTF-8 continuation bytes to
+ * find the start of the last codepoint, truncates there, then
+ * re-applies the predicate. When filter_string becomes empty the menu
+ * view swaps back to unfiltered_result. No-op (returns LLE_SUCCESS)
+ * when the buffer is already empty.
+ *
+ * @param state menu state
+ * @return LLE_SUCCESS, LLE_ERROR_INVALID_PARAMETER on NULL state.
+ */
+lle_result_t
+lle_completion_menu_pop_filter_char(lle_completion_menu_state_t *state);
+
+/**
+ * @brief Reapply the filter against the current filter_string.
+ *
+ * Constructs the combined prefix (original_prefix + filter_string) and
+ * calls lle_completion_filter_invoke for each item in unfiltered_result.
+ * Items that admit become entries in filtered_result. Empty
+ * filter_string short-circuits to swapping result back at
+ * unfiltered_result without allocating a filtered copy. selected_index
+ * is reset to 0; first_visible likewise so the new top item is
+ * immediately in view.
+ *
+ * @param state menu state
+ * @return LLE_SUCCESS, LLE_ERROR_INVALID_PARAMETER on NULL state,
+ *         LLE_ERROR_OUT_OF_MEMORY on allocation failure.
+ */
+lle_result_t
+lle_completion_menu_apply_filter(lle_completion_menu_state_t *state);
+
+/**
+ * @brief True if a non-empty filter string is currently in effect.
+ *
+ * Used by keybinding intercepts and the renderer to distinguish "menu
+ * open with type-to-filter active" from "menu open at TAB-time state".
+ *
+ * @param state menu state (may be NULL)
+ * @return true when filter_string is non-empty.
+ */
+bool lle_completion_menu_filter_active(
+    const lle_completion_menu_state_t *state);
 
 #ifdef __cplusplus
 }

--- a/include/lle/completion/menu_filter.h
+++ b/include/lle/completion/menu_filter.h
@@ -1,0 +1,67 @@
+/**
+ * @file menu_filter.h
+ * @brief LLE-side bridge to the shell's completion filter predicate.
+ *
+ * The in-menu type-to-filter pass and the bridge pre-emit filter share
+ * a single predicate (completion_filter_admits in
+ * src/completion_filter.c) that consults completion.match_mode and
+ * dispatches to lle_unicode_is_prefix_z / lle_unicode_contains_z /
+ * fuzzy_completion_score. The predicate is shell-side; this header
+ * exposes a function-pointer registration so menu logic inside liblle
+ * can invoke it without taking a hard dependency on shell-side code.
+ *
+ * Shell init registers the predicate at startup via
+ * completion_filter_bridge_init() (see src/completion_filter.c). When
+ * no predicate is registered (test stubs, early init), the invoker
+ * admits every candidate so menu code can run without special-casing
+ * the unset state.
+ *
+ * @author Michael Berry <trismegustis@gmail.com>
+ * @copyright Copyright (C) 2021-2026 Michael Berry
+ */
+
+#ifndef LLE_COMPLETION_MENU_FILTER_H
+#define LLE_COMPLETION_MENU_FILTER_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Predicate signature.
+ *
+ * Returns true if @p candidate is admitted under the active completion
+ * configuration for @p prefix. The shell-side implementation reads
+ * completion.match_mode, completion.case_sensitive, and
+ * completion.threshold each call so runtime changes take effect
+ * without re-registration.
+ */
+typedef bool (*lle_completion_filter_fn_t)(const char *prefix,
+                                           const char *candidate);
+
+/**
+ * @brief Register the predicate the menu and bridge will consult.
+ *
+ * Passing NULL clears the registration and reverts every subsequent
+ * lle_completion_filter_invoke call to admitting all candidates.
+ * Idempotent; safe to call multiple times.
+ */
+void lle_completion_set_filter_fn(lle_completion_filter_fn_t fn);
+
+/**
+ * @brief Apply the registered predicate to a (prefix, candidate) pair.
+ *
+ * Edge cases are uniform across modes:
+ *   - NULL or empty @p candidate returns false.
+ *   - NULL or empty @p prefix returns true (no filter active).
+ *   - No predicate registered returns true (open-by-default).
+ */
+bool lle_completion_filter_invoke(const char *prefix, const char *candidate);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LLE_COMPLETION_MENU_FILTER_H */

--- a/meson.build
+++ b/meson.build
@@ -2298,6 +2298,17 @@ if fs.exists('tests/unit/test_completion_filter.c')
        timeout: 30)
 endif
 
+# In-menu type-to-filter state-machine tests
+if fs.exists('tests/unit/test_menu_filter.c')
+  test_menu_filter = executable('test_menu_filter',
+                                 'tests/unit/test_menu_filter.c',
+                                 include_directories: [inc, include_directories('tests')],
+                                 dependencies: [lle_dep, libm])
+  test('Menu Type-to-Filter', test_menu_filter,
+       suite: 'lle-unit',
+       timeout: 30)
+endif
+
 # Compdef LLE source tests
 if fs.exists('tests/unit/test_compdef_source.c')
   test_compdef_source_sources = []

--- a/src/completion_filter.c
+++ b/src/completion_filter.c
@@ -12,6 +12,7 @@
 
 #include "config.h"
 #include "fuzzy_match.h"
+#include "lle/completion/menu_filter.h"
 #include "lle/unicode_compare.h"
 
 /// Project-wide config storage. Defined in src/config.c.
@@ -41,4 +42,8 @@ bool completion_filter_admits(const char *prefix, const char *candidate) {
     default:
         return lle_unicode_is_prefix_z(prefix, candidate, &cmp_opts);
     }
+}
+
+void completion_filter_bridge_init(void) {
+    lle_completion_set_filter_fn(completion_filter_admits);
 }

--- a/src/init.c
+++ b/src/init.c
@@ -22,6 +22,7 @@
 #include "compat.h"
 #include "compdef.h"
 #include "compdef_source.h"
+#include "completion_filter.h"
 #include "config.h"
 #include "dirstack.h"
 #include "errors.h"
@@ -944,6 +945,11 @@ int init(int argc, char **argv, FILE **in) {
     /// call is a no-op inside liblle; we still call it unconditionally
     /// to keep the init sequence linear.
     compdef_source_init();
+
+    /// Register completion_filter_admits with the LLE menu/bridge so
+    /// the in-menu type-to-filter pass and the compdef pre-emit
+    /// filter share a single predicate driven by completion.match_mode.
+    completion_filter_bridge_init();
 
     /// Initialize command hash table
     init_command_hash();

--- a/src/lle/completion/completion_menu_logic.c
+++ b/src/lle/completion/completion_menu_logic.c
@@ -9,7 +9,11 @@
  */
 
 #include "lle/completion/completion_menu_logic.h"
+
+#include "lle/completion/completion_menu_state.h"
+
 #include <stddef.h>
+#include <stdint.h>
 
 /**
  * @brief Ensure selected item is visible in the current view
@@ -754,11 +758,19 @@ lle_result_t lle_completion_menu_cancel(lle_completion_menu_state_t *state) {
 /**
  * @brief Handle a character input while menu is active
  *
- * Currently cancels the menu on any character input.
- * Future: implement incremental filtering.
+ * Non-printable input cancels the menu; printable input is treated as
+ * a type-to-filter character: appended to the menu's filter_string and
+ * the predicate is re-applied. When the predicate leaves zero
+ * candidates the caller is signaled to cancel (the keybinding intercept
+ * then lets the character flow through to the buffer's normal insert
+ * path), keeping the user's progress visible rather than silently
+ * swallowing the typed character.
  *
  * @param state Menu state to modify
- * @param c Character that was typed
+ * @param c Character that was typed (single byte; non-ASCII printable
+ *          characters that should narrow the menu must be appended via
+ *          lle_completion_menu_append_filter_char directly with their
+ *          full codepoint)
  * @param should_cancel Output flag indicating if menu should be cancelled
  * @return LLE_SUCCESS on success, LLE_ERROR_INVALID_PARAMETER on error
  */
@@ -768,11 +780,34 @@ lle_result_t lle_completion_menu_handle_char(lle_completion_menu_state_t *state,
         return LLE_ERROR_INVALID_PARAMETER;
     }
 
-    /// For now, any character input cancels the menu
-    /// Future: implement incremental filtering
-    (void)c; /// Unused for now
-    *should_cancel = true;
-    state->menu_active = false;
+    unsigned char uc = (unsigned char)c;
+    /// Non-printable input cancels the menu. The printable range is
+    /// 0x20-0x7E; control characters and high bytes fall through to
+    /// the existing dismiss-on-char behavior.
+    if (uc < 0x20 || uc > 0x7E) {
+        *should_cancel = true;
+        state->menu_active = false;
+        return LLE_SUCCESS;
+    }
 
+    /// Printable: append to filter and re-apply the predicate.
+    lle_result_t res =
+        lle_completion_menu_append_filter_char(state, (uint32_t)uc);
+    if (res != LLE_SUCCESS) {
+        *should_cancel = true;
+        state->menu_active = false;
+        return res;
+    }
+
+    /// Empty result after filter means no candidate matches the user's
+    /// typed input. Cancel so the keybinding intercept lets the char
+    /// fall through to a normal buffer insert; the menu does not
+    /// linger in an empty "no matches" state.
+    if (state->result == NULL || state->result->count == 0) {
+        *should_cancel = true;
+        state->menu_active = false;
+    } else {
+        *should_cancel = false;
+    }
     return LLE_SUCCESS;
 }

--- a/src/lle/completion/completion_menu_state.c
+++ b/src/lle/completion/completion_menu_state.c
@@ -16,6 +16,11 @@
  */
 
 #include "lle/completion/completion_menu_state.h"
+
+#include "lle/completion/menu_filter.h"
+#include "lle/utf8_support.h"
+
+#include <stdint.h>
 #include <string.h>
 
 /// ============================================================================
@@ -108,11 +113,10 @@ calculate_category_positions(lle_completion_menu_state_t *state) {
  * @param state Output for created state
  * @return LLE_SUCCESS or error code
  */
-lle_result_t
-lle_completion_menu_state_create(lle_memory_pool_t *memory_pool,
-                                 lle_completion_result_t *result,
-                                 const lle_completion_menu_config_t *config,
-                                 lle_completion_menu_state_t **state) {
+lle_result_t lle_completion_menu_state_create(
+    lle_memory_pool_t *memory_pool, lle_completion_result_t *result,
+    const lle_completion_menu_config_t *config, const char *original_prefix,
+    lle_completion_menu_state_t **state) {
     if (!memory_pool || !result || !state) {
         return LLE_ERROR_INVALID_PARAMETER;
     }
@@ -135,6 +139,27 @@ lle_completion_menu_state_create(lle_memory_pool_t *memory_pool,
     new_state->category_count = 0;
     new_state->menu_active = true; /// Menu is active when created
     new_state->memory_pool = memory_pool;
+
+    /// In-menu type-to-filter state. unfiltered_result aliases the
+    /// engine's result so apply_filter has a stable source to scan;
+    /// filter_string starts empty and lazily allocates on first
+    /// append. original_prefix is duplicated into the pool when the
+    /// caller passes a non-empty value so it survives the source
+    /// context's lifetime.
+    new_state->unfiltered_result = result;
+    new_state->filtered_result = NULL;
+    new_state->filter_string = NULL;
+    new_state->filter_len = 0;
+    new_state->filter_capacity = 0;
+    new_state->original_prefix = NULL;
+    if (original_prefix && original_prefix[0] != '\0') {
+        size_t pref_len = strlen(original_prefix);
+        new_state->original_prefix = (char *)lle_pool_alloc(pref_len + 1);
+        if (new_state->original_prefix) {
+            memcpy(new_state->original_prefix, original_prefix, pref_len);
+            new_state->original_prefix[pref_len] = '\0';
+        }
+    }
 
     /// Copy configuration or use defaults
     if (config) {
@@ -181,11 +206,201 @@ lle_completion_menu_state_free(lle_completion_menu_state_t *state) {
         lle_pool_free(state->category_positions);
     }
 
+    /// Filter-state buffers are pool-allocated; release them so a
+    /// recycled pool does not retain stale entries. unfiltered_result
+    /// is owned by the completion system; filtered_result owns its
+    /// items array (pool-allocated) but not the per-item strings
+    /// (those alias into unfiltered_result and the completion
+    /// system's pool).
+    if (state->filter_string) {
+        lle_pool_free(state->filter_string);
+    }
+    if (state->original_prefix) {
+        lle_pool_free(state->original_prefix);
+    }
+    if (state->filtered_result) {
+        if (state->filtered_result->items) {
+            lle_pool_free(state->filtered_result->items);
+        }
+        lle_pool_free(state->filtered_result);
+    }
+
     /// Free state structure
     /// Note: result is owned by caller, so we don't free it
     lle_pool_free(state);
 
     return LLE_SUCCESS;
+}
+
+/// ============================================================================
+/// TYPE-TO-FILTER STATE OPERATIONS
+/// ============================================================================
+
+/// Build the combined prefix used by the filter predicate. Writes up
+/// to out_size-1 bytes followed by a NUL. Returns the bytes written
+/// (excluding NUL), or -1 if the combined string would not fit.
+static int combine_prefix(const lle_completion_menu_state_t *state, char *out,
+                          size_t out_size) {
+    size_t orig_len =
+        state->original_prefix ? strlen(state->original_prefix) : 0;
+    size_t total = orig_len + state->filter_len;
+    if (total + 1 > out_size) {
+        return -1;
+    }
+    if (orig_len) {
+        memcpy(out, state->original_prefix, orig_len);
+    }
+    if (state->filter_len) {
+        memcpy(out + orig_len, state->filter_string, state->filter_len);
+    }
+    out[total] = '\0';
+    return (int)total;
+}
+
+bool lle_completion_menu_filter_active(
+    const lle_completion_menu_state_t *state) {
+    return state != NULL && state->filter_len > 0;
+}
+
+lle_result_t
+lle_completion_menu_apply_filter(lle_completion_menu_state_t *state) {
+    if (!state) {
+        return LLE_ERROR_INVALID_PARAMETER;
+    }
+    if (!state->unfiltered_result) {
+        /// Menu has no source to scan -- nothing to do.
+        return LLE_SUCCESS;
+    }
+
+    /// Empty filter clamps back to the unfiltered view. The filtered
+    /// items buffer is intentionally retained so future filter
+    /// additions can reuse its capacity without a second allocation.
+    if (state->filter_len == 0) {
+        state->result = state->unfiltered_result;
+        state->selected_index = 0;
+        state->first_visible = 0;
+        return LLE_SUCCESS;
+    }
+
+    char combined[1024];
+    if (combine_prefix(state, combined, sizeof(combined)) < 0) {
+        /// Combined prefix exceeds our scratch buffer; refuse to
+        /// narrow rather than truncate (truncation would silently
+        /// admit candidates that don't match the actual input).
+        return LLE_ERROR_OUT_OF_MEMORY;
+    }
+
+    /// Lazily allocate the filtered_result container and items array
+    /// on first use. The items array is sized to the full unfiltered
+    /// capacity so it never reallocates as filtered_count grows or
+    /// shrinks between filter passes.
+    if (!state->filtered_result) {
+        state->filtered_result = (lle_completion_result_t *)lle_pool_alloc(
+            sizeof(lle_completion_result_t));
+        if (!state->filtered_result) {
+            return LLE_ERROR_OUT_OF_MEMORY;
+        }
+        memset(state->filtered_result, 0, sizeof(lle_completion_result_t));
+        size_t cap = state->unfiltered_result->count;
+        if (cap == 0) {
+            cap = 1;
+        }
+        state->filtered_result->items = (lle_completion_item_t *)lle_pool_alloc(
+            cap * sizeof(lle_completion_item_t));
+        if (!state->filtered_result->items) {
+            return LLE_ERROR_OUT_OF_MEMORY;
+        }
+        state->filtered_result->capacity = cap;
+    }
+
+    /// Shallow-copy admitted items; per-item strings live in the
+    /// unfiltered result's pool and are not duplicated.
+    size_t kept = 0;
+    for (size_t i = 0; i < state->unfiltered_result->count; i++) {
+        const lle_completion_item_t *item = &state->unfiltered_result->items[i];
+        if (!item->text) {
+            continue;
+        }
+        if (lle_completion_filter_invoke(combined, item->text)) {
+            state->filtered_result->items[kept++] = *item;
+        }
+    }
+    state->filtered_result->count = kept;
+
+    state->result = state->filtered_result;
+    state->selected_index = 0;
+    state->first_visible = 0;
+    return LLE_SUCCESS;
+}
+
+lle_result_t
+lle_completion_menu_append_filter_char(lle_completion_menu_state_t *state,
+                                       uint32_t codepoint) {
+    if (!state) {
+        return LLE_ERROR_INVALID_PARAMETER;
+    }
+
+    char encoded[4];
+    int n = lle_utf8_encode_codepoint(codepoint, encoded);
+    if (n <= 0) {
+        return LLE_ERROR_INVALID_PARAMETER;
+    }
+
+    /// Grow filter_string to fit. Start at 16 bytes (enough for any
+    /// realistic shell filter session) and double thereafter so the
+    /// amortized cost stays linear in the typed length.
+    size_t needed = state->filter_len + (size_t)n + 1;
+    if (needed > state->filter_capacity) {
+        size_t new_cap = state->filter_capacity ? state->filter_capacity : 16;
+        while (new_cap < needed) {
+            new_cap *= 2;
+        }
+        char *new_buf = (char *)lle_pool_alloc(new_cap);
+        if (!new_buf) {
+            return LLE_ERROR_OUT_OF_MEMORY;
+        }
+        if (state->filter_len) {
+            memcpy(new_buf, state->filter_string, state->filter_len);
+        }
+        if (state->filter_string) {
+            lle_pool_free(state->filter_string);
+        }
+        state->filter_string = new_buf;
+        state->filter_capacity = new_cap;
+    }
+
+    memcpy(state->filter_string + state->filter_len, encoded, (size_t)n);
+    state->filter_len += (size_t)n;
+    state->filter_string[state->filter_len] = '\0';
+
+    return lle_completion_menu_apply_filter(state);
+}
+
+lle_result_t
+lle_completion_menu_pop_filter_char(lle_completion_menu_state_t *state) {
+    if (!state) {
+        return LLE_ERROR_INVALID_PARAMETER;
+    }
+    if (state->filter_len == 0) {
+        return LLE_SUCCESS;
+    }
+
+    /// Walk backward over UTF-8 continuation bytes (0x80-0xBF) to find
+    /// the start of the last codepoint, then truncate there. A single
+    /// ASCII byte hits the != continuation test on the first
+    /// iteration so the cost is constant for the common case.
+    size_t i = state->filter_len;
+    while (i > 0) {
+        i--;
+        unsigned char b = (unsigned char)state->filter_string[i];
+        if ((b & 0xC0) != 0x80) {
+            break;
+        }
+    }
+    state->filter_len = i;
+    state->filter_string[i] = '\0';
+
+    return lle_completion_menu_apply_filter(state);
 }
 
 /// ============================================================================

--- a/src/lle/completion/completion_system.c
+++ b/src/lle/completion/completion_system.c
@@ -276,8 +276,16 @@ lle_completion_system_generate(lle_completion_system_t *system,
             .enable_scrolling = true,
             .min_items_for_menu = 2};
 
-        res = lle_completion_menu_state_create(system->pool, result,
-                                               &menu_config, &menu);
+        /// Pass the dequoted word prefix so the menu's in-menu
+        /// type-to-filter pass can construct the combined prefix
+        /// (original_prefix + filter_string) when the user types
+        /// additional characters while the menu is open.
+        const char *original_prefix =
+            (context && context->dequoted_filename_prefix)
+                ? context->dequoted_filename_prefix
+                : "";
+        res = lle_completion_menu_state_create(
+            system->pool, result, &menu_config, original_prefix, &menu);
         if (res != LLE_SUCCESS) {
             /// state owns result and context, so freeing state frees them too.
             /// Do NOT call result_free or context_free separately - that would

--- a/src/lle/completion/menu_filter.c
+++ b/src/lle/completion/menu_filter.c
@@ -1,0 +1,32 @@
+/**
+ * @file menu_filter.c
+ * @brief Function-pointer dispatch for the shell completion predicate.
+ *
+ * See include/lle/completion/menu_filter.h for the contract.
+ *
+ * @author Michael Berry <trismegustis@gmail.com>
+ * @copyright Copyright (C) 2021-2026 Michael Berry
+ */
+
+#include "lle/completion/menu_filter.h"
+
+#include <stddef.h>
+
+static lle_completion_filter_fn_t g_filter_fn = NULL;
+
+void lle_completion_set_filter_fn(lle_completion_filter_fn_t fn) {
+    g_filter_fn = fn;
+}
+
+bool lle_completion_filter_invoke(const char *prefix, const char *candidate) {
+    if (!candidate || candidate[0] == '\0') {
+        return false;
+    }
+    if (!prefix || prefix[0] == '\0') {
+        return true;
+    }
+    if (!g_filter_fn) {
+        return true;
+    }
+    return g_filter_fn(prefix, candidate);
+}

--- a/src/lle/keybinding/keybinding_actions.c
+++ b/src/lle/keybinding/keybinding_actions.c
@@ -1187,9 +1187,31 @@ lle_result_t lle_backward_delete_char(lle_editor_t *editor) {
         return LLE_ERROR_INVALID_PARAMETER;
     }
 
-    /// Dismiss completion menu on backspace
+    /// In-menu type-to-filter: when the menu is open and the user has
+    /// already typed filter characters, backspace widens the filter
+    /// by one codepoint rather than mutating the buffer. When no
+    /// filter is active, backspace dismisses the menu and proceeds
+    /// to a normal buffer delete -- the legacy behavior.
     if (editor->completion_system &&
         lle_completion_system_is_menu_visible(editor->completion_system)) {
+        lle_completion_menu_state_t *menu =
+            lle_completion_system_get_menu(editor->completion_system);
+        if (menu && lle_completion_menu_filter_active(menu)) {
+            lle_result_t pres = lle_completion_menu_pop_filter_char(menu);
+            if (pres == LLE_SUCCESS && menu->result &&
+                menu->result->count > 0) {
+                lle_completion_state_t *cstate =
+                    lle_completion_system_get_state(editor->completion_system);
+                if (cstate) {
+                    update_inline_completion(editor, menu, cstate);
+                }
+                display_controller_t *dc = display_integration_get_controller();
+                if (dc) {
+                    dc->menu_state_changed = true;
+                }
+                return LLE_SUCCESS;
+            }
+        }
         clear_completion_menu(editor);
     }
 
@@ -2962,9 +2984,40 @@ lle_result_t lle_self_insert(lle_editor_t *editor, uint32_t codepoint) {
         return LLE_ERROR_INVALID_PARAMETER;
     }
 
-    /// Dismiss completion menu on character input
+    /// In-menu type-to-filter: when the completion menu is visible and
+    /// the user types a printable character, treat it as a filter
+    /// keystroke rather than a buffer insert. The narrowed menu's new
+    /// top candidate is previewed in place of the prior preview, so
+    /// the buffer continuously reflects the most-relevant completion
+    /// for what has been typed so far. Non-printable input or a
+    /// filter that admits zero candidates falls through to the
+    /// legacy dismiss-on-char path; the character is then inserted
+    /// into the buffer normally.
     if (editor->completion_system &&
         lle_completion_system_is_menu_visible(editor->completion_system)) {
+        bool printable = codepoint >= 0x20 && codepoint != 0x7F;
+        lle_completion_menu_state_t *menu =
+            lle_completion_system_get_menu(editor->completion_system);
+        if (printable && menu) {
+            lle_result_t fres =
+                lle_completion_menu_append_filter_char(menu, codepoint);
+            if (fres == LLE_SUCCESS && menu->result &&
+                menu->result->count > 0) {
+                lle_completion_state_t *cstate =
+                    lle_completion_system_get_state(editor->completion_system);
+                if (cstate) {
+                    update_inline_completion(editor, menu, cstate);
+                }
+                display_controller_t *dc = display_integration_get_controller();
+                if (dc) {
+                    dc->menu_state_changed = true;
+                }
+                return LLE_SUCCESS;
+            }
+            /// Filter admitted nothing or allocation failed -- drop
+            /// to the normal dismiss path so the user retains
+            /// progress and the typed character lands in the buffer.
+        }
         clear_completion_menu(editor);
     }
 

--- a/src/lle/meson.build
+++ b/src/lle/meson.build
@@ -205,6 +205,7 @@ lle_sources += files(
   'completion/completion_menu_state.c',
   'completion/completion_menu_logic.c',
   'completion/completion_menu_renderer.c',
+  'completion/menu_filter.c',
   'completion/source_manager.c',
   'completion/completion_state.c',
   'completion/completion_system.c',

--- a/tests/integration/test_pty_compdef.c
+++ b/tests/integration/test_pty_compdef.c
@@ -145,6 +145,48 @@ int main(int argc, char **argv_main) {
                 s.out_len, s.output);
     }
 
+    /// In-menu type-to-filter: open the menu with a bare prefix,
+    /// then type additional characters while the menu is visible.
+    /// The new chars must narrow the menu rather than insert into
+    /// the buffer; "checkout" must stay visible after typing "h"
+    /// because it is the only candidate that matches "ch".
+    pty_send(&s, "\x03");
+    pty_drain(&s, 100);
+
+    s.out_len = 0;
+    s.output[0] = '\0';
+    /// Open menu with prefix "c": all three c-prefix candidates
+    /// (checkout, clone, commit) appear; first is auto-previewed.
+    pty_send(&s, "git c\t");
+    pty_drain(&s, 500);
+    /// Type 'h' while menu is open. The keybinding intercept treats
+    /// it as a filter keystroke; result must narrow to "checkout"
+    /// only.
+    pty_send(&s, "h");
+    pty_drain(&s, 500);
+
+    if (!strstr(s.output, "checkout")) {
+        fprintf(stderr,
+                "test_pty_compdef: 'checkout' missing after in-menu 'h'\n");
+        failures++;
+    }
+    if (strstr(s.output, "clone")) {
+        fprintf(stderr, "test_pty_compdef: 'clone' leaked after in-menu 'h'\n");
+        failures++;
+    }
+    if (strstr(s.output, "commit")) {
+        fprintf(stderr,
+                "test_pty_compdef: 'commit' leaked after in-menu 'h'\n");
+        failures++;
+    }
+
+    if (failures) {
+        fprintf(stderr,
+                "test_pty_compdef: in-menu type-to-filter output "
+                "(%zu bytes):\n---\n%s\n---\n",
+                s.out_len, s.output);
+    }
+
     pty_send(&s, "\x03");
     pty_drain(&s, 100);
     pty_send(&s, "exit\r");

--- a/tests/unit/test_menu_filter.c
+++ b/tests/unit/test_menu_filter.c
@@ -1,0 +1,296 @@
+/**
+ * @file test_menu_filter.c
+ * @brief Unit tests for the in-menu type-to-filter state machine.
+ *
+ * Exercises lle_completion_menu_state_t's filter fields end-to-end:
+ *   - append_filter_char narrows the active view
+ *   - pop_filter_char widens it
+ *   - apply_filter against an empty filter swaps back to unfiltered
+ *   - filter_active reports the active/inactive transition
+ *   - the menu-filter function-pointer bridge is honored
+ *
+ * Uses a real lush memory pool and a real lle_completion_result_t so
+ * the pool-allocation paths inside the new APIs are exercised. The
+ * predicate is registered with a deterministic test stand-in
+ * (case-insensitive ASCII strncmp prefix match) so test outcomes do
+ * not depend on the central config state.
+ *
+ * @author Michael Berry <trismegustis@gmail.com>
+ * @copyright Copyright (C) 2021-2026 Michael Berry
+ */
+
+#include "lle/completion/completion_menu_state.h"
+#include "lle/completion/completion_types.h"
+#include "lle/completion/menu_filter.h"
+#include "lle/memory_management.h"
+#include "lush_memory_pool.h"
+#include "test_framework.h"
+
+#include <ctype.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#undef ASSERT
+#define ASSERT(cond, msg) ASSERT_TRUE(cond, msg)
+
+static lle_memory_pool_t *test_pool = NULL;
+
+/// Test predicate: case-insensitive ASCII prefix match. Mirrors the
+/// shape of the production predicate (NULL/empty prefix admits all,
+/// NULL/empty candidate rejected) so the menu logic exercises the
+/// same edge cases the production code will.
+static bool test_filter_fn(const char *prefix, const char *candidate) {
+    if (!candidate || candidate[0] == '\0') {
+        return false;
+    }
+    if (!prefix || prefix[0] == '\0') {
+        return true;
+    }
+    size_t i = 0;
+    while (prefix[i] != '\0' && candidate[i] != '\0') {
+        if (tolower((unsigned char)prefix[i]) !=
+            tolower((unsigned char)candidate[i])) {
+            return false;
+        }
+        i++;
+    }
+    /// Prefix consumed -> candidate matched.
+    return prefix[i] == '\0';
+}
+
+static void global_setup(void) {
+    lush_pool_init(NULL);
+    lle_memory_pool_create_from_lush(&test_pool, global_memory_pool,
+                                     LLE_POOL_BUFFER);
+    lle_completion_set_filter_fn(test_filter_fn);
+}
+
+static void global_teardown(void) {
+    lle_completion_set_filter_fn(NULL);
+    if (test_pool) {
+        lle_memory_pool_destroy(test_pool);
+        test_pool = NULL;
+    }
+}
+
+/// Build a six-candidate result populated with the same set the
+/// compdef e2e tests use, so the chosen prefixes ("c", "ch", "co")
+/// produce predictable narrowed views.
+static lle_completion_result_t *make_test_result(void) {
+    lle_completion_result_t *r = NULL;
+    if (lle_completion_result_create(test_pool, 8, &r) != LLE_SUCCESS) {
+        return NULL;
+    }
+    const char *names[] = {"checkout", "branch", "merge",
+                           "clone",    "commit", "pull"};
+    for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); i++) {
+        (void)lle_completion_result_add(r, names[i], NULL,
+                                        LLE_COMPLETION_TYPE_CUSTOM, 500);
+    }
+    return r;
+}
+
+static int find_in_result(const lle_completion_result_t *r, const char *text) {
+    if (!r) {
+        return -1;
+    }
+    for (size_t i = 0; i < r->count; i++) {
+        if (r->items[i].text && strcmp(r->items[i].text, text) == 0) {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
+/* ============================================================================
+ * Filter lifecycle
+ * ============================================================================
+ */
+
+TEST(filter_inactive_after_create) {
+    lle_completion_result_t *r = make_test_result();
+    lle_completion_menu_state_t *state = NULL;
+    ASSERT_EQ(
+        lle_completion_menu_state_create(test_pool, r, NULL, "git", &state),
+        LLE_SUCCESS, "menu state created");
+    ASSERT_NOT_NULL(state, "state allocated");
+    ASSERT_FALSE(lle_completion_menu_filter_active(state),
+                 "no filter active immediately after create");
+    ASSERT_TRUE(state->result == state->unfiltered_result,
+                "result points at unfiltered view");
+    ASSERT_EQ(state->result->count, 6u, "all six candidates visible");
+    lle_completion_menu_state_free(state);
+}
+
+TEST(filter_active_after_first_char) {
+    lle_completion_result_t *r = make_test_result();
+    lle_completion_menu_state_t *state = NULL;
+    lle_completion_menu_state_create(test_pool, r, NULL, "", &state);
+
+    ASSERT_EQ(lle_completion_menu_append_filter_char(state, 'c'), LLE_SUCCESS,
+              "append 'c' succeeded");
+    ASSERT_TRUE(lle_completion_menu_filter_active(state),
+                "filter is active after appending one char");
+    /// With predicate strncmp("c", x), candidates starting with 'c'
+    /// survive: checkout, clone, commit.
+    ASSERT_EQ(state->result->count, 3u, "three c-prefix matches");
+    ASSERT_TRUE(find_in_result(state->result, "checkout") >= 0,
+                "checkout admitted");
+    ASSERT_TRUE(find_in_result(state->result, "clone") >= 0, "clone admitted");
+    ASSERT_TRUE(find_in_result(state->result, "commit") >= 0,
+                "commit admitted");
+    ASSERT_EQ(find_in_result(state->result, "branch"), -1, "branch dropped");
+    lle_completion_menu_state_free(state);
+}
+
+TEST(filter_narrows_further_with_more_chars) {
+    lle_completion_result_t *r = make_test_result();
+    lle_completion_menu_state_t *state = NULL;
+    lle_completion_menu_state_create(test_pool, r, NULL, "", &state);
+
+    lle_completion_menu_append_filter_char(state, 'c');
+    lle_completion_menu_append_filter_char(state, 'h');
+    /// "ch" prefix: only checkout matches.
+    ASSERT_EQ(state->result->count, 1u, "ch narrows to one");
+    ASSERT_TRUE(find_in_result(state->result, "checkout") >= 0,
+                "checkout admitted at 'ch'");
+    lle_completion_menu_state_free(state);
+}
+
+TEST(filter_pop_widens_view) {
+    lle_completion_result_t *r = make_test_result();
+    lle_completion_menu_state_t *state = NULL;
+    lle_completion_menu_state_create(test_pool, r, NULL, "", &state);
+
+    lle_completion_menu_append_filter_char(state, 'c');
+    lle_completion_menu_append_filter_char(state, 'h');
+    ASSERT_EQ(state->result->count, 1u, "narrowed to one at 'ch'");
+
+    lle_completion_menu_pop_filter_char(state);
+    ASSERT_EQ(state->result->count, 3u, "pop widens back to three at 'c'");
+    ASSERT_TRUE(lle_completion_menu_filter_active(state),
+                "filter still active after one pop");
+
+    lle_completion_menu_pop_filter_char(state);
+    ASSERT_EQ(state->result->count, 6u, "second pop restores all six");
+    ASSERT_FALSE(lle_completion_menu_filter_active(state),
+                 "filter inactive after popping to empty");
+    ASSERT_TRUE(state->result == state->unfiltered_result,
+                "result reverts to unfiltered view after empty filter");
+    lle_completion_menu_state_free(state);
+}
+
+TEST(filter_pop_on_empty_is_noop) {
+    lle_completion_result_t *r = make_test_result();
+    lle_completion_menu_state_t *state = NULL;
+    lle_completion_menu_state_create(test_pool, r, NULL, "", &state);
+
+    /// Popping when filter is already empty must not crash or
+    /// produce a spurious filter_active transition.
+    ASSERT_EQ(lle_completion_menu_pop_filter_char(state), LLE_SUCCESS,
+              "pop on empty returns SUCCESS");
+    ASSERT_FALSE(lle_completion_menu_filter_active(state),
+                 "filter remains inactive after no-op pop");
+    ASSERT_EQ(state->result->count, 6u,
+              "result count unchanged after no-op pop");
+    lle_completion_menu_state_free(state);
+}
+
+TEST(filter_no_matches_keeps_filter_active_with_zero_results) {
+    lle_completion_result_t *r = make_test_result();
+    lle_completion_menu_state_t *state = NULL;
+    lle_completion_menu_state_create(test_pool, r, NULL, "", &state);
+
+    /// 'z' matches nothing in the candidate set; the menu's filter
+    /// stays active so backspace can widen it back, but the visible
+    /// result becomes empty.
+    lle_completion_menu_append_filter_char(state, 'z');
+    ASSERT_TRUE(lle_completion_menu_filter_active(state),
+                "filter active even when no candidates match");
+    ASSERT_EQ(state->result->count, 0u, "no matches in filtered view");
+    lle_completion_menu_state_free(state);
+}
+
+TEST(filter_uses_original_prefix_when_provided) {
+    /// Source candidates already pre-filtered by a 'c' prefix: the
+    /// menu was opened with original_prefix='c'. Appending 'h' should
+    /// build the combined prefix "ch" and narrow accordingly.
+    lle_completion_result_t *r = NULL;
+    lle_completion_result_create(test_pool, 4, &r);
+    lle_completion_result_add(r, "checkout", NULL, LLE_COMPLETION_TYPE_CUSTOM,
+                              500);
+    lle_completion_result_add(r, "clone", NULL, LLE_COMPLETION_TYPE_CUSTOM,
+                              500);
+    lle_completion_result_add(r, "commit", NULL, LLE_COMPLETION_TYPE_CUSTOM,
+                              500);
+
+    lle_completion_menu_state_t *state = NULL;
+    lle_completion_menu_state_create(test_pool, r, NULL, "c", &state);
+
+    lle_completion_menu_append_filter_char(state, 'h');
+    /// Combined prefix "ch" -> only checkout admitted.
+    ASSERT_EQ(state->result->count, 1u, "ch narrows to checkout only");
+    ASSERT_TRUE(find_in_result(state->result, "checkout") >= 0,
+                "checkout admitted by combined prefix");
+    lle_completion_menu_state_free(state);
+}
+
+/* ============================================================================
+ * Bridge invoke
+ * ============================================================================
+ */
+
+TEST(filter_invoke_admits_when_no_fn_registered) {
+    /// Save then unset the predicate to verify the open-by-default
+    /// behavior when LLE runs without a shell-side filter (test
+    /// harnesses, early init).
+    lle_completion_set_filter_fn(NULL);
+    ASSERT_TRUE(lle_completion_filter_invoke("anything", "everything"),
+                "no predicate registered -> admit all");
+    /// Restore for downstream tests.
+    lle_completion_set_filter_fn(test_filter_fn);
+}
+
+TEST(filter_invoke_rejects_null_candidate) {
+    ASSERT_FALSE(lle_completion_filter_invoke("p", NULL),
+                 "NULL candidate is rejected");
+    ASSERT_FALSE(lle_completion_filter_invoke("p", ""),
+                 "empty candidate is rejected");
+}
+
+TEST(filter_invoke_admits_when_prefix_empty) {
+    ASSERT_TRUE(lle_completion_filter_invoke("", "candidate"),
+                "empty prefix admits");
+    ASSERT_TRUE(lle_completion_filter_invoke(NULL, "candidate"),
+                "NULL prefix admits");
+}
+
+int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
+
+    global_setup();
+
+    printf("Running menu type-to-filter tests\n");
+    printf("=================================\n");
+
+    printf("\nFilter lifecycle:\n");
+    RUN_TEST(filter_inactive_after_create);
+    RUN_TEST(filter_active_after_first_char);
+    RUN_TEST(filter_narrows_further_with_more_chars);
+    RUN_TEST(filter_pop_widens_view);
+    RUN_TEST(filter_pop_on_empty_is_noop);
+    RUN_TEST(filter_no_matches_keeps_filter_active_with_zero_results);
+    RUN_TEST(filter_uses_original_prefix_when_provided);
+
+    printf("\nBridge invoke:\n");
+    RUN_TEST(filter_invoke_admits_when_no_fn_registered);
+    RUN_TEST(filter_invoke_rejects_null_candidate);
+    RUN_TEST(filter_invoke_admits_when_prefix_empty);
+
+    int rc = TEST_RESULT();
+    global_teardown();
+    return rc;
+}


### PR DESCRIPTION
## Summary

PR3 of the 3-PR type-to-filter UX arc, completing the work begun in #229 (`fuzzy_completion_score`) and #230 (`completion.match_mode` ENUM + `completion_filter_admits()` predicate).

- The completion menu dismissed on any character input. Modern shells narrow the visible candidate set as the user types more characters with the menu open.
- Menu state gains `unfiltered_result` (the TAB-time set), `filter_string` (typed input), and `filtered_result` (a pool-allocated narrowed sibling). The menu's `result` pointer swaps between the two views so renderer, navigation, and selection paths see one current view without per-call indirection.
- Predicate dispatch is a function pointer registered with `lle_completion_set_filter_fn` at startup; `completion_filter_bridge_init` wires `completion_filter_admits` so the in-menu pass and the bridge pre-emit filter share the same `completion.match_mode` / `case_sensitive` / `threshold` state.
- `lle_self_insert` and `lle_backward_delete_char` detect a visible menu and route printable input to `append_filter_char` or backspace to `pop_filter_char`, updating the inline preview via `update_inline_completion`.
- Non-printable input, an empty filter result, and backspace at TAB-time state fall through to the legacy dismiss path so behavior at the boundary stays predictable.

## Test plan

- [x] `meson test -C build` on macOS clang: 126/126 PASS
- [x] `meson test -C build` in `ubuntu:24.04` Docker: 126/126 PASS
- [x] Full clean rebuild both sides: 0 warnings
- [x] New `tests/unit/test_menu_filter.c` (10 cases): create / append / pop / apply lifecycle, original_prefix combination, no-match retains active filter, bridge invoke edge cases
- [x] `tests/integration/test_pty_compdef.c`: real-PTY narrowing case typing 'h' after the menu opens with prefix 'c', asserting that `clone` and `commit` disappear from the rendered output while `checkout` survives

## Try it

```
$ git config --get user.email > /dev/null  # arbitrary command with a subcommand
$ git c<TAB>     # menu opens: checkout, clone, commit, ...
$ <type "h">     # menu narrows to: checkout only
$ <backspace>    # menu widens back to: checkout, clone, commit
```

`completion.match_mode = fuzzy` (default in lush mode) makes the narrowing accept subsequence matches; `substring` matches anywhere in the candidate; `prefix` matches the start.